### PR TITLE
Dropping Zords onto MFZ sheets

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -66,7 +66,29 @@ export class Essence20ActorSheet extends ActorSheet {
     // Prepare active effects
     context.effects = prepareActiveEffectCategories(this.actor.effects);
 
+    // Prepare Zords for MFZs
+    this._prepareZords(context);
+
     return context;
+  }
+
+  /**
+   * Prepare Zords for MFZs.
+   *
+   * @param {Object} context The actor data to prepare.
+   *
+   * @return {undefined}
+   */
+  _prepareZords(context) {
+    if (this.actor.type == 'megaformZord') {
+      let zords = [];
+
+      for (let zordId of this.actor.system.zordIds) {
+        zords.push(game.actors.get(zordId));
+      }
+
+      context.zords = zords;
+    }
   }
 
   /**
@@ -86,7 +108,7 @@ export class Essence20ActorSheet extends ActorSheet {
   /**
    * Organize and classify Items for Character sheets.
    *
-   * @param {Object} actorData The actor to prepare.
+   * @param {Object} context The actor data to prepare.
    *
    * @return {undefined}
    */

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -345,4 +345,35 @@ export class Essence20ActorSheet extends ActorSheet {
       if (item) return item.roll();
     }
   }
+
+  /**
+   * Handle dropping of an Actor data onto another Actor sheet
+   * @param {DragEvent} event            The concluding DragEvent which contains drop data
+   * @param {object} data                The data transfer extracted from the event
+   * @returns {Promise<object|boolean>}  A data object which describes the result of the drop, or false if the drop was
+   *                                     not permitted.
+   * @override
+   */
+  async _onDropActor(event, data) {
+    if (!this.actor.isOwner) return false;
+
+    // Get the target actor
+    let sourceActor = await fromUuid(data.uuid);
+    if (!sourceActor) return false;
+
+    // Handles dropping Zords onto Megaform Zords
+    if (this.actor.type == 'megaformZord' && sourceActor.type == 'zord') {
+      const zordIds = duplicate(this.actor.system.zordIds);
+
+      // Can't contain duplicate Zords
+      // if (!zordIds.includes(sourceActor.id)) {
+        zordIds.push(sourceActor.id);
+        await this.actor.update({
+          "system.zordIds": zordIds
+        }).then(this.render(false));
+      // }
+    } else {
+      return false;
+    }
+  }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -386,12 +386,12 @@ export class Essence20ActorSheet extends ActorSheet {
       const zordIds = duplicate(this.actor.system.zordIds);
 
       // Can't contain duplicate Zords
-      // if (!zordIds.includes(sourceActor.id)) {
+      if (!zordIds.includes(sourceActor.id)) {
         zordIds.push(sourceActor.id);
         await this.actor.update({
           "system.zordIds": zordIds
         }).then(this.render(false));
-      // }
+      }
     } else {
       return false;
     }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -128,7 +128,6 @@ export class Essence20ActorSheet extends ActorSheet {
     const threatPowers = [];
     const traits = []; // Catchall for Megaform Zords, Vehicles, NPCs
     const weapons = [];
-    const zordCombiners = [];
 
     // // Iterate through items, allocating to containers
     for (let i of context.items) {
@@ -176,9 +175,6 @@ export class Essence20ActorSheet extends ActorSheet {
         case 'weapon':
           weapons.push(i);
           break;
-        case 'zordCombiner':
-          zordCombiners.push(i);
-          break;
       };
     }
 
@@ -197,7 +193,6 @@ export class Essence20ActorSheet extends ActorSheet {
     context.threatPowers = threatPowers;
     context.traits = traits;
     context.weapons = weapons;
-    context.zordCombiners = zordCombiners;
   }
 
   /* -------------------------------------------- */

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -228,6 +228,9 @@ export class Essence20ActorSheet extends ActorSheet {
       li.slideUp(200, () => this.render(false));
     });
 
+    // Delete Zord from MFZ
+    html.find('.zord-delete').click(this._onZordDelete.bind(this));
+
     // Edit specialization name inline
     html.find(".inline-edit").change(this._onInlineEdit.bind(this));
 
@@ -397,5 +400,20 @@ export class Essence20ActorSheet extends ActorSheet {
     } else {
       return false;
     }
+  }
+
+  /**
+   * Handle deleting Zords from MFZs
+   * @param {Event} event   The originating click event
+   * @private
+   */
+   async _onZordDelete(event) {
+    const li = $(event.currentTarget).parents(".zord");
+    const zordId = li.data("zordId");
+    let zordIds = this.actor.system.zordIds.filter(x => x !== zordId);
+    this.actor.update({
+        "system.zordIds": zordIds,
+    });
+    li.slideUp(200, () => this.render(false));
   }
 }

--- a/template.json
+++ b/template.json
@@ -287,7 +287,6 @@
       "gear",
       "weapon",
       "weaponUpgrade",
-      "zordCombiner",
       "threatPower",
       "generalPerk",
       "power",
@@ -364,19 +363,6 @@
       "availability": "standard",
       "benefit": "",
       "prerequisite": null
-    },
-    "zordCombiner": {
-      "templates": [
-        "itemDescription"
-      ],
-      "colorSpectrum": "",
-      "health": {
-        "max": 8,
-        "min": 0,
-        "value": 8
-      },
-      "ranger": "",
-      "skillNotes": ""
     },
     "threatPower": {
       "actionType": "",

--- a/template.json
+++ b/template.json
@@ -277,7 +277,8 @@
         "machine",
         "zordBase"
       ],
-      "health": null
+      "health": null,
+      "zordIds": []
     }
   },
   "Item": {

--- a/templates/actor/parts/actor-zordcombiner.hbs
+++ b/templates/actor/parts/actor-zordcombiner.hbs
@@ -4,13 +4,14 @@
 <a class="item-create" data-type="zordCombiner" title="{{ localize 'E20.addzordCombiner' }}">
     <i class="fas fa-plus"></i>
 </a>
-{{#each @root.zordCombiners as |zordCombiner|}}
-<li class="item flexrow" data-item-id="{{zordCombiner._id}}">
+
+{{#each @root.zords as |zord|}}
+<li class="item flexrow" data-item-id="{{zord._id}}">
     <div class="item-name">
-        <input class="inline-edit" data-field="name" type="text" name="zordCombiner.{{@index}}.name"
-            value="{{zordCombiner.name}}" placeholder="{{ localize 'E20.name' }}" />
-        <textarea class="inline-edit" data-field="data.description" name="zordCombiner.{{@index}}.description"
-            placeholder="{{localize 'E20.description'}}">{{zordCombiner.system.description}}</textarea>
+        <input class="inline-edit" data-field="name" type="text" name="zord.{{@index}}.name"
+            value="{{zord.name}}" placeholder="{{ localize 'E20.name' }}" />
+        <textarea class="inline-edit" data-field="data.description" name="zord.{{@index}}.description"
+            placeholder="{{localize 'E20.description'}}">{{zord.system.description}}</textarea>
     </div>
     <div class="item-controls">
         <a class="item-control item-delete" title="{{localize 'E20.deletezordCombiner'}}"><i

--- a/templates/actor/parts/actor-zordcombiner.hbs
+++ b/templates/actor/parts/actor-zordcombiner.hbs
@@ -1,21 +1,20 @@
 <span class="flex-group-center">
-    <h1>{{localize 'E20.zordCombiner'}}</h1>
+  <h1>{{localize 'E20.zordCombiner'}}</h1>
 </span>
 <a class="item-create" data-type="zordCombiner" title="{{ localize 'E20.addzordCombiner' }}">
-    <i class="fas fa-plus"></i>
+  <i class="fas fa-plus"></i>
 </a>
 
 {{#each @root.zords as |zord|}}
-<li class="item flexrow" data-item-id="{{zord._id}}">
-    <div class="item-name">
-        <input class="inline-edit" data-field="name" type="text" name="zord.{{@index}}.name"
-            value="{{zord.name}}" placeholder="{{ localize 'E20.name' }}" />
-        <textarea class="inline-edit" data-field="data.description" name="zord.{{@index}}.description"
-            placeholder="{{localize 'E20.description'}}">{{zord.system.description}}</textarea>
-    </div>
-    <div class="item-controls">
-        <a class="item-control item-delete" title="{{localize 'E20.deletezordCombiner'}}"><i
-                class="fas fa-trash"></i></a>
-    </div>
+<li class="zord flexrow" data-zord-id="{{zord._id}}">
+  <div class="item-name">
+    <input class="inline-edit" data-field="name" type="text" name="zord.{{@index}}.name" value="{{zord.name}}"
+      placeholder="{{ localize 'E20.name' }}" />
+    <textarea class="inline-edit" data-field="data.description" name="zord.{{@index}}.description"
+      placeholder="{{localize 'E20.description'}}">{{zord.system.description}}</textarea>
+  </div>
+  <div class="item-controls">
+    <a class="item-control zord-delete" title="{{localize 'E20.deletezordCombiner'}}"><i class="fas fa-trash"></i></a>
+  </div>
 </li>
 {{/each}}


### PR DESCRIPTION
In this change
- Zord actors can now be dropped onto MFZ sheets
- MFZs now have a `zordIds` property. Like it sounds, it's a list of Zord IDs, and when a Zord is dragged onto a MFZ, the Zord's ID is appended to the list. The Zord actors' actual data is fetched as part of `getData()`.
- Duplicate Zords (IDs) are not allowed
- Removed the zordComponent Item
- Didn't mess with how Zords are displayed on the sheet at all. This means there are input boxes that really should not be there (and don't work) for now.

Testing
- Create a MFZ and some Zords
- Dragging Zords onto the MFZ should add them, but only once each
- Deleting Zords should work
