### PR TITLE
Roll dialog specialization; manifest URL tweak

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -13,11 +13,12 @@ export class Dice {
 
   /**
    * Displays the dialog used for skill and specialization rolls.
+   * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @returns {Promise<Dialog>}   The dialog to be displayed.
    */
-  async getSkillRollOptions() {
+  async getSkillRollOptions(dataset) {
     const template = "systems/essence20/templates/dialog/roll-dialog.hbs"
-    const html = await renderTemplate(template, {});
+    const html = await renderTemplate(template, {specialized: !!dataset.specialization});
 
     return new Promise(resolve => {
       const data = {
@@ -51,6 +52,7 @@ export class Dice {
       shiftDown: parseInt(form.shiftDown.value),
       snag: form.snag.checked,
       edge: form.edge.checked,
+      specialized: form.specialized.checked,
     }
   }
 
@@ -77,7 +79,8 @@ export class Dice {
     }
 
     const modifier = actorSkillData[rolledEssence][rolledSkill].modifier;
-    const formula = this._getFormula(!!dataset.specialization, skillRollOptions, finalShift, modifier);
+    const formula = this._getFormula(
+      !!dataset.specialization || skillRollOptions.specialized, skillRollOptions, finalShift, modifier);
 
     let roll = new Roll(formula, actor.getRollData());
     roll.toMessage({

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -261,7 +261,7 @@ export class Essence20ActorSheet extends ActorSheet {
 
     // Handle type-specific rolls.
     if (dataset.rollType) {
-      const skillRollOptions = await this._dice.getSkillRollOptions();
+      const skillRollOptions = await this._dice.getSkillRollOptions(dataset);
 
       if (skillRollOptions.cancelled) {
         return;

--- a/system.json
+++ b/system.json
@@ -22,7 +22,7 @@
   "primaryTokenAttribute": "health",
   "secondaryTokenAttribute": "power",
   "url": "https://github.com/WookieeMatt/Essence20",
-  "manifest": "https://github.com/WookieeMatt/Essence20/releases/download/v0.7/system.json",
+  "manifest": "https://raw.githubusercontent.com/WookieeMatt/Essence20/main/system.json",
   "download": "https://github.com/WookieeMatt/Essence20/releases/download/v0.7/Essence20-0.7.zip",
   "license": "LICENSE.txt"
 }

--- a/system.json
+++ b/system.json
@@ -23,6 +23,6 @@
   "secondaryTokenAttribute": "power",
   "url": "https://github.com/WookieeMatt/Essence20",
   "manifest": "https://raw.githubusercontent.com/WookieeMatt/Essence20/main/system.json",
-  "download": "https://github.com/WookieeMatt/Essence20/releases/download/v0.7/Essence20-0.7.zip",
+  "download": "https://github.com/WookieeMatt/Essence20/releases/download/v0.8/Essence20-0.8.zip",
   "license": "LICENSE.txt"
 }

--- a/templates/dialog/roll-dialog.hbs
+++ b/templates/dialog/roll-dialog.hbs
@@ -15,4 +15,8 @@
     <input type="checkbox" name="edge" />
     <label>Edge</label>
   </div>
+  <div>
+    <input type="checkbox" name="specialized" {{checked specialized}} />
+    <label>Specialized</label>
+  </div>
 </form>


### PR DESCRIPTION
In this change
- Adding a specialization checkbox to the roll dialog
- Changing manifest to raw file so that updating can work through the app

Testing
- When you click to roll a skill, there should now be a specialization checkbox in the dialog. If it was a specialization you clicked, it will be checked initially. Rolls should become specialized when it's checked.
- Hopefully you can update via the app when the tag is created