### PR TITLE
Creating Origin item

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -105,7 +105,6 @@
     "numHands": "Hands",
     "numPassengers": "Passengers",
     "numTargets": "Targets",
-    "origin": "Origin",
     "perk": "Perk",
     "perks": "Perks",
     "personalPower": "Personal Power",
@@ -224,6 +223,18 @@
       "aerial": "Aerial",
       "ground": "Ground",
       "swim": "Swim"
+    },
+    "origin": {
+      "benefit": {
+        "name": "Benefit Name",
+        "description": "Benefit Description"
+      },
+      "bonusSkillLevels": "Bonus Skill Levels",
+      "essenceIncreaseOptions": "Essence Increase Options",
+      "groundMovement": "Ground Movement",
+      "origin": "Origin",
+      "languages": "Languages",
+      "startingHealth": "Starting Health"
     },
     "rangers": {
       "black": "Black Ranger",

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,6 +18,7 @@
     "TypeThreatpower": "Threat Power",
     "TypeHangup": "Hang Up",
     "TypeMegaformtrait": "Megaform Trait",
+    "TypeOrigin": "Origin",
     "TypePerk": "Perk",
     "TypePower": "Power",
     "TypeResource": "Resource",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -147,6 +147,7 @@ export class Essence20ActorSheet extends ActorSheet {
     const hangUps = [];
     const influences = [];
     const gears = [];
+    const origins = []; // Used by PCs
     const perks = []; // Used by PCs
     const powers = []; // Used by PCs
     const resources = []; // Used by PCs
@@ -181,6 +182,9 @@ export class Essence20ActorSheet extends ActorSheet {
         case 'megaformTrait':
           megaformTraits.push(i);
           break;
+        case 'origin':
+          origins.push(i);
+          break;
         case 'perk':
           perks.push(i);
           break;
@@ -214,6 +218,7 @@ export class Essence20ActorSheet extends ActorSheet {
     context.influences = influences;
     context.features = features;
     context.gears = gears;
+    context.origins = origins;
     context.perks = perks;
     context.hangUps = hangUps;
     context.powers = powers;

--- a/template.json
+++ b/template.json
@@ -132,10 +132,6 @@
       },
       "character": {
         "background": {
-          "origin": {
-            "description": "",
-            "name": ""
-          },
           "pronouns": "",
           "role": ""
         },
@@ -303,7 +299,8 @@
       "hangUp",
       "specialization",
       "megaformTrait",
-      "resource"
+      "resource",
+      "origin"
     ],
     "templates": {
       "itemDescription": {
@@ -415,6 +412,18 @@
       "uses": {
         "max": 0,
         "value": 0
+      }
+    },
+    "origin": {
+      "templates": ["itemDescription"],
+      "essenceIncreaseOptions": "",
+      "startingHealth": "",
+      "bonusSkillLevels": "",
+      "groundMovement": "",
+      "languages": "",
+      "benefit" : {
+        "name": "",
+        "description": ""
       }
     }
   }

--- a/templates/actor/parts/actor-background.hbs
+++ b/templates/actor/parts/actor-background.hbs
@@ -1,11 +1,13 @@
-<div class="origin-entries origin-notes flexcol">
-  <span class="resource flex-group-center">
-    <h3 class="origin-title">{{ localize "E20.origin" }}</h3>
-  </span>
-  {{editor system.origins target="system.origins" button=true owner=owner editable=editable}}
-</div>
-
-<hr>
+{{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.origins title='E20.origin.origin' dataType='origin'}}
+  {{#*inline "additional-expand-details" item}}
+    <div>{{localize 'E20.origin.essenceIncreaseOptions'}}: {{item.system.essenceIncreaseOptions}}</div>
+    <div>{{localize 'E20.origin.startingHealth'}}: {{item.system.startingHealth}}</div>
+    <div>{{localize 'E20.origin.bonusSkillLevels'}}: {{item.system.bonusSkillLevels}}</div>
+    <div>{{localize 'E20.origin.groundMovement'}}: {{item.system.groundMovement}}</div>
+    <div>{{localize 'E20.origin.benefit.name'}}: {{item.system.benefit.name}}</div>
+    <div>{{localize 'E20.origin.benefit.description'}}: {{item.system.benefit.description}}</div>
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}
 
 <div class="origin-info">
   {{> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.bonds title='E20.bonds' dataType='bond'}}

--- a/templates/item/item-origin-sheet.hbs
+++ b/templates/item/item-origin-sheet.hbs
@@ -1,0 +1,19 @@
+<form class="{{cssClass}}" autocomplete="off">
+
+  {{!-- Item Sheet Header --}}
+  {{> "systems/essence20/templates/item/parts/item-header.hbs"}}
+
+  {{!-- Item Sheet Body --}}
+  <section class="sheet-body">
+    {{!-- Description Section --}}
+    {{> "systems/essence20/templates/item/parts/item-description.hbs"}}
+
+    <span>{{localize 'E20.origin.essenceIncreaseOptions'}}</span><input type="text" name="system.essenceIncreaseOptions" value="{{system.essenceIncreaseOptions}}"/>
+    <span>{{localize 'E20.origin.startingHealth'}}</span><input type="text" name="system.startingHealth" value="{{system.startingHealth}}"/>
+    <span>{{localize 'E20.origin.bonusSkillLevels'}}</span><input type="text" name="system.bonusSkillLevels" value="{{system.bonusSkillLevels}}"/>
+    <span>{{localize 'E20.origin.groundMovement'}}</span><input type="text" name="system.groundMovement" value="{{system.groundMovement}}"/>
+    <span>{{localize 'E20.origin.languages'}}</span><input type="text" name="system.languages" value="{{system.languages}}"/>
+    <span>{{localize 'E20.origin.benefit.name'}}</span><input type="text" name="system.benefit.name" value="{{system.benefit.name}}"/>
+    <span>{{localize 'E20.origin.benefit.description'}}</span><input type="text" name="system.benefit.description" value="{{system.benefit.description}}"/>
+  </section>
+</form>


### PR DESCRIPTION
Testing: Should be able to create and edit an Origin item on PR sheets

Note: For now it's using the normal collapsible item container, so you can add a bunch of origins. In a separate change I can either implement a single item collapsible container or make a new container altogether.