### PR TITLE
Item container fixes; weapon roll fix

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -1204,6 +1204,10 @@ form .hint {
   text-align: left;
 }
 
+.essence20 .item-label {
+  align-items: center;
+}
+
 .essence20 .item-formula {
   -webkit-box-flex: 0;
   -ms-flex: 0 0 200px;

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -881,21 +881,26 @@ form .hint {
 }
 
 /* Content toggle open/close. */
-.accordion-content {
+.essence20 .accordion-content {
   display: none;
 }
 
-.open .accordion-content {
+.essence20 .open .accordion-content {
   display: block;
 }
 
 /* Chevron icon. */
-.accordion-icon {
+.essence20 .accordion-icon {
   transition: all ease-in-out 0.25s;
 }
 
-.open .accordion-icon {
+.essence20 .open .accordion-icon {
   transform: rotate(180deg);
+}
+
+.essence20 .chip-section {
+  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .essence20 .origin-bonds {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -324,7 +324,7 @@ export class Essence20ActorSheet extends ActorSheet {
       this._dice.rollSkill(dataset, skillRollOptions, this.actor);
     }
     else if (rollType == 'weapon') {
-      const skillRollOptions = await this._dice.getSkillRollOptions(dataset);
+      const skillRollOptions = await this._dice.getSkillRollOptions(dataset, this.actor);
 
       if (skillRollOptions.cancelled) {
         return;

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -11,7 +11,7 @@
     {{#each items as |item|}}
     <li class="item accordion-wrapper" data-item-id="{{item._id}}">
       {{!-- Item label and buttons --}}
-      <div class="flexrow accordion-label">
+      <div class="flexrow">
         <div class="item-image" style="flex-grow: 0;">
           {{#> roll-button item=item}}
           {{!-- Custom roll button here, or use default below --}}
@@ -30,7 +30,7 @@
         <div class="item-controls">
           <a class="item-control item-edit" title="{{localize 'E20.edit'}}"><i class="fas fa-edit"></i></a>
           <a class="item-control item-delete" title="{{localize 'E20.delete'}}"><i class="fas fa-trash"></i></a>
-          <a class="item-control"><i class="accordion-icon fas fa-chevron-down"></i></a>
+          <a class="item-control accordion-label"><i class="accordion-icon fas fa-chevron-down"></i></a>
         </div>
       </div>
 

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -42,9 +42,11 @@
 
         <div>{{{item.system.description}}}</div>
 
+        <div class="chip-section">
         {{#> chips item=item}}
         {{!-- Custom chips here --}}
         {{/chips}}
+        </div>
       </div>
     </li>
     {{/each}}

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -11,7 +11,7 @@
     {{#each items as |item|}}
     <li class="item accordion-wrapper" data-item-id="{{item._id}}">
       {{!-- Item label and buttons --}}
-      <div class="flexrow">
+      <div class="flexrow item-label">
         <div class="item-image" style="flex-grow: 0;">
           {{#> roll-button item=item}}
           {{!-- Custom roll button here, or use default below --}}


### PR DESCRIPTION
In this change
- Making it so only the chevron toggles item collapsing. Otherwise it collapses when you try to interact with any of the other buttons and prevents you from rolling
- Spacing fixes
- Realized weapon rolls were broken so a quick fix for that

Testing: Weapon rolls and collapsing items via chevron work