### PR TITLE
Zord/MFZ/Vehicle defenses

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -734,11 +734,10 @@ form .hint {
 
 .essence20 .common-container {
   display: grid;
-  grid-template-columns: repeat(2fr, 1fr);
+  grid-template-columns: 1fr 1fr 1fr;
   grid-gap: 5px;
   grid-template-areas:
-    "common-container-1 common-container-2"
-    "common-container-1 common-container-2";
+    "common-container-1 common-container-2 common-container-3";
   padding-bottom: 15px;
 }
 

--- a/template.json
+++ b/template.json
@@ -234,10 +234,18 @@
         }
       ],
       "defenses": {
-        "toughness": 10,
-        "evasion": 10,
-        "willpower": 10,
-        "cleverness": 10
+        "toughness": {
+          "value": 10
+        },
+        "evasion": {
+          "value": 10
+        },
+        "willpower": {
+          "value": null
+        },
+        "cleverness": {
+          "value": null
+        }
       },
       "hangUp": {
         "description": "",

--- a/templates/actor/actor-megaformZord-sheet.hbs
+++ b/templates/actor/actor-megaformZord-sheet.hbs
@@ -13,21 +13,9 @@
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body">
     <div class="zord-sheet-grid">
-      <div class="zord-container-1">
-        <div>
-          {{> "systems/essence20/templates/actor/parts/actor-zord-movement.hbs"}}
-        </div>
-        <div class="zord-health-container">
-          <div class="resource flex-group-center">
-            <h3>{{localize 'E20.health'}}</h3>
-            <div class="resource-content flexrow flex-center flex-between">
-              <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
-              <span>/</span>
-              <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
-            </div>
-          </div>
-        </div>
-      </div>
+      {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+      {{> "systems/essence20/templates/actor/parts/actor-common.hbs"}}
+
       <div class="flexcol">
         <div class="zord-container-2">
           {{> "systems/essence20/templates/actor/parts/actor-zord-skills.hbs"}}

--- a/templates/actor/actor-powerRanger-sheet.hbs
+++ b/templates/actor/actor-powerRanger-sheet.hbs
@@ -20,6 +20,7 @@
       <section class="sheet-body">
         {{!-- Skills Tab --}}
         <div class="tab skills" data-group="primary" data-tab="skills">
+          {{> "systems/essence20/templates/actor/parts/actor-defenses.hbs"}}
           {{> "systems/essence20/templates/actor/parts/actor-common.hbs"}}
         </div>
 

--- a/templates/actor/actor-vehicle-sheet.hbs
+++ b/templates/actor/actor-vehicle-sheet.hbs
@@ -5,7 +5,9 @@
 
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body">
+    {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
     {{> "systems/essence20/templates/actor/parts/actor-common.hbs"}}
+
     <span>{{localize 'E20.threatLevel'}}</span><input type="number" name="system.threatLevel"
       value="{{system.threatLevel}}" />
 

--- a/templates/actor/actor-zord-sheet.hbs
+++ b/templates/actor/actor-zord-sheet.hbs
@@ -13,21 +13,9 @@
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body">
     <div class="zord-sheet-grid">
-      <div class="zord-container-1">
-        <div>
-          {{> "systems/essence20/templates/actor/parts/actor-zord-movement.hbs"}}
-        </div>
-        <div class="zord-health-container">
-          <div class="resource flex-group-center">
-            <h3>{{localize 'E20.health'}}</h3>
-            <div class="resource-content flexrow flex-center flex-between">
-              <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
-              <span>/</span>
-              <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
-            </div>
-          </div>
-        </div>
-      </div>
+      {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+      {{> "systems/essence20/templates/actor/parts/actor-common.hbs"}}
+
       <div class="flexcol">
         <div class="zord-container-2">
           {{> "systems/essence20/templates/actor/parts/actor-zord-skills.hbs"}}

--- a/templates/actor/parts/actor-common.hbs
+++ b/templates/actor/parts/actor-common.hbs
@@ -1,8 +1,6 @@
 <div class="common-container">
+  {{!-- Initiative --}}
   <div class="common-container-1">
-    {{> "systems/essence20/templates/actor/parts/actor-defenses.hbs"}}
-
-    {{!-- Initiative --}}
     <div class="initiative-container">
       <div class="initiative-header">
         <span>{{localize 'E20.initiative'}}</span>
@@ -18,8 +16,8 @@
     </div>
   </div>
 
+  {{!-- Movement --}}
   <div class="common-container-2">
-    {{!-- Movement --}}
     <div class="stats-container">
       <div class="flexrow flex-group-center">
         <div>{{localize 'E20.movement.ground'}}</div>
@@ -38,7 +36,10 @@
         <div><input class="two-digit-input" type="number" name="system.movement.aerialMin" value="{{system.movement.aerialMin}}" /></div>
       </div>
     </div>
-    {{!-- Health --}}
+  </div>
+
+  {{!-- Health --}}
+  <div class="common-container-3">
     <div class="health-container">
       <div class="resource flex-group-center">
         <label for="system.health.value" class="resource-label">{{localize 'E20.health'}}</label>

--- a/templates/actor/parts/actor-npc-defenses.hbs
+++ b/templates/actor/parts/actor-npc-defenses.hbs
@@ -1,10 +1,10 @@
 <div class="npc-defenses-section">
     <div class="npc-defenses-container">
       <div class="npc-defenses">
-        {{#each system.defenses as |value defense|}}
+        {{#each system.defenses as |fields defense|}}
           <div class="resource flexcol">
           <span class="resource flex-group-center">{{localize (concat 'E20.defenses.' defense)}}: </span>
-          <input type="number" name="system.defenses.{{defense}}" value="{{value}}"/>
+          <input type="number" name="system.defenses.{{defense}}.value" value="{{fields.value}}"/>
         </div>
         {{/each}}
       </div>


### PR DESCRIPTION
In this change
- Moving defenses out of actor-common.hbs since PR defenses are different
- Adding `value` field to NPC defenses to align with machines
- Showing defenses for Zords, MFZs, and Vehicles

Testing: Defenses for Zords, MFZs, and Vehicles should appear like it does for NPCs
