### PR TITLE
Replacing `data` with `system` for items; Weapon range fix

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -53,6 +53,7 @@
     "bonuses": "Bonuses",
     "bonus": "Bonus",
     "cancel": "Cancel",
+    "charges": "Charges",
     "classification": "Classification",
     "colorSpectrum": "Color Spectrum",
     "conditioning": "CONDITIONING",

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -208,11 +208,11 @@ E20.weaponSizes = {
 };
 
 E20.weaponSkills = {
-  athletics: "E20.essenceSkills.strength.athletics",
-  might: "E20.essenceSkills.strength.might",
-  finesse: "E20.essenceSkills.speed.finesse",
-  targeting: "E20.essenceSkills.speed.targeting",
-  technology: "E20.essenceSkills.smarts.technology",
+  athletics: "E20.essenceSkills.athletics",
+  might: "E20.essenceSkills.might",
+  finesse: "E20.essenceSkills.finesse",
+  targeting: "E20.essenceSkills.targeting",
+  technology: "E20.essenceSkills.technology",
 };
 
 E20.weaponRequirementSkills = {

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -46,7 +46,7 @@ export class Essence20ItemSheet extends ItemSheet {
     }
 
     // Add the actor's data to context.data for easier access, as well as flags.
-    context.data = itemData.system;
+    context.system = itemData.system;
     context.flags = itemData.flags;
 
     return context;

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -84,8 +84,8 @@
               </div>
               <input class="inline-edit" data-field="name" type="text" name="power.{{@index}}.name"
                 value="{{power.name}}" placeholder="{{ localize 'E20.name' }}" />
-              <textarea class="inline-edit" data-field="data.description" name="power.{{@index}}.description"
-                placeholder="{{localize 'E20.description'}}">{{power.data.description}}</textarea>
+              <textarea class="inline-edit" data-field="system.description" name="power.{{@index}}.description"
+                placeholder="{{localize 'E20.description'}}">{{power.system.description}}</textarea>
             </div>
             <div class="item-controls">
               <a class="item-control item-delete" title="{{localize 'E20.deletePower'}}"><i

--- a/templates/actor/parts/actor-npc-defenses.hbs
+++ b/templates/actor/parts/actor-npc-defenses.hbs
@@ -9,7 +9,6 @@
           </div>
           {{/each}}
       </div>
-      {{/each}}
     </div>
   </div>
 </div>

--- a/templates/actor/parts/actor-traits.hbs
+++ b/templates/actor/parts/actor-traits.hbs
@@ -7,7 +7,7 @@
 <li class="item flexrow" data-item-id="{{trait._id}}">
     <div class="item-name">
         <input class="inline-edit" data-field="name" type="text" name="trait.{{@index}}.name" value="{{trait.name}}" placeholder="{{ localize 'E20.name' }}"/>
-        <textarea class="inline-edit" data-field="data.description" name="trait.{{@index}}.description" placeholder="{{localize 'E20.description'}}">{{trait.data.description}}</textarea>
+        <textarea class="inline-edit" data-field="system.description" name="trait.{{@index}}.description" placeholder="{{localize 'E20.description'}}">{{trait.system.description}}</textarea>
     </div>
     <div class="item-controls">
         <a class="item-control item-delete" title="{{localize 'E20.deleteTrait'}}"><i class="fas fa-trash"></i></a>

--- a/templates/actor/parts/actor-zordcombiner.hbs
+++ b/templates/actor/parts/actor-zordcombiner.hbs
@@ -10,7 +10,7 @@
   <div class="item-name">
     <input class="inline-edit" data-field="name" type="text" name="zord.{{@index}}.name" value="{{zord.name}}"
       placeholder="{{ localize 'E20.name' }}" />
-    <textarea class="inline-edit" data-field="data.description" name="zord.{{@index}}.description"
+    <textarea class="inline-edit" data-field="system.description" name="zord.{{@index}}.description"
       placeholder="{{localize 'E20.description'}}">{{zord.system.description}}</textarea>
   </div>
   <div class="item-controls">

--- a/templates/item/item-armor-sheet.hbs
+++ b/templates/item/item-armor-sheet.hbs
@@ -10,24 +10,24 @@
   {{!-- Item Sheet Body --}}
   
         <div>
-          <select name="data.availability">
-            {{#select data.availability}}
+          <select name="system.availability">
+            {{#select system.availability}}
             {{#each config.availabilities as |name type|}}
             <option value="{{type}}">{{localize name}}</option>
             {{/each}}
             {{/select}}
           </select>
 
-          <select name="data.classification">
-            {{#select data.classification}}
+          <select name="system.classification">
+            {{#select system.classification}}
             {{#each config.armorClassifications as |name type|}}
             <option value="{{type}}">{{localize name}}</option>
             {{/each}}
             {{/select}}
           </select>
 
-          <select name="data.trait">
-            {{#select data.trait}}
+          <select name="system.trait">
+            {{#select system.trait}}
             {{#each config.armorTraits as |name type|}}
             <option value="{{type}}">{{localize name}}</option>
             {{/each}}
@@ -35,8 +35,8 @@
           </select>
         </div>
 
-        <span class="armor-effect">{{localize 'E20.effect'}}</span><input type="number" name="data.effect"
-          value="{{data.effect}}" />
+        <span class="armor-effect">{{localize 'E20.effect'}}</span><input type="number" name="system.effect"
+          value="{{system.effect}}" />
 
         <div class="armor-description">
           {{!-- Description Section --}}

--- a/templates/item/item-gear-sheet.hbs
+++ b/templates/item/item-gear-sheet.hbs
@@ -5,11 +5,11 @@
 
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
-    <input type="number" name="data.effectArea" value="{{data.effectArea}}" placeholder="{{ localize 'E20.effectArea' }}"/>
+    <input type="number" name="system.effectArea" value="{{system.effectArea}}" placeholder="{{ localize 'E20.effectArea' }}"/>
 
     <span>{{localize 'E20.effectShape'}}</span>
-    <select name="data.effectShape">
-      {{#select data.effectShape}}
+    <select name="system.effectShape">
+      {{#select system.effectShape}}
       {{#each config.effectShapes as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}
@@ -17,11 +17,11 @@
     </select>
 
     <h3>{{localize 'E20.lightRangeStr'}}</h3>
-    <span>{{localize 'E20.lightRange.bright'}}</span><input type="number" name="data.lightRange.bright" value="{{data.lightRange.bright}}"/>
-    <span>{{localize 'E20.lightRange.dim'}}</span><input type="number" name="data.lightRange.dim" value="{{data.lightRange.dim}}"/>
+    <span>{{localize 'E20.lightRange.bright'}}</span><input type="number" name="system.lightRange.bright" value="{{system.lightRange.bright}}"/>
+    <span>{{localize 'E20.lightRange.dim'}}</span><input type="number" name="system.lightRange.dim" value="{{system.lightRange.dim}}"/>
 
-    <span>{{localize 'E20.quantity'}}</span><input type="number" name="data.quantity" value="{{data.quantity}}"/>
-    <span>{{localize 'E20.toughness'}}</span><input type="number" name="data.toughness" value="{{data.toughness}}"/>
+    <span>{{localize 'E20.quantity'}}</span><input type="number" name="system.quantity" value="{{system.quantity}}"/>
+    <span>{{localize 'E20.toughness'}}</span><input type="number" name="system.toughness" value="{{system.toughness}}"/>
 
     {{!-- Description Section --}}
     {{> "systems/essence20/templates/item/parts/item-description.hbs"}}

--- a/templates/item/item-generalPerk-sheet.hbs
+++ b/templates/item/item-generalPerk-sheet.hbs
@@ -5,8 +5,8 @@
 
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
-    <input type="text" name="data.source" value="{{data.source}}" placeholder="{{ localize 'E20.source' }}"/>
-    <input type="text" name="data.prerequisite" value="{{data.prerequisite}}" placeholder="{{ localize 'E20.prerequisite' }}"/>
+    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'E20.source' }}"/>
+    <input type="text" name="system.prerequisite" value="{{system.prerequisite}}" placeholder="{{ localize 'E20.prerequisite' }}"/>
 
     {{!-- Description Section --}}
     {{> "systems/essence20/templates/item/parts/item-description.hbs"}}

--- a/templates/item/item-power-sheet.hbs
+++ b/templates/item/item-power-sheet.hbs
@@ -5,7 +5,7 @@
 
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
-    <input type="text" name="data.source" value="{{data.source}}" placeholder="{{ localize 'E20.source' }}"/>
+    <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'E20.source' }}"/>
 
     {{!-- Description Section --}}
     {{> "systems/essence20/templates/item/parts/item-description.hbs"}}

--- a/templates/item/item-threatPower-sheet.hbs
+++ b/templates/item/item-threatPower-sheet.hbs
@@ -5,10 +5,10 @@
 
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
-    <span>{{localize 'E20.charges'}}</span><input type="number" name="data.charges" value="{{data.charges}}"/>
-    <span>{{localize 'E20.cost'}}</span><input type="number" name="data.cost" value="{{data.cost}}"/>
-    <span>{{localize 'E20.limited'}}</span><input type="checkbox" name="data.limited" {{checked data.limited}}/>
-    <span>{{localize 'E20.actionType'}}</span><input type="text" name="data.actionType" value="{{data.actionType}}" placeholder="{{ localize 'E20.actionType' }}"/>
+    <span>{{localize 'E20.charges'}}</span><input type="number" name="system.charges" value="{{system.charges}}"/>
+    <span>{{localize 'E20.cost'}}</span><input type="number" name="system.cost" value="{{system.cost}}"/>
+    <span>{{localize 'E20.limited'}}</span><input type="checkbox" name="system.limited" {{checked system.limited}}/>
+    <span>{{localize 'E20.actionType'}}</span><input type="text" name="system.actionType" value="{{system.actionType}}" placeholder="{{ localize 'E20.actionType' }}"/>
 
     {{!-- Description Section --}}
     {{> "systems/essence20/templates/item/parts/item-description.hbs"}}

--- a/templates/item/item-weapon-sheet.hbs
+++ b/templates/item/item-weapon-sheet.hbs
@@ -6,40 +6,40 @@
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
     <div>
-      <select name="data.availability">
-        {{#select data.availability}}
+      <select name="system.availability">
+        {{#select system.availability}}
         {{#each config.availabilities as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
         {{/each}}
         {{/select}}
       </select>
 
-      <select name="data.classification.skill">
-        {{#select data.classification.skill}}
+      <select name="system.classification.skill">
+        {{#select system.classification.skill}}
         {{#each config.weaponSkills as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
         {{/each}}
         {{/select}}
       </select>
 
-      <select name="data.classification.size">
-        {{#select data.classification.size}}
+      <select name="system.classification.size">
+        {{#select system.classification.size}}
         {{#each config.weaponSizes as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
         {{/each}}
         {{/select}}
       </select>
 
-      <select name="data.classification.style">
-        {{#select data.classification.style}}
+      <select name="system.classification.style">
+        {{#select system.classification.style}}
         {{#each config.weaponStyles as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
         {{/each}}
         {{/select}}
       </select>
 
-      <select name="data.shift">
-        {{#select data.shift}}
+      <select name="system.shift">
+        {{#select system.shift}}
         {{#each config.shifts as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
         {{/each}}
@@ -47,38 +47,38 @@
       </select>
     </div>
 
-    <span>{{localize 'E20.numCharges'}}</span><input type="number" name="data.numCharges" value="{{data.numCharges}}"/>
-    <input type="text" name="data.custom" value="{{data.custom}}" placeholder="{{ localize 'E20.custom' }}"/>
+    <span>{{localize 'E20.numCharges'}}</span><input type="number" name="system.numCharges" value="{{system.numCharges}}"/>
+    <input type="text" name="system.custom" value="{{system.custom}}" placeholder="{{ localize 'E20.custom' }}"/>
 
     <h3>{{localize 'E20.effect'}}</h3>
-    <input type="text" name="data.effect" value="{{data.effect}}" placeholder="{{ localize 'E20.effect' }}"/>
+    <input type="text" name="system.effect" value="{{system.effect}}" placeholder="{{ localize 'E20.effect' }}"/>
 
     <h3>{{localize 'E20.alternateEffects'}}</h3>
-    <input type="text" name="data.alternateEffects" value="{{data.alternateEffects}}" placeholder="{{ localize 'E20.alternateEffects' }}"/>
+    <input type="text" name="system.alternateEffects" value="{{system.alternateEffects}}" placeholder="{{ localize 'E20.alternateEffects' }}"/>
 
     <div>
-      <span>{{localize 'E20.numHands'}}</span><input type="number" name="data.numHands" value="{{data.numHands}}"/>
-      <span>{{localize 'E20.numTargets'}}</span><input type="number" name="data.numTargets" value="{{data.numTargets}}"/>
-      <span>{{localize 'E20.radius'}}</span><input type="number" name="data.radius" value="{{data.radius}}"/>
+      <span>{{localize 'E20.numHands'}}</span><input type="number" name="system.numHands" value="{{system.numHands}}"/>
+      <span>{{localize 'E20.numTargets'}}</span><input type="number" name="system.numTargets" value="{{system.numTargets}}"/>
+      <span>{{localize 'E20.radius'}}</span><input type="number" name="system.radius" value="{{system.radius}}"/>
     </div>
 
     <h3>{{localize 'E20.range'}}</h3>
-    <span>{{localize 'E20.min'}}</span><input type="number" name="data.range.min" value="{{data.range.min}}"/>
-    <span>{{localize 'E20.reachMultiplier'}}</span><input type="number" name="data.range.reachMultiplier" value="{{data.range.reachMultiplier}}"/>
-    <span>{{localize 'E20.long'}}</span><input type="number" name="data.range.long" value="{{data.range.long}}"/>
-    <span>{{localize 'E20.value'}}</span><input type="number" name="data.range.value" value="{{data.range.value}}"/>
+    <span>{{localize 'E20.min'}}</span><input type="number" name="system.range.min" value="{{system.range.min}}"/>
+    <span>{{localize 'E20.reachMultiplier'}}</span><input type="number" name="system.range.reachMultiplier" value="{{system.range.reachMultiplier}}"/>
+    <span>{{localize 'E20.long'}}</span><input type="number" name="system.range.long" value="{{system.range.long}}"/>
+    <span>{{localize 'E20.value'}}</span><input type="number" name="system.range.value" value="{{system.range.value}}"/>
 
     <h3>{{localize 'E20.requirements'}}</h3>
-    <input type="text" name="data.requirements.custom" value="{{data.requirements.custom}}" placeholder="{{ localize 'E20.custom' }}"/>
-    <select name="data.skill">
-      {{#select data.skill}}
+    <input type="text" name="system.requirements.custom" value="{{system.requirements.custom}}" placeholder="{{ localize 'E20.custom' }}"/>
+    <select name="system.skill">
+      {{#select system.skill}}
       {{#each config.weaponRequirementSkills as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}
       {{/select}}
     </select>
-    <select name="data.requirements.shift">
-      {{#select data.shift}}
+    <select name="system.requirements.shift">
+      {{#select system.shift}}
       {{#each config.weaponRequirementShifts as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}

--- a/templates/item/item-weapon-sheet.hbs
+++ b/templates/item/item-weapon-sheet.hbs
@@ -63,8 +63,8 @@
     </div>
 
     <h3>{{localize 'E20.range'}}</h3>
-    <span>{{localize 'E20.min'}}</span><input type="number" name="data.range.min" value="{{data.min}}"/>
-    <span>{{localize 'E20.reachMultiplier'}}</span><input type="number" name="data.range.reachMultiplier" value="{{data.reachMultiplier}}"/>
+    <span>{{localize 'E20.min'}}</span><input type="number" name="data.range.min" value="{{data.range.min}}"/>
+    <span>{{localize 'E20.reachMultiplier'}}</span><input type="number" name="data.range.reachMultiplier" value="{{data.range.reachMultiplier}}"/>
     <span>{{localize 'E20.long'}}</span><input type="number" name="data.range.long" value="{{data.range.long}}"/>
     <span>{{localize 'E20.value'}}</span><input type="number" name="data.range.value" value="{{data.range.value}}"/>
 

--- a/templates/item/item-weaponUpgrade-sheet.hbs
+++ b/templates/item/item-weaponUpgrade-sheet.hbs
@@ -5,16 +5,16 @@
 
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
-    <select name="data.availability">
-      {{#select data.availability}}
+    <select name="system.availability">
+      {{#select system.availability}}
       {{#each config.availabilities as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}
       {{/select}}
     </select>
 
-    <input type="text" name="data.benefit" value="{{data.benefit}}" placeholder="{{ localize 'E20.benefit' }}"/>
-    <input type="text" name="data.prerequisite" value="{{data.prerequisite}}" placeholder="{{ localize 'E20.prerequisite' }}"/>
+    <input type="text" name="system.benefit" value="{{system.benefit}}" placeholder="{{ localize 'E20.benefit' }}"/>
+    <input type="text" name="system.prerequisite" value="{{system.prerequisite}}" placeholder="{{ localize 'E20.prerequisite' }}"/>
 
     {{!-- Description Section --}}
     {{> "systems/essence20/templates/item/parts/item-description.hbs"}}

--- a/templates/item/item-zordCombiner-sheet.hbs
+++ b/templates/item/item-zordCombiner-sheet.hbs
@@ -5,8 +5,8 @@
 
   {{!-- Item Sheet Body --}}
   <section class="sheet-body">
-    <select name="data.colorSpectrum">
-      {{#select data.colorSpectrum}}
+    <select name="system.colorSpectrum">
+      {{#select system.colorSpectrum}}
       {{#each config.rangers as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}
@@ -14,16 +14,16 @@
     </select>
 
     <div class="resource flex-group-center">
-      <label for="data.health.value" class="resource-label">Health</label>
+      <label for="system.health.value" class="resource-label">{{localize 'E20.health'}}</label>
       <div class="resource-content flexrow flex-center flex-between">
-        <input type="text" name="data.health.value" value="{{data.health.value}}" data-dtype="Number" />
+        <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
         <span> / </span>
-        <input type="text" name="data.health.max" value="{{data.health.max}}" data-dtype="Number" />
+        <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
       </div>
     </div>
 
-    <input type="text" name="data.ranger" value="{{data.ranger}}" placeholder="{{ localize 'E20.ranger' }}" />
-    <input type="text" name="data.skillNotes" value="{{data.skillNotes}}"
+    <input type="text" name="system.ranger" value="{{system.ranger}}" placeholder="{{ localize 'E20.ranger' }}" />
+    <input type="text" name="system.skillNotes" value="{{system.skillNotes}}"
       placeholder="{{ localize 'E20.skillNotes' }}" />
 
     {{!-- Description Section --}}

--- a/templates/item/parts/item-description.hbs
+++ b/templates/item/parts/item-description.hbs
@@ -1,4 +1,4 @@
 <h3>Description</h3>
 <div class="description-tab flexrow active" data-group="primary" data-tab="description">
-  {{editor data.description target="data.description" button=true owner=owner editable=editable}}
+  {{editor system.description target="system.description" button=true owner=owner editable=editable}}
 </div>


### PR DESCRIPTION
In this change
- Replacing `data` with `system` for a bunch of item sheets
- Fixing bug for weapon range inputs https://github.com/WookieeMatt/Essence20/issues/102

Testing
- Weapon min and reach multiplier fields should be saving
- Unfortunately almost every field for Traits, Armor, Gear, General Perks, Powers, Threat Powers, and Weapons has been touched