### PR TITLE
Collapsing NPC skills

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -1070,6 +1070,18 @@ form .hint {
   margin-top: 5px;
 }
 
+.essence20 .skill-body .shift-select > * {
+  vertical-align: middle;
+}
+
+.essence20 .skill-body .shift-select .specialized-label {
+  margin-left: 5px;
+}
+
+.essence20 .skill-body .shift-select .specialized-checkbox {
+  margin-left: 2px;
+}
+
 .essence20 .skill-body .specializations-list {
   margin-top: 5px;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -130,6 +130,7 @@
     "skills": "SKILLS",
     "spec": "SPEC?",
     "specializations": "SPECIALIZATIONS",
+    "specialized": "Specialized",
     "style": "Style",
     "source": "Source",
     "threatLevel": "Threat Level",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -87,7 +87,7 @@ export class Essence20ActorSheet extends ActorSheet {
         displayedNpcSkills[skill] = true;
       }
 
-      // Include any skills > d20, are specialized, or have a modifier
+      // Include any skills not d20, are specialized, or have a modifier
       for (let [_, skills] of Object.entries(context.system.skills)) {
         for (let [skill, fields] of Object.entries(skills)) {
           if (fields.shift != 'd20' || fields.isSpecialized || fields.modifier) {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -46,12 +46,6 @@ export class Essence20ActorSheet extends ActorSheet {
     context.system = actorData.system;
     context.flags = actorData.flags;
 
-    // // Prepare character data and items.
-    // if (actorData.type == 'character') {
-    //   this._prepareItems(context);
-    //   this._prepareCharacterData(context);
-    // }
-
     // // Prepare NPC data and items.
     // if (actorData.type == 'npc') {
     //   this._prepareItems(context);
@@ -59,6 +53,11 @@ export class Essence20ActorSheet extends ActorSheet {
 
     // Might need to filter like above eventually
     this._prepareItems(context);
+
+    // Prepare npc data and items.
+    if (actorData.type == 'npc') {
+      this._prepareDisplayedNpcSkills(context);
+    }
 
     // Add roll data for TinyMCE editors.
     context.rollData = context.actor.getRollData();
@@ -70,6 +69,33 @@ export class Essence20ActorSheet extends ActorSheet {
     this._prepareZords(context);
 
     return context;
+  }
+
+  /**
+   * Prepare skills that are always displayed for NPCs.
+   *
+   * @param {Object} context The actor data to prepare.
+   *
+   * @return {undefined}
+   */
+   _prepareDisplayedNpcSkills(context) {
+    if (this.actor.type == 'npc') {
+      let displayedNpcSkills = {};
+
+      for (let skill in context.specializations) {
+        displayedNpcSkills[skill] = true;
+      }
+
+      for (let [_, skills] of Object.entries(context.system.skills)) {
+        for (let [skill, fields] of Object.entries(skills)) {
+          if (fields.shift != 'd20' || fields.isSpecialized || fields.modifier) {
+            displayedNpcSkills[skill] = true;
+          }
+        }
+      }
+
+      context.displayedNpcSkills = displayedNpcSkills;
+    }
   }
 
   /**

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -82,10 +82,12 @@ export class Essence20ActorSheet extends ActorSheet {
     if (this.actor.type == 'npc') {
       let displayedNpcSkills = {};
 
+      // Include any skill that have specializations
       for (let skill in context.specializations) {
         displayedNpcSkills[skill] = true;
       }
 
+      // Include any skills > d20, are specialized, or have a modifier
       for (let [_, skills] of Object.entries(context.system.skills)) {
         for (let [skill, fields] of Object.entries(skills)) {
           if (fields.shift != 'd20' || fields.isSpecialized || fields.modifier) {

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -101,4 +101,24 @@
     {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
   </div>
 
+  <div class="skills-container accordion-wrapper">
+    <div class="flex-group-center accordion-label">
+      <span>Skills</span>
+      <a class="item-control"><i class="accordion-icon fas fa-chevron-down"></i></a>
+    </div>
+
+    {{#each system.skills as |skills essence|}}
+      {{#each skills as |fields skill|}}
+        {{#ifEquals fields.shift 'd20'}}
+        <div class="accordion-content">
+        {{else}}
+        <div>
+        {{/ifEquals}}
+
+        {{> "systems/essence20/templates/actor/parts/actor-essence-skills.hbs" essence=essence skill=skill fields=fields}}
+        </div>
+      {{/each}}
+    {{/each}}
+  </div>
+
 </form>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -1,6 +1,5 @@
 <form class="{{cssClass}} {{actor.type}} flexcol" autocomplete="off">
   <div class="sheet-header">
-
     {{!-- Actor Sheet Header --}}
     <span class="resource flex-group-center">
       {{> "systems/essence20/templates/actor/parts/actor-base-header.hbs"}}
@@ -22,6 +21,7 @@
       </div>
     </div>
   </div>
+
   <div class="npc-sheet-container-1">
     {{!-- NPC Defenses --}}
     <div class="npc-sheet-container-2">
@@ -30,15 +30,11 @@
 
     <div>
       {{> "systems/essence20/templates/actor/parts/actor-zord-movement.hbs"}}
-
     </div>
   </div>
 
-  {{!-- Need to add Skills ass dropdowns or hidable --}}
-
   <div class="npc-abilities">
     <div class="npc-abilities-1">
-
       {{> "systems/essence20/templates/actor/parts/actor-general-perks.hbs"}}
 
       <div class="npc-hangup">
@@ -109,11 +105,11 @@
 
     {{#each system.skills as |skills essence|}}
       {{#each skills as |fields skill|}}
-        {{#ifEquals fields.shift 'd20'}}
-        <div class="accordion-content">
-        {{else}}
+        {{#if (lookup @root.displayedNpcSkills skill)}}
         <div>
-        {{/ifEquals}}
+        {{else}}
+        <div class="accordion-content">
+        {{/if}}
 
         {{> "systems/essence20/templates/actor/parts/actor-essence-skills.hbs" essence=essence skill=skill fields=fields}}
         </div>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -39,9 +39,8 @@
   <div class="npc-abilities">
     <div class="npc-abilities-1">
 
-      <div class="npc-perks">
-        {{> "systems/essence20/templates/actor/parts/actor-general-perks.hbs"}}
-      </div>
+      {{> "systems/essence20/templates/actor/parts/actor-general-perks.hbs"}}
+
       <div class="npc-hangup">
         <span class="resource flex-group-center">
           <h2>{{localize 'E20.hangUps'}}</h2>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -1,4 +1,4 @@
-<form class="{{cssClass}} {{actor.type}} flexcol" autocomplete="off">
+<form class="{{cssClass}} {{actor.type}}" autocomplete="off">
   <div class="sheet-header">
     {{!-- Actor Sheet Header --}}
     <span class="resource flex-group-center">

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -1,3 +1,5 @@
+
+
 {{!-- Skill header and shift selector --}}
 <div class="flexrow skill-header">
   <span class="skill-roll">

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -32,7 +32,7 @@
   {{!-- Specializations list --}}
   <ol class="items-list"></ol>
     {{#each (lookup @root.specializations skill) as |specialization i|}}
-    <li class="specializations-list" data-item-id="{{specialization._id}}">
+    <li class="item specializations-list" data-item-id="{{specialization._id}}">
       <div class="flexrow specializations-item">
         <span class="item-button-container">
           <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-specialization="{{specialization.name}}"><i class="fas fa-dice-d20"></i></a>

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -10,14 +10,16 @@
 
 <div class="skill-body">
   {{!-- Mod and Spec inputs --}}
-  <div>
-    <select class="shift-select" name="system.skills.{{essence}}.{{skill}}.shift">
+  <div class="shift-select">
+    <select name="system.skills.{{essence}}.{{skill}}.shift">
       {{selectOptions @root.config.shifts selected=fields.shift localize=true}}
     </select>
     <span for="system.skills.{{essence}}.{{skill}}.modifier">+</span>
     <input class="one-digit-input" type="number" name="system.skills.{{essence}}.{{skill}}.modifier" value="{{fields.modifier}}"/>
+
     {{#ifEquals @root.actor.type 'npc'}}
-    <input type="checkbox" name="system.skills.{{essence}}.{{skill}}.isSpecialized" {{checked fields.isSpecialized}} data-dtype="Boolean"/>
+    <span class="specialized-label">{{localize 'E20.specialized'}}:</span>
+    <input class="specialized-checkbox" type="checkbox" name="system.skills.{{essence}}.{{skill}}.isSpecialized" {{checked fields.isSpecialized}} data-dtype="Boolean"/>
     {{/ifEquals}}
   </div>
 

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -1,5 +1,3 @@
-
-
 {{!-- Skill header and shift selector --}}
 <div class="flexrow skill-header">
   <span class="skill-roll">

--- a/templates/actor/parts/actor-npc-defenses.hbs
+++ b/templates/actor/parts/actor-npc-defenses.hbs
@@ -1,15 +1,13 @@
 <div class="npc-defenses-section">
     <div class="npc-defenses-container">
-      
       <div class="npc-defenses">
-          {{#each system.defenses as |value defense|}}
-           <div class="resource flexcol">
-            <span class="resource flex-group-center">{{localize (concat 'E20.defenses.' defense)}}: </span>
-            <input type="number" name="system.defenses.{{defense}}" value="{{value}}"/>
-          </div>
-          {{/each}}
+        {{#each system.defenses as |value defense|}}
+          <div class="resource flexcol">
+          <span class="resource flex-group-center">{{localize (concat 'E20.defenses.' defense)}}: </span>
+          <input type="number" name="system.defenses.{{defense}}" value="{{value}}"/>
+        </div>
+        {{/each}}
       </div>
-      {{/each}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
In this change
- NPC sheets now have a skill section that can be collapsed
- The only skills that remain visible are either non-d20, have a non-zero modifier, are specialized, or have specializations
- To help determine this, there's a new `_prepareDisplayedNpcSkills()` method so we don't have to do all that logic in the hbs
- Random cleanup in actor-npc-defenses.hbs
- Also fixes deleting specializations on sheets

Testing
- For an NPC, set skills that are non-d20, have a non-zero modifier, are specialized, and/or have specializations. Only those ones should remain visible after collapsing.

Things to note:
- There's a quirk with the collapsing code Asacolips sent us, where if you have something expanded, then modify it, it will collapse again. I'd like to leave this for another PR since I also noticed it in the other item containers.
- Looking at this more, it seems like a common thing because of sheet re-rendering. It happens in dnd5e as well.