### PR TITLE
Making the Create Item/Actor type dropdowns readable

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,27 @@
 {
+  "ACTOR": {
+    "TypeGijoe": "GI JOE",
+    "TypePowerranger": "Power Ranger",
+    "TypeNpc": "NPC",
+    "TypeThreat": "Threat",
+    "TypeVehicle": "Vehicle",
+    "TypeZord": "Zord",
+    "TypeMegaformzord": "Megaform Zord"
+  },
+  "ITEM": {
+    "TypeArmor": "Armor",
+    "TypeGear": "Gear",
+    "TypeWeapon": "Weapon",
+    "TypeWeaponupgrade": "Weapon Upgrade",
+    "TypeZordcombiner": "Zord Combiner",
+    "TypeThreatpower": "Threat Power",
+    "TypePerk": "Perk",
+    "TypePower": "Power",
+    "TypeFeature": "Feature",
+    "TypeMegaformtrait": "Megaform Trait",
+    "TypeInfluence": "Influence",
+    "TypeSpecialization": "Specialization"
+  },
   "E20": {
     "actionType": "Action Type",
     "addInfluence": "Add Influence",


### PR DESCRIPTION
Apparently Foundry handles this automatically when you supply ACTOR.Type* and ITEM.Type* fields in the en.json.

I also looked into removing some of the items from the Create Items menu without much success. For something like Specializations, it would probably be easiest to make it no longer an Item, but I don't think it's worth the trouble at this point.