### PR TITLE
SPT options and string tweaks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -323,7 +323,8 @@
       "options": {
         "show.name": "Dialog display behavior",
         "access.name": "Who can access the SPT?",
-        "message.name": "Display chat messages"
+        "message.name": "Display chat messages",
+        "gmPointsArePublic.name": "Display GM Points to Players"
       },
 
       "roll": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -301,35 +301,35 @@
       "trip": "Trip",
       "wrecker": "Wrecker"
     },
-    "STORY_POINTS": {
-      "alwaysShow": "Always show",
-      "dontShow": "Don't show",
-      "allowToggle": "Allow toggling",
-    
-      "everyone": "Everyone",
-      "gm": "GM Only",
-      "players": "Player Only",
-  
-      "gmPoints": "GM Points",
-      "storyPoints": "Story Points",
-
-      "gmPointSpent": "A GM Point has been spent!",
-      "storyPointSpent": "A Story Point has been spent!",
-
+    "spt": {
       "title": "Story Points Tracker",
-
       "toggleDialog": "Toggle Story Points Tracker Dialog",
-
       "options": {
         "show.name": "Dialog display behavior",
         "access.name": "Who can access the SPT?",
         "message.name": "Display chat messages",
         "gmPointsArePublic.name": "Display GM Points to Players"
       },
-
+      "points": {
+        "gm": "GM Points",
+        "story": "Story Points"
+      },
       "roll": {
         "button": "Roll major scene GM Points",
         "flavor": "Rolling for major scene GM Points!"
+      },
+      "show": {
+        "always": "Always show",
+        "never": "Never show",
+        "toggle": "Allow toggling"
+      },
+      "spend": {
+        "gmPoint": "A GM Point has been spent!",
+        "storyPoint": "A Story Point has been spent!"
+      },
+      "users": {
+        "everyone": "Everyone",
+        "gm": "GM Only"
       }
     }
   }

--- a/module/settings.js
+++ b/module/settings.js
@@ -8,22 +8,21 @@ export const registerSettings = function () {
   /* -------------------------------------------- */
 
   const SHOW_OPTIONS = {
-    on: game.i18n.localize("E20.STORY_POINTS.alwaysShow"),
-    off: game.i18n.localize("E20.STORY_POINTS.dontShow"),
-    toggle: game.i18n.localize("E20.STORY_POINTS.allowToggle"),
+    on: game.i18n.localize("E20.spt.show.always"),
+    off: game.i18n.localize("E20.spt.show.never"),
+    toggle: game.i18n.localize("E20.spt.show.toggle"),
   };
 
   const ACCESS_OPTIONS = {
-    everyone: game.i18n.localize("E20.STORY_POINTS.everyone"),
-    gm: game.i18n.localize("E20.STORY_POINTS.gm"),
-    players: game.i18n.localize("E20.STORY_POINTS.players"),
+    everyone: game.i18n.localize("E20.spt.users.everyone"),
+    gm: game.i18n.localize("E20.spt.users.gm"),
   };
 
   /* -------------------------------------------- */
   /*  Config settings                             */
   /* -------------------------------------------- */
   game.settings.register(systemName, "sptAccess", {
-    name: game.i18n.localize("E20.STORY_POINTS.options.access.name"),
+    name: game.i18n.localize("E20.spt.options.access.name"),
     scope: "world",
     config: true,
     default: "everyone",
@@ -33,7 +32,7 @@ export const registerSettings = function () {
   });
 
   game.settings.register(systemName, "sptGmPointsArePublic", {
-    name: game.i18n.localize("E20.STORY_POINTS.options.gmPointsArePublic.name"),
+    name: game.i18n.localize("E20.spt.options.gmPointsArePublic.name"),
     scope: "world",
     config: true,
     default: true,
@@ -42,7 +41,7 @@ export const registerSettings = function () {
   });
 
   game.settings.register(systemName, "sptShow", {
-    name: game.i18n.localize("E20.STORY_POINTS.options.show.name"),
+    name: game.i18n.localize("E20.spt.options.show.name"),
     scope: "client",
     config: true,
     default: "toggle",
@@ -52,7 +51,7 @@ export const registerSettings = function () {
   });
 
   game.settings.register(systemName, "sptMessage", {
-    name: game.i18n.localize("E20.STORY_POINTS.options.message.name"),
+    name: game.i18n.localize("E20.spt.options.message.name"),
     scope: "world",
     config: true,
     default: true,

--- a/module/settings.js
+++ b/module/settings.js
@@ -32,6 +32,15 @@ export const registerSettings = function () {
     onChange: debouncedReload
   });
 
+  game.settings.register(systemName, "sptGmPointsArePublic", {
+    name: game.i18n.localize("E20.STORY_POINTS.options.gmPointsArePublic.name"),
+    scope: "world",
+    config: true,
+    default: true,
+    type: Boolean,
+    onChange: debouncedReload
+  });
+
   game.settings.register(systemName, "sptShow", {
     name: game.i18n.localize("E20.STORY_POINTS.options.show.name"),
     scope: "client",

--- a/module/story-points-tracker.js
+++ b/module/story-points-tracker.js
@@ -34,6 +34,7 @@ export class StoryPointsTracker extends Application {
       gmPoints: this.gmPoints,
       storyPoints: this.storyPoints,
       isGm: game.user.isGM,
+      gmPointsArePublic: game.user.isGM || setting('sptGmPointsArePublic'),
     };
   }
 

--- a/module/story-points-tracker.js
+++ b/module/story-points-tracker.js
@@ -24,7 +24,7 @@ export class StoryPointsTracker extends Application {
       resizable: false,
       top: pos?.top || 60,
       left: pos?.left || (($('#board').width / 2) - 150),
-      title: i18n('E20.STORY_POINTS.title'),
+      title: i18n('E20.spt.title'),
     });
   }
 
@@ -67,7 +67,7 @@ export class StoryPointsTracker extends Application {
     html.find('#gm-points-btn-dec').click(ev => {
       ev.preventDefault();
       this.changeGmPoints(this.gmPoints - 1);
-      this.sendMessage(`${i18n("E20.STORY_POINTS.gmPointSpent")}`);
+      this.sendMessage(`${i18n("E20.spt.spend.gmPoint")}`);
     });
     html.find('#gm-points-btn-inc').click(ev => {
       ev.preventDefault();
@@ -87,7 +87,7 @@ export class StoryPointsTracker extends Application {
         let roll = new Roll('d2 + 1');
         await roll.toMessage({
           speaker: game.user.name,
-          flavor: `${i18n("E20.STORY_POINTS.roll.flavor")}`,
+          flavor: `${i18n("E20.spt.roll.flavor")}`,
           rollMode: game.settings.get('core', 'rollMode'),
         });
         this.changeGmPoints(this.gmPoints + roll.total);
@@ -98,7 +98,7 @@ export class StoryPointsTracker extends Application {
     html.find('#story-points-btn-dec').click(ev => {
       ev.preventDefault();
       this.changeStoryPoints(this.storyPoints - 1);
-      this.sendMessage(`${i18n("E20.STORY_POINTS.storyPointSpent")}`);
+      this.sendMessage(`${i18n("E20.spt.spend.storyPoint")}`);
     });
     html.find('#story-points-btn-inc').click(ev => {
       ev.preventDefault();
@@ -181,7 +181,7 @@ Hooks.on("getSceneControlButtons", (controls) => {
     let tokenControls = controls.find(control => control.name === "token")
     tokenControls.tools.push({
       name: "toggleDialog",
-      title: "E20.STORY_POINTS.toggleDialog",
+      title: "E20.spt.toggleDialog",
       icon: "fas fa-circle-s",
       toggle: true,
       active: setting('sptToggleState'),

--- a/templates/story-points.hbs
+++ b/templates/story-points.hbs
@@ -1,3 +1,4 @@
+{{#if gmPointsArePublic}}
 <div class="story-points-content">
   <div class="story-points-label">{{localize 'E20.STORY_POINTS.gmPoints'}}</div>
   {{#if isGm}}
@@ -9,9 +10,10 @@
     <i class="fas fa-angle-double-up"></i>
   </div>
   {{else}}
-  <input id="gm-points-input" type="number" value="{{gmPoints}}" disabled/>
+  <input id="gm-points-input" type="number" value="{{gmPoints}}" disabled />
   {{/if}}
 </div>
+{{/if}}
 
 <div class="story-points-content">
   <div class="story-points-label">{{localize 'E20.STORY_POINTS.storyPoints'}}</div>
@@ -24,7 +26,7 @@
     <i class="fas fa-angle-double-up"></i>
   </div>
   {{else}}
-  <input id="story-points-input" type="number" value="{{storyPoints}}" disabled/>
+  <input id="story-points-input" type="number" value="{{storyPoints}}" disabled />
   {{/if}}
 </div>
 

--- a/templates/story-points.hbs
+++ b/templates/story-points.hbs
@@ -1,6 +1,6 @@
 {{#if gmPointsArePublic}}
 <div class="story-points-content">
-  <div class="story-points-label">{{localize 'E20.STORY_POINTS.gmPoints'}}</div>
+  <div class="story-points-label">{{localize 'E20.spt.points.gm'}}</div>
   {{#if isGm}}
   <div id="gm-points-btn-dec" class="story-points-btn bad-ones">
     <i class="fas fa-angle-double-down"></i>
@@ -16,7 +16,7 @@
 {{/if}}
 
 <div class="story-points-content">
-  <div class="story-points-label">{{localize 'E20.STORY_POINTS.storyPoints'}}</div>
+  <div class="story-points-label">{{localize 'E20.spt.points.story'}}</div>
   {{#if isGm}}
   <div id="story-points-btn-dec" class="story-points-btn bad-ones">
     <i class="fas fa-angle-double-down"></i>
@@ -32,6 +32,6 @@
 
 {{#if isGm}}
 <div style="text-align: center; margin-top: 10px;">
-  <a id="major-scene-points-button">{{localize 'E20.STORY_POINTS.roll.button'}}</a>
+  <a id="major-scene-points-button">{{localize 'E20.spt.roll.button'}}</a>
 </div>
 {{/if}}


### PR DESCRIPTION
In this change
- Adding a new option to hide GM points from players
- Removing "Player only" access option
- Bunch of localization string tweaks

Testing: Unchecking the new option should hide GM Points from the player view

Note: Hitting enter to submit a value is weird because the way Foundry works the input is never unfocused, so it doesn't look like it's doing anything. It's the same for fields in other sheets. With Always HP it's a bit different since they clear the input afterwards, which we don't want to do. In short, I'm leaving it as it is for now.