### PR TITLE
Fixing PR defense calculations

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -87,22 +87,53 @@ export class Essence20Actor extends Actor {
     if (this.type !== 'powerRanger') return;
 
     const system = this.system;
-    const unmorphed = {
-      toughness: CONFIG.E20.defenseBase + system.essences.strength,
-      evasion: CONFIG.E20.defenseBase + system.essences.speed,
-      willpower: CONFIG.E20.defenseBase + system.essences.smarts,
-      cleverness: CONFIG.E20.defenseBase + system.essences.social,
-    };
-    const morphed = {
-      toughness: unmorphed.toughness + system.bonuses.toughness, // Armor added in sheet
-      evasion: unmorphed.evasion + system.bonuses.evasion,
-      willpower: unmorphed.willpower +  system.bonuses.willpower,
-      cleverness: unmorphed.cleverness +  system.bonuses.cleverness,
-    };
-    system.defenses = {
-      morphed,
-      unmorphed,
-    };
+
+    system.defenses = [
+      {
+        essence: "strength",
+        name: "toughness",
+        morphed: {
+          value: CONFIG.E20.defenseBase + system.essences.strength + system.bonuses.toughness,
+          bonus: system.bonuses.toughness
+        },
+        unmorphed: {
+          value: CONFIG.E20.defenseBase + system.essences.strength,
+        },
+      },
+      {
+        essence: "speed",
+        name: "evasion",
+        morphed: {
+          value: CONFIG.E20.defenseBase + system.essences.speed + system.bonuses.evasion,
+          bonus: system.bonuses.evasion
+        },
+        unmorphed: {
+          value: CONFIG.E20.defenseBase + system.essences.speed,
+        },
+      },
+      {
+        essence: "smarts",
+        name: "cleverness",
+        morphed: {
+          value: CONFIG.E20.defenseBase + system.essences.smarts + system.bonuses.cleverness,
+          bonus: system.bonuses.cleverness
+        },
+        unmorphed: {
+          value: CONFIG.E20.defenseBase + system.essences.smarts,
+        },
+      },
+      {
+        essence: "social",
+        name: "willpower",
+        morphed: {
+          value: CONFIG.E20.defenseBase + system.essences.social + system.bonuses.willpower,
+          bonus: system.bonuses.willpower
+        },
+        unmorphed: {
+          value: CONFIG.E20.defenseBase + system.essences.social,
+        },
+      },
+    ];
   }
 
   /**

--- a/templates/actor/parts/actor-defenses.hbs
+++ b/templates/actor/parts/actor-defenses.hbs
@@ -5,13 +5,13 @@
         <th class="tg-td">{{localize 'E20.DefenseTitle'}}</th>
 
         {{!-- Defense headers --}}
-        {{#each system.defenses.morphed as |value defense|}}
+        {{#each system.defenses as |defense|}}
         <th class="tg-td">
-          <span>{{localize (lookup @root.config.defenses defense)}}</span>
+          <span>{{localize (lookup @root.config.defenses defense.name)}}</span>
           <span>
             {{#ifEquals ../bonusDisplayType 'input'}}
-            +<input class="one-digit-input" type="number" name={{concat 'system.bonuses.' defense}}
-              value="{{lookup @root.system.bonuses defense}}" />
+            +<input class="one-digit-input" type="number" name={{concat 'system.bonuses.' defense.name}}
+              value="{{lookup @root.system.bonuses defense.name}}" />
             {{/ifEquals}}
           </span>
         </th>
@@ -24,11 +24,11 @@
       {{!-- Unmorphed row --}}
       <tr>
         <td class="tg-td">{{localize 'E20.DefenseUnmorphed'}}</td>
-        {{#each system.essences as |value essence|}}
+        {{#each system.defenses as |defense|}}
         <td class="tg-td">
           <span
-            title="10 {{localize 'E20.defenseBase'}} + {{value}} {{localize (lookup @root.config.essences essence)}}">
-            {{sum 10 value}}
+            title="{{@root.config.defenseBase}} {{localize 'E20.DefenseBase'}} + {{lookup @root.system.essences defense.essence}} {{localize (lookup @root.config.essences defense.essence)}}">
+            {{defense.unmorphed.value}}
           </span>
         </td>
         {{/each}}
@@ -37,21 +37,21 @@
       {{!-- Morphed row --}}
       <tr>
         <td class="tg-td">{{localize 'E20.DefenseMorphed'}}</td>
-        {{#each system.defenses.unmorphed as |value defense|}}
+        {{#each system.defenses as |defense|}}
         {{!-- Special case for Toughness to add armor --}}
-        {{#ifEquals defense 'toughness'}}
+        {{#ifEquals defense.name 'toughness'}}
         <td class="tg-td">
           <span
-            title="{{value}} {{localize 'E20.DefenseUnmorphed'}} + {{@root.system.bonuses.toughness}} {{localize 'E20.DefenseBonus'}} + {{@root.equippedArmorEffect}} {{localize 'ITEM.TypeArmor'}}">
-            {{sum value @root.system.bonuses.toughness @root.equippedArmorEffect}}
+            title="{{defense.unmorphed.value}} {{localize 'E20.DefenseUnmorphed'}} + {{defense.morphed.bonus}} {{localize 'E20.DefenseBonus'}} + {{@root.equippedArmorEffect}} {{localize 'ITEM.TypeArmor'}}">
+            {{sum defense.morphed.value @root.equippedArmorEffect}}
           </span>
         </td>
         {{else}}
         {{!-- Remaining Defenses --}}
         <td class="tg-td">
           <span
-            title="{{value}} {{localize 'E20.DefenseMorphed'}} + {{lookup @root.system.bonuses defense}} {{localize 'E20.DefenseBonus'}}">
-            {{sum value (lookup @root.system.bonuses defense)}}
+            title="{{defense.unmorphed.value}} {{localize 'E20.DefenseUnmorphed'}} + {{defense.morphed.bonus}} {{localize 'E20.DefenseBonus'}}">
+            {{sum defense.morphed.value}}
           </span>
         </td>
         {{/ifEquals}}


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/140
I cheated a bit doing the original PR defense calculations and the sorting got screwed up, so this fixes that.

Testing: Change essences, bonuses, and armor to make sure PR defense values and tooltip calculations are correct