### PR TITLE
Item collapsing via event listener

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -892,6 +892,24 @@ form .hint {
   height: fit-content;
 }
 
+/* Content toggle open/close. */
+.accordion-content {
+  display: none;
+}
+
+.open .accordion-content {
+  display: block;
+}
+
+/* Chevron icon. */
+.accordion-icon {
+  transition: all ease-in-out 0.25s;
+}
+
+.open .accordion-icon {
+  transform: rotate(180deg);
+}
+
 .essence20 .origin-bonds {
   list-style: none;
   margin-top: 10px;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -217,6 +217,13 @@ export class Essence20ActorSheet extends ActorSheet {
       html.find('.rollable').click(this._onRoll.bind(this));
     }
 
+    // Open and collapse Item content
+      html.find('.accordion-label').click(ev => {
+      const el = ev.currentTarget;
+      const parent = $(el).parents('.accordion-wrapper');
+      parent.toggleClass('open');
+    });
+
     // Drag events for macros.
     if (this.actor.isOwner) {
       let handler = ev => this._onDragStart(ev);

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -1,40 +1,44 @@
 <div class="collapsible-item-container">
+  {{!-- Header with + button --}}
   <div class="flex-group-center">
     {{localize title}}
     <a class="item-create" data-type={{dataType}} title="{{ localize 'E20.add' }}">
       <i class="fas fa-plus"></i>
     </a>
   </div>
+
   <ol class="items-list">
     {{#each items as |item|}}
-    <li class="item flexrow" data-item-id="{{item._id}}">
-      <details>
-        <summary class="flexrow">
-          <div class="item-image" style="flex-grow: 0;">
-            {{#> roll-button item=item}}
-              {{!-- Custom roll button here, or use default below --}}
-              <a class="rollable" data-roll-type={{item.type}}><i class="fas fa-dice-d20"></i></a>
-            {{/roll-button}}
-          </div>
-          {{#if (isdefined item.system.equipped)}}
-            <div style="flex-grow: 0;">
-              <input class="inline-edit" data-field="system.equipped" type="checkbox" name="armor.{{@index}}.equipped" {{checked item.system.equipped}} />
-            </div>
-          {{/if}}
-          <div>
-            {{item.name}}
-          </div>
-        </summary>
-        <div class="expand-details">
-          {{#> additional-expand-details item=item}}
-            {{!-- Custom expanded details here --}}
-          {{/additional-expand-details}}
-          <div>{{{item.system.description}}}</div>
+    <li class="item accordion-wrapper" data-item-id="{{item._id}}">
+      {{!-- Item label and buttons --}}
+      <div class="flexrow accordion-label">
+        <div class="item-image" style="flex-grow: 0;">
+          {{#> roll-button item=item}}
+            {{!-- Custom roll button here, or use default below --}}
+            <a class="rollable" data-roll-type={{item.type}}><i class="fas fa-dice-d20"></i></a>
+          {{/roll-button}}
         </div>
-      </details>
-      <div class="item-controls">
-        <a class="item-control item-edit" title="{{localize 'E20.edit'}}"><i class="fas fa-edit"></i></a>
-        <a class="item-control item-delete" title="{{localize 'E20.delete'}}"><i class="fas fa-trash"></i></a>
+        {{#if (isdefined item.system.equipped)}}
+          <div style="flex-grow: 0;">
+            <input class="inline-edit" data-field="system.equipped" type="checkbox" name="armor.{{@index}}.equipped" {{checked item.system.equipped}} />
+          </div>
+        {{/if}}
+        <div>
+          {{item.name}}
+        </div>
+        <div class="item-controls">
+          <a class="item-control item-edit" title="{{localize 'E20.edit'}}"><i class="fas fa-edit"></i></a>
+          <a class="item-control item-delete" title="{{localize 'E20.delete'}}"><i class="fas fa-trash"></i></a>
+          <a class="item-control"><i class="accordion-icon fas fa-chevron-down"></i></a>
+        </div>
+      </div>
+
+      {{!-- Item content --}}
+      <div class="accordion-content">
+        {{#> additional-expand-details item=item}}
+          {{!-- Custom expanded details here --}}
+        {{/additional-expand-details}}
+        <div>{{{item.system.description}}}</div>
       </div>
     </li>
     {{/each}}


### PR DESCRIPTION
It now has a collapsing-chevron-icon-thing, but it should work the same as before for all Items on the PR sheet.