### PR TITLE
A handful of Item fixes

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -77,6 +77,7 @@
     "shift": "Shift",
     "size": "Size",
     "skill": "Skill",
+    "skillNotes": "Skill Notes",
     "skills": "SKILLS",
     "spec": "SPEC?",
     "specializations": "Specializations",

--- a/template.json
+++ b/template.json
@@ -351,12 +351,12 @@
     },
     "perk": {
       "templates": ["itemDescription"],
-      "source": "generalPerk",
+      "source": "",
       "prerequisite": null
     },
     "power": {
       "templates": ["itemDescription"],
-      "source": "gridPower"
+      "source": ""
     },
     "feature": {
       "templates": ["itemDescription"]

--- a/template.json
+++ b/template.json
@@ -329,7 +329,7 @@
     "weaponUpgrade": {
       "templates": ["itemDescription"],
       "availability": "standard",
-      "benefit": "benefit",
+      "benefit": "",
       "prerequisite": null
     },
     "zordCombiner": {

--- a/templates/item/item-influence-sheet.hbs
+++ b/templates/item/item-influence-sheet.hbs
@@ -1,0 +1,16 @@
+<form class="{{cssClass}}" autocomplete="off">
+
+  {{!-- Item Sheet Header --}}
+  {{> "systems/essence20/templates/item/parts/item-header.hbs"}}
+
+  {{!-- Item Sheet Body --}}
+  <section class="sheet-body">
+    <input type="text" name="data.bond" value="{{data.bond}}" placeholder="{{ localize 'E20.bond' }}"/>
+    <input type="text" name="data.perk" value="{{data.perk}}" placeholder="{{ localize 'E20.perk' }}"/>
+    <input type="text" name="data.hangUp" value="{{data.hangUp}}" placeholder="{{ localize 'E20.hangUp' }}"/>
+
+    {{!-- Description Section --}}
+    {{> "systems/essence20/templates/item/parts/item-description.hbs"}}
+  </section>
+
+</form>

--- a/templates/item/item-specialization-sheet.hbs
+++ b/templates/item/item-specialization-sheet.hbs
@@ -1,0 +1,6 @@
+<form class="{{cssClass}}" autocomplete="off">
+
+  {{!-- Item Sheet Header --}}
+  {{> "systems/essence20/templates/item/parts/item-header.hbs"}}
+
+</form>

--- a/templates/item/item-threatPower-sheet.hbs
+++ b/templates/item/item-threatPower-sheet.hbs
@@ -1,0 +1,17 @@
+<form class="{{cssClass}}" autocomplete="off">
+
+  {{!-- Item Sheet Header --}}
+  {{> "systems/essence20/templates/item/parts/item-header.hbs"}}
+
+  {{!-- Item Sheet Body --}}
+  <section class="sheet-body">
+    <span>{{localize 'E20.charges'}}</span><input type="number" name="data.charges" value="{{data.charges}}"/>
+    <span>{{localize 'E20.cost'}}</span><input type="number" name="data.cost" value="{{data.cost}}"/>
+    <span>{{localize 'E20.limited'}}</span><input type="checkbox" name="data.limited" {{checked data.limited}}/>
+    <span>{{localize 'E20.actionType'}}</span><input type="text" name="data.actionType" value="{{data.actionType}}" placeholder="{{ localize 'E20.actionType' }}"/>
+
+    {{!-- Description Section --}}
+    {{> "systems/essence20/templates/item/parts/item-description.hbs"}}
+  </section>
+
+</form>


### PR DESCRIPTION
In this change:
- Adding sheets for some Items. We might want to only make them available to create on actor sheets eventually, but for now it's helpful for testing. Specializations, for example, only have a name, so it's kind of pointless.
- Removing some default values