### PR TITLE
Sorting template.json; Quick Perk roll fix

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -38,7 +38,8 @@ export class Essence20Item extends Item {
    * @private
    */
   async roll(dataset) {
-    if (this.type == 'generalPerk') {
+    console.log('here');
+    if (this.type == 'perk') {
       // Initialize chat data.
       const speaker = ChatMessage.getSpeaker({ actor: this.actor });
       const rollMode = game.settings.get('core', 'rollMode');

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -38,7 +38,6 @@ export class Essence20Item extends Item {
    * @private
    */
   async roll(dataset) {
-    console.log('here');
     if (this.type == 'perk') {
       // Initialize chat data.
       const speaker = ChatMessage.getSpeaker({ actor: this.actor });

--- a/template.json
+++ b/template.json
@@ -1,12 +1,12 @@
 {
   "Actor": {
     "types": [
-      "giJoe",
       "powerRanger",
+      "megaformZord",
       "npc",
       "vehicle",
       "zord",
-      "megaformZord"
+      "giJoe"
     ],
     "templates": {
       "common": {
@@ -208,12 +208,14 @@
         "value": 2
       }
     },
-    "giJoe": {
+    "megaformZord": {
       "templates": [
         "common",
-        "creature",
-        "character"
-      ]
+        "machine",
+        "zordBase"
+      ],
+      "health": null,
+      "zordIds": []
     },
     "npc": {
       "templates": [
@@ -274,33 +276,31 @@
       "prerequisites": [],
       "ranger": ""
     },
-    "megaformZord": {
+    "giJoe": {
       "templates": [
         "common",
-        "machine",
-        "zordBase"
-      ],
-      "health": null,
-      "zordIds": []
+        "creature",
+        "character"
+      ]
     }
   },
   "Item": {
     "types": [
       "armor",
+      "bond",
+      "feature",
       "gear",
-      "weapon",
-      "weaponUpgrade",
-      "threatPower",
+      "hangUp",
+      "megaformTrait",
+      "origin",
       "perk",
       "power",
-      "feature",
-      "trait",
-      "bond",
-      "hangUp",
-      "specialization",
-      "megaformTrait",
       "resource",
-      "origin"
+      "specialization",
+      "threatPower",
+      "trait",
+      "weapon",
+      "weaponUpgrade"
     ],
     "templates": {
       "itemDescription": {
@@ -317,6 +317,14 @@
       "equipped": false,
       "trait": "deflective"
     },
+    "bond": {
+      "templates": ["itemDescription"]
+    },
+    "feature": {
+      "templates": [
+        "itemDescription"
+      ]
+    },
     "gear": {
       "templates": [
         "itemDescription"
@@ -329,6 +337,56 @@
       },
       "quantity": 1,
       "toughness": null
+    },
+    "hangUp": {
+      "templates": ["itemDescription"]
+    },
+    "megaformTrait": {
+      "templates": ["itemDescription"]
+    },
+    "origin": {
+      "templates": ["itemDescription"],
+      "essenceIncreaseOptions": "",
+      "startingHealth": "",
+      "bonusSkillLevels": "",
+      "groundMovement": "",
+      "languages": "",
+      "benefit" : {
+        "name": "",
+        "description": ""
+      }
+    },
+    "perk": {
+      "templates": [
+        "itemDescription"
+      ],
+      "source": "",
+      "prerequisite": null
+    },
+    "power": {
+      "templates": [
+        "itemDescription"
+      ],
+      "source": ""
+    },
+    "resource": {
+      "templates": ["itemDescription"],
+      "uses": {
+        "max": 0,
+        "value": 0
+      }
+    },
+    "specialization": {},
+    "threatPower": {
+      "actionType": "",
+      "charges": null,
+      "cost": null,
+      "limited": false
+    },
+    "trait": {
+      "templates": [
+        "itemDescription"
+      ]
     },
     "weapon": {
       "templates": [
@@ -368,64 +426,6 @@
       "availability": "standard",
       "benefit": "",
       "prerequisite": null
-    },
-    "threatPower": {
-      "actionType": "",
-      "charges": null,
-      "cost": null,
-      "limited": false
-    },
-    "perk": {
-      "templates": [
-        "itemDescription"
-      ],
-      "source": "",
-      "prerequisite": null
-    },
-    "power": {
-      "templates": [
-        "itemDescription"
-      ],
-      "source": ""
-    },
-    "feature": {
-      "templates": [
-        "itemDescription"
-      ]
-    },
-    "trait": {
-      "templates": [
-        "itemDescription"
-      ]
-    },
-    "bond": {
-      "templates": ["itemDescription"]
-    },
-    "hangUp": {
-      "templates": ["itemDescription"]
-    },
-    "specialization": {},
-    "megaformTrait": {
-      "templates": ["itemDescription"]
-    },
-    "resource": {
-      "templates": ["itemDescription"],
-      "uses": {
-        "max": 0,
-        "value": 0
-      }
-    },
-    "origin": {
-      "templates": ["itemDescription"],
-      "essenceIncreaseOptions": "",
-      "startingHealth": "",
-      "bonusSkillLevels": "",
-      "groundMovement": "",
-      "languages": "",
-      "benefit" : {
-        "name": "",
-        "description": ""
-      }
     }
   }
 }


### PR DESCRIPTION
Testing
- Items and Actors should be mostly alphabetically sorted in the creation menu. Power Ranger is at the top of the actor list and GI JOE is at the bottom, though. Let me know if you have other sorting preferences.
- Rolling a Perk should display Source/Prerequisite/Description in the chat message again