### PR TITLE
More detailed weapon roll chat messages

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -89,6 +89,7 @@
     "modifier": "Modifier",
     "morphedDefenses": "Morphed Defenses",
     "name": "NAME",
+    "none": "None",
     "notes": "NOTES",
     "numCharges": "Charges",
     "numDrivers": "Drivers",

--- a/lang/en.json
+++ b/lang/en.json
@@ -36,6 +36,7 @@
     "addWeapon": "Add Weapon",
     "alternateEffects": "Alternate Effects",
     "armor": "Armor",
+    "attackRoll": "Attack Roll",
     "autoFail": "automatically fails",
     "autoFailFumble": "automatically fails and fumbles",
     "availability": "Availability",

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -61,9 +61,10 @@ export class Dice {
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().
    * @param {Actor} actor   The actor performing the roll.
+   * @param {Item} weapon   The weapon being used, if any.
    */
-  rollSkill(dataset, skillRollOptions, actor) {
-    let label = this._getSkillRollLabel(dataset);
+  rollSkill(dataset, skillRollOptions, actor, weapon) {
+    let label = weapon ? this._getWeaponRollLabel(dataset, weapon) : this._getSkillRollLabel(dataset);
     const rolledSkill = dataset.skill;
     const rolledEssence = this._config.skillToEssence[rolledSkill];
     const actorSkillData = actor.getRollData().skills;
@@ -103,6 +104,27 @@ export class Dice {
       : this._i18n.localize(this._config.skills[rolledSkill]);
     const rollingForStr = this._i18n.localize(this._config.rollingFor)
     return `${rollingForStr} ${rolledSkillStr}`;
+  }
+
+  /**
+   * Create weapon roll label.
+   * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
+   * @returns {String}   The resultant roll label.
+   * @param {Item} weapon   The weapon being used, if any.
+   * @private
+   */
+   _getWeaponRollLabel(dataset, weapon) {
+    const rolledSkill = dataset.skill;
+    const rolledSkillStr = dataset.specialization
+      ? dataset.specialization
+      : this._i18n.localize(this._config.skills[rolledSkill]);
+    const attackRollStr = this._i18n.localize(this._config.attackRoll)
+
+    let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})<br>`;
+    label += `<b>Effect</b> - ${weapon.system.effect || 'None'}<br>`;
+    label += `<b>Alternate Effects</b> - ${weapon.system.alternateEffects || 'None'}`;
+
+    return label;
   }
 
   /**

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -110,14 +110,12 @@ export class Dice {
    * Create weapon roll label.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @returns {String}   The resultant roll label.
-   * @param {Item} weapon   The weapon being used, if any.
+   * @param {Item} weapon   The weapon being used.
    * @private
    */
    _getWeaponRollLabel(dataset, weapon) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = dataset.specialization
-      ? dataset.specialization
-      : this._i18n.localize(this._config.skills[rolledSkill]);
+    const rolledSkillStr = this._i18n.localize(this._config.skills[rolledSkill]);
     const attackRollStr = this._i18n.localize(this._config.attackRoll)
 
     let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})<br>`;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -117,10 +117,13 @@ export class Dice {
     const rolledSkill = dataset.skill;
     const rolledSkillStr = this._i18n.localize(this._config.skills[rolledSkill]);
     const attackRollStr = this._i18n.localize(this._config.attackRoll)
+    const effectStr = this._i18n.localize(this._config.effect)
+    const alternateEffectsStr = this._i18n.localize(this._config.alternateEffects)
+    const noneStr = this._i18n.localize(this._config.none)
 
     let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})<br>`;
-    label += `<b>Effect</b> - ${weapon.system.effect || 'None'}<br>`;
-    label += `<b>Alternate Effects</b> - ${weapon.system.alternateEffects || 'None'}`;
+    label += `<b>${effectStr}</b> - ${weapon.system.effect || noneStr}<br>`;
+    label += `<b>${alternateEffectsStr}</b> - ${weapon.system.alternateEffects || noneStr}`;
 
     return label;
   }

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -34,6 +34,47 @@ describe("_getSkillRollLabel", () => {
   });
 });
 
+/* _getWeaponRollLabel */
+describe("_getWeaponRollLabel", () => {
+  test("weapon roll", () => {
+    const dataset = {
+      skill: 'athletics',
+    };
+    const weapon = {
+      name: 'Zeo Power Clubs',
+      system: {
+        effect: "Some effect",
+        alternateEffects: "Some alternate effects",
+      },
+    };
+    const expected =
+     "<b>E20.attackRoll</b> - Zeo Power Clubs (E20.essenceSkills.strength.athletics)<br>" +
+     "<b>Effect</b> - Some effect<br>" +
+     "<b>Alternate Effects</b> - Some alternate effects";
+
+    expect(dice._getWeaponRollLabel(dataset, weapon)).toEqual(expected);
+  });
+
+  test("no effects", () => {
+    const dataset = {
+      skill: 'athletics',
+    };
+    const weapon = {
+      name: 'Zeo Power Clubs',
+      system: {
+        effect: "",
+        alternateEffects: "",
+      },
+    };
+    const expected =
+     "<b>E20.attackRoll</b> - Zeo Power Clubs (E20.essenceSkills.strength.athletics)<br>" +
+     "<b>Effect</b> - None<br>" +
+     "<b>Alternate Effects</b> - None";
+
+    expect(dice._getWeaponRollLabel(dataset, weapon)).toEqual(expected);
+  });
+});
+
 /* _getFinalShift */
 describe("_getFinalShift", () => {
   const initialShift = 'd20';

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -49,8 +49,8 @@ describe("_getWeaponRollLabel", () => {
     };
     const expected =
      "<b>E20.attackRoll</b> - Zeo Power Clubs (E20.essenceSkills.strength.athletics)<br>" +
-     "<b>Effect</b> - Some effect<br>" +
-     "<b>Alternate Effects</b> - Some alternate effects";
+     "<b>E20.effect</b> - Some effect<br>" +
+     "<b>E20.alternateEffects</b> - Some alternate effects";
 
     expect(dice._getWeaponRollLabel(dataset, weapon)).toEqual(expected);
   });
@@ -68,8 +68,8 @@ describe("_getWeaponRollLabel", () => {
     };
     const expected =
      "<b>E20.attackRoll</b> - Zeo Power Clubs (E20.essenceSkills.strength.athletics)<br>" +
-     "<b>Effect</b> - None<br>" +
-     "<b>Alternate Effects</b> - None";
+     "<b>E20.effect</b> - E20.none<br>" +
+     "<b>E20.alternateEffects</b> - E20.none";
 
     expect(dice._getWeaponRollLabel(dataset, weapon)).toEqual(expected);
   });

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -2,6 +2,7 @@ export const E20 = {};
 
 E20.defenseBase = 10;
 
+E20.attackRoll = "E20.attackRoll";
 E20.rollingFor = "E20.rollingFor";
 E20.withAnEdge = "E20.withAnEdge";
 E20.withASnag = "E20.withASnag";

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -2,15 +2,18 @@ export const E20 = {};
 
 E20.defenseBase = 10;
 
+E20.alternateEffects = "E20.alternateEffects";
 E20.attackRoll = "E20.attackRoll";
+E20.autoFail = "E20.autoFail";
+E20.autoFailFumble = "E20.autoFailFumble";
+E20.cancel = "E20.cancel";
+E20.effect = "E20.effect";
+E20.none = "E20.none";
+E20.roll = "E20.roll";
+E20.rollDialogTitle = "E20.rollDialogTitle";
 E20.rollingFor = "E20.rollingFor";
 E20.withAnEdge = "E20.withAnEdge";
 E20.withASnag = "E20.withASnag";
-E20.autoFail = "E20.autoFail";
-E20.autoFailFumble = "E20.autoFailFumble";
-E20.rollDialogTitle = "E20.rollDialogTitle";
-E20.cancel = "E20.cancel";
-E20.roll = "E20.roll";
 
 E20.armorClassifications = {
   non: "E20.armorClassifications.non",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -298,6 +298,18 @@ export class Essence20ActorSheet extends ActorSheet {
 
         this._dice.rollSkill(dataset, skillRollOptions, this.actor);
       }
+      else if (dataset.rollType == 'weapon') {
+        const skillRollOptions = await this._dice.getSkillRollOptions(dataset);
+
+        if (skillRollOptions.cancelled) {
+          return;
+        }
+
+        const itemId = element.closest('.item').dataset.itemId;
+        const weapon = this.actor.items.get(itemId);
+
+        this._dice.rollSkill(dataset, skillRollOptions, this.actor, weapon);
+      }
       else if (dataset.rollType == 'initiative') {
         this.actor.rollInitiative({createCombatants: true});
       }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -313,7 +313,7 @@ export class Essence20ActorSheet extends ActorSheet {
       else if (dataset.rollType == 'initiative') {
         this.actor.rollInitiative({createCombatants: true});
       }
-      else if (['influence', 'generalPerk'].includes(dataset.rollType)) {
+      else if (dataset.rollType == 'generalPerk') {
         const itemId = element.closest('.item').dataset.itemId;
         const item = this.actor.items.get(itemId);
 
@@ -322,18 +322,9 @@ export class Essence20ActorSheet extends ActorSheet {
         const rollMode = game.settings.get('core', 'rollMode');
         const label = `[${item.type}] ${item.name}`;
 
-        let content = '';
-
-        if (dataset.rollType == 'influence') {
-          content += `Bond: ${item.system.bond || 'None'} <br>`;
-          content += `Hang Up: ${item.system.hangUp || 'None'} <br>`;
-          content += `Perk: ${item.system.perk || 'None'}`;
-        }
-        else { // General Perk
-          content += `Source: ${item.system.source || 'None'} <br>`;
+        let content = `Source: ${item.system.source || 'None'} <br>`;
           content += `Prerequisite: ${item.system.prerequisite || 'None'} <br>`;
           content += `Description: ${item.system.description || 'None'}`;
-        }
 
         ChatMessage.create({
           speaker: speaker,

--- a/templates/actor/parts/actor-weapons.hbs
+++ b/templates/actor/parts/actor-weapons.hbs
@@ -15,7 +15,7 @@
     <li class="item flexrow" data-item-id="{{weapon._id}}" style="margin-left: 20px;">
       <div class="item-name">
         <div class="item-image">
-          <a class="rollable" data-roll-type="skill" data-skill="{{weapon.system.classification.skill}}"><i class="fas fa-dice-d20"></i></a>
+          <a class="rollable" data-roll-type="weapon" data-skill="{{weapon.system.classification.skill}}"><i class="fas fa-dice-d20"></i></a>
         </div>
         <div style="display:block">
           <input class="inline-edit" data-field="data.equipped" type="checkbox" name="weapon.{{@index}}.equipped" style="margin-left: 0px; margin-right: 0px" {{checked weapon.system.equipped}}/>


### PR DESCRIPTION
https://github.com/WookieeMatt/Essence20/issues/78

In this change
- Weapon rolls chat messages have more useful info 
- Adding unit tests for these
- Fixing some formatting for the actor-sheet _onRoll(). It looks like a ton being changed but it's mostly indentation.

Testing
- Make weapons with and without effects and get rollin
- You can run the unit tests with `npm test`