### PR TITLE
Weapon skill and requirements fixes

### DIFF
--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -207,19 +207,6 @@ E20.weaponSizes = {
   heavy: "E20.weaponSizes.heavy",
 };
 
-E20.weaponSkills = {
-  athletics: "E20.essenceSkills.athletics",
-  might: "E20.essenceSkills.might",
-  finesse: "E20.essenceSkills.finesse",
-  targeting: "E20.essenceSkills.targeting",
-  technology: "E20.essenceSkills.technology",
-};
-
-E20.weaponRequirementSkills = {
-  none: "",
-  ...E20.weaponSkills,
-};
-
 E20.weaponStyles = {
   melee: "E20.weaponStyles.melee",
   energy: "E20.weaponStyles.energy",

--- a/template.json
+++ b/template.json
@@ -361,8 +361,7 @@
         "custom": null,
         "skill": null,
         "shift": null
-      },
-      "shift": "d20"
+      }
     },
     "weaponUpgrade": {
       "templates": [

--- a/templates/item/item-weapon-sheet.hbs
+++ b/templates/item/item-weapon-sheet.hbs
@@ -16,7 +16,7 @@
 
       <select name="system.classification.skill">
         {{#select system.classification.skill}}
-        {{#each config.weaponSkills as |name type|}}
+        {{#each config.essenceSkills as |name type|}}
         <option value="{{type}}">{{localize name}}</option>
         {{/each}}
         {{/select}}
@@ -62,15 +62,15 @@
 
     <h3>{{localize 'E20.requirements'}}</h3>
     <input type="text" name="system.requirements.custom" value="{{system.requirements.custom}}" placeholder="{{ localize 'E20.custom' }}"/>
-    <select name="system.skill">
-      {{#select system.skill}}
-      {{#each config.weaponRequirementSkills as |name type|}}
+    <select name="system.requirements.skill">
+      {{#select system.requirements.skill}}
+      {{#each config.essenceSkills as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}
       {{/select}}
     </select>
     <select name="system.requirements.shift">
-      {{#select system.shift}}
+      {{#select system.requirements.shift}}
       {{#each config.weaponRequirementShifts as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}

--- a/templates/item/item-weapon-sheet.hbs
+++ b/templates/item/item-weapon-sheet.hbs
@@ -37,14 +37,6 @@
         {{/each}}
         {{/select}}
       </select>
-
-      <select name="system.shift">
-        {{#select system.shift}}
-        {{#each config.shifts as |name type|}}
-        <option value="{{type}}">{{localize name}}</option>
-        {{/each}}
-        {{/select}}
-      </select>
     </div>
 
     <span>{{localize 'E20.numCharges'}}</span><input type="number" name="system.numCharges" value="{{system.numCharges}}"/>


### PR DESCRIPTION
In this change
- Removing unused shift field from Weapon items
- No longer restricting Weapon skills
- Fixing requirements fields in template

Testing
- TEMPLATE CHANGE, so restart Foundry
- Create a new Weapon
- Skill selectors should now show all skills
- Requirements fields work as expected