### PR TITLE
Weapon Snag/Edge fix; updating dice tests

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -44,11 +44,11 @@ export class Dice {
           },
           cancel: {
             label: this._i18n.localize(this._config.cancel),
-            callback: html => resolve({cancelled: true}),
+            callback: html => resolve({ cancelled: true }),
           },
         },
         default: "normal",
-        close: () => resolve({cancelled: true}),
+        close: () => resolve({ cancelled: true }),
       };
       new Dialog(data, null).render(true);
     });
@@ -77,7 +77,9 @@ export class Dice {
    * @param {Item} weapon   The weapon being used, if any.
    */
   rollSkill(dataset, skillRollOptions, actor, weapon) {
-    let label = weapon ? this._getWeaponRollLabel(dataset, weapon) : this._getSkillRollLabel(dataset);
+    let label = weapon
+      ? this._getWeaponRollLabel(dataset, skillRollOptions, weapon)
+      : this._getSkillRollLabel(dataset, skillRollOptions);
     const rolledSkill = dataset.skill;
     const rolledEssence = this._config.skillToEssence[rolledSkill];
     const actorSkillData = actor.getRollData().skills;
@@ -99,7 +101,7 @@ export class Dice {
     let roll = new Roll(formula, actor.getRollData());
     roll.toMessage({
       speaker: this._chatMessage.getSpeaker({ actor }),
-      flavor: label + this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag),
+      flavor: label,
       rollMode: game.settings.get('core', 'rollMode'),
     });
   }
@@ -107,26 +109,28 @@ export class Dice {
   /**
    * Create skill roll label.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
+   * @param {Object} skillRollOptions   The result of getSkillRollOptions().
    * @returns {String}   The resultant roll label.
    * @private
    */
-  _getSkillRollLabel(dataset) {
+  _getSkillRollLabel(dataset, skillRollOptions) {
     const rolledSkill = dataset.skill;
     const rolledSkillStr = dataset.specialization
       ? dataset.specialization
       : this._i18n.localize(this._config.essenceSkills[rolledSkill]);
     const rollingForStr = this._i18n.localize(this._config.rollingFor)
-    return `${rollingForStr} ${rolledSkillStr}`;
+    return `${rollingForStr} ${rolledSkillStr}` + this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag);
   }
 
   /**
    * Create weapon roll label.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
+   * @param {Object} skillRollOptions   The result of getSkillRollOptions().
    * @returns {String}   The resultant roll label.
    * @param {Item} weapon   The weapon being used.
    * @private
    */
-   _getWeaponRollLabel(dataset, weapon) {
+  _getWeaponRollLabel(dataset, skillRollOptions, weapon) {
     const rolledSkill = dataset.skill;
     const rolledSkillStr = this._i18n.localize(this._config.essenceSkills[rolledSkill]);
     const attackRollStr = this._i18n.localize(this._config.attackRoll)
@@ -134,7 +138,8 @@ export class Dice {
     const alternateEffectsStr = this._i18n.localize(this._config.alternateEffects)
     const noneStr = this._i18n.localize(this._config.none)
 
-    let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})<br>`;
+    let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})`
+    label += ` ${this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag)}<br>`;
     label += `<b>${effectStr}</b> - ${weapon.system.effect || noneStr}<br>`;
     label += `<b>${alternateEffectsStr}</b> - ${weapon.system.alternateEffects || noneStr}`;
 
@@ -172,7 +177,7 @@ export class Dice {
       const chatData = {
         speaker: this._chatMessage.getSpeaker({ actor }),
       };
-      switch(skillShift) {
+      switch (skillShift) {
         case 'autoFail':
           label += ` ${this._i18n.localize(this._config.autoFail)}`;
           break;
@@ -235,7 +240,7 @@ export class Dice {
     let result = '';
     const len = operands.length;
 
-    for (let i=0; i < len; i+=1) {
+    for (let i = 0; i < len; i += 1) {
       const operand = operands[i];
       result += i == len - 1 ? operand : `${operand},`;
     }

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -139,7 +139,7 @@ export class Dice {
     const noneStr = this._i18n.localize(this._config.none)
 
     let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})`
-    label += ` ${this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag)}<br>`;
+    label += `${this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag)}<br>`;
     label += `<b>${effectStr}</b> - ${weapon.system.effect || noneStr}<br>`;
     label += `<b>${alternateEffectsStr}</b> - ${weapon.system.alternateEffects || noneStr}`;
 

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -18,9 +18,39 @@ describe("_getSkillRollLabel", () => {
     const dataset = {
       skill: 'athletics',
     };
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+    }
     const expected = "E20.rollingFor E20.essenceSkills.athletics";
 
-    expect(dice._getSkillRollLabel(dataset)).toEqual(expected);
+    expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
+  });
+
+  test("skill roll with Edge", () => {
+    const dataset = {
+      skill: 'athletics',
+    };
+    const skillRollOptions = {
+      edge: true,
+      snag: false,
+    }
+    const expected = "E20.rollingFor E20.essenceSkills.athletics E20.withAnEdge";
+
+    expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
+  });
+
+  test("skill roll with Snag", () => {
+    const dataset = {
+      skill: 'athletics',
+    };
+    const skillRollOptions = {
+      edge: false,
+      snag: true,
+    }
+    const expected = "E20.rollingFor E20.essenceSkills.athletics E20.withASnag";
+
+    expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
   });
 
   test("specialization roll", () => {
@@ -28,9 +58,13 @@ describe("_getSkillRollLabel", () => {
       skill: 'athletics',
       specialization: "Foo Specialization",
     };
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+    }
     const expected = "E20.rollingFor Foo Specialization";
 
-    expect(dice._getSkillRollLabel(dataset)).toEqual(expected);
+    expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
   });
 });
 
@@ -40,6 +74,10 @@ describe("_getWeaponRollLabel", () => {
     const dataset = {
       skill: 'athletics',
     };
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+    }
     const weapon = {
       name: 'Zeo Power Clubs',
       system: {
@@ -52,13 +90,63 @@ describe("_getWeaponRollLabel", () => {
      "<b>E20.effect</b> - Some effect<br>" +
      "<b>E20.alternateEffects</b> - Some alternate effects";
 
-    expect(dice._getWeaponRollLabel(dataset, weapon)).toEqual(expected);
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
+  });
+
+  test("weapon roll with Edge", () => {
+    const dataset = {
+      skill: 'athletics',
+    };
+    const skillRollOptions = {
+      edge: true,
+      snag: false,
+    }
+    const weapon = {
+      name: 'Zeo Power Clubs',
+      system: {
+        effect: "Some effect",
+        alternateEffects: "Some alternate effects",
+      },
+    };
+    const expected =
+     "<b>E20.attackRoll</b> - Zeo Power Clubs (E20.essenceSkills.athletics) E20.withAnEdge<br>" +
+     "<b>E20.effect</b> - Some effect<br>" +
+     "<b>E20.alternateEffects</b> - Some alternate effects";
+
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
+  });
+
+  test("weapon roll with Snag", () => {
+    const dataset = {
+      skill: 'athletics',
+    };
+    const skillRollOptions = {
+      edge: false,
+      snag: true,
+    }
+    const weapon = {
+      name: 'Zeo Power Clubs',
+      system: {
+        effect: "Some effect",
+        alternateEffects: "Some alternate effects",
+      },
+    };
+    const expected =
+     "<b>E20.attackRoll</b> - Zeo Power Clubs (E20.essenceSkills.athletics) E20.withASnag<br>" +
+     "<b>E20.effect</b> - Some effect<br>" +
+     "<b>E20.alternateEffects</b> - Some alternate effects";
+
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
   });
 
   test("no effects", () => {
     const dataset = {
       skill: 'athletics',
     };
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+    }
     const weapon = {
       name: 'Zeo Power Clubs',
       system: {
@@ -71,7 +159,7 @@ describe("_getWeaponRollLabel", () => {
      "<b>E20.effect</b> - E20.none<br>" +
      "<b>E20.alternateEffects</b> - E20.none";
 
-    expect(dice._getWeaponRollLabel(dataset, weapon)).toEqual(expected);
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
   });
 });
 


### PR DESCRIPTION
The "with a Snag/Edge" text was being appended to the Alternate Source section,  so this moves it where it belongs and updates unit tests.

Testing: Do weapon and skill rolls. Snag/Edge text should appear next to the skill roll info.