### PR TITLE
Fixing a merge that broke _prepareDisplayedNpcSkills()

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -79,8 +79,7 @@ export class Essence20ActorSheet extends ActorSheet {
    * @return {undefined}
    */
   _prepareDisplayedNpcSkills(context) {
-    if (this.actor.type == 'npc') {
-      let displayedNpcSkills = {};
+    let displayedNpcSkills = {};
 
     // Include any skill that have specializations
     for (let skill in context.specializations) {


### PR DESCRIPTION
Previously was breaking all actor sheets because of mismatched brackets