### PR TITLE
Origin field sorting; Moving description out of actor-collapsible-item-container

### DIFF
--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -32,6 +32,7 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/actor-notes.hbs",
     "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs",
     "systems/essence20/templates/actor/parts/actor-powers.hbs",
+    "systems/essence20/templates/actor/parts/actor-resources.hbs",
     "systems/essence20/templates/actor/parts/actor-traits.hbs",
     "systems/essence20/templates/actor/parts/actor-weapons.hbs",
     "systems/essence20/templates/actor/parts/actor-zord-common.hbs",

--- a/templates/actor/actor-powerRanger-sheet.hbs
+++ b/templates/actor/actor-powerRanger-sheet.hbs
@@ -27,18 +27,7 @@
     {{!-- Combat Tab --}}
     <div class="tab combat flexcol" data-group="primary" data-tab="combat">
       {{> "systems/essence20/templates/actor/parts/actor-defenses.hbs" bonusDisplayType='input'}}
-      {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.resources
-      title='E20.ItemTypeResourcePlural' dataType='resource'}}
-      {{#*inline "item-label" item}}
-      {{item.name}}
-      <input class="one-digit-input inline-edit" data-field="system.uses.value" type="number"
-        name="item.system.uses.value" value="{{item.system.uses.value}}" />
-      /
-      <input class="one-digit-input inline-edit" data-field="system.uses.max" type="number" name="item.system.uses.max"
-        value="{{item.system.uses.max}}" />
-      </span>
-      {{/inline}}
-      {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}
+      {{> "systems/essence20/templates/actor/parts/actor-resources.hbs"}}
       {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
       {{> "systems/essence20/templates/actor/parts/actor-armor.hbs"}}
     </div>

--- a/templates/actor/parts/actor-armor.hbs
+++ b/templates/actor/parts/actor-armor.hbs
@@ -5,4 +5,8 @@
   <span class="chip" name="chip.armor.effect">{{localize 'E20.WeaponEffect'}}: {{item.system.effect}}</span>
   <span class="chip" name="chip.armor.trait">{{localize (lookup @root.config.armorTraits item.system.trait)}}</span>
   {{/inline}}
+
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-armor.hbs
+++ b/templates/actor/parts/actor-armor.hbs
@@ -6,7 +6,7 @@
   <span class="chip" name="chip.armor.trait">{{localize (lookup @root.config.armorTraits item.system.trait)}}</span>
   {{/inline}}
 
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-background.hbs
+++ b/templates/actor/parts/actor-background.hbs
@@ -9,10 +9,22 @@
     <div>{{localize 'E20.OriginBenefitName'}}: {{item.system.benefit.name}}</div>
     <div>{{localize 'E20.OriginBenefitDescription'}}: {{item.system.benefit.description}}</div>
   {{/inline}}
+
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}
 
 {{!-- Bonds --}}
-{{> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.bonds title='E20.ItemTypeBondPlural' dataType='bond'}}
+{{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.bonds title='E20.ItemTypeBondPlural' dataType='bond'}}
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}
 
 {{!-- Hang Ups --}}
-{{> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.hangUps title='E20.ItemTypeHangupPlural' dataType='hangUp'}}
+{{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.hangUps title='E20.ItemTypeHangupPlural' dataType='hangUp'}}
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-background.hbs
+++ b/templates/actor/parts/actor-background.hbs
@@ -1,6 +1,6 @@
 {{!-- Origin --}}
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.origins title='E20.Origin' dataType='origin'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
     <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
     <div>{{localize 'E20.OriginStartingHealth'}}: {{item.system.startingHealth}}</div>
     <div>{{localize 'E20.OriginEssenceAbilityScoreIncreaseOptions'}}: {{item.system.essenceAbilityScoreIncreaseOptions}}</div>
@@ -15,14 +15,14 @@
 
 {{!-- Bonds --}}
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.bonds title='E20.ItemTypeBondPlural' dataType='bond'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}
 
 {{!-- Hang Ups --}}
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.hangUps title='E20.ItemTypeHangupPlural' dataType='hangUp'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-background.hbs
+++ b/templates/actor/parts/actor-background.hbs
@@ -1,17 +1,15 @@
 {{!-- Origin --}}
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.origins title='E20.Origin' dataType='origin'}}
   {{#*inline "additional-expand-details" item}}
-    <div>{{localize 'E20.OriginEssenceIncreaseOptions'}}: {{item.system.essenceIncreaseOptions}}</div>
+    <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
     <div>{{localize 'E20.OriginStartingHealth'}}: {{item.system.startingHealth}}</div>
+    <div>{{localize 'E20.OriginEssenceAbilityScoreIncreaseOptions'}}: {{item.system.essenceAbilityScoreIncreaseOptions}}</div>
+    <div>{{localize 'E20.OriginEssenceScoreIncreaseOptions'}}: {{item.system.essenceScoreIncreaseOptions}}</div>
     <div>{{localize 'E20.OriginBonusSkillLevels'}}: {{item.system.bonusSkillLevels}}</div>
     <div>{{localize 'E20.OriginGroundMovement'}}: {{item.system.groundMovement}}</div>
     <div>{{localize 'E20.OriginLanguages'}}: {{item.system.languages}}</div>
     <div>{{localize 'E20.OriginBenefitName'}}: {{item.system.benefit.name}}</div>
     <div>{{localize 'E20.OriginBenefitDescription'}}: {{item.system.benefit.description}}</div>
-  {{/inline}}
-
-  {{#*inline "additional-expand-details" item}}
-  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}
 

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -39,9 +39,9 @@
 
       {{!-- Item content --}}
       <div class="accordion-content">
-        {{#> additional-expand-details item=item}}
+        {{#> expand-details item=item}}
         {{!-- Custom expanded details here --}}
-        {{/additional-expand-details}}
+        {{/expand-details}}
 
         <div class="chip-section">
         {{#> chips item=item}}

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -43,8 +43,6 @@
         {{!-- Custom expanded details here --}}
         {{/additional-expand-details}}
 
-        <div>{{{item.system.description}}}</div>
-
         <div class="chip-section">
         {{#> chips item=item}}
         {{!-- Custom chips here --}}

--- a/templates/actor/parts/actor-gear.hbs
+++ b/templates/actor/parts/actor-gear.hbs
@@ -1,5 +1,5 @@
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.gears title='E20.ItemTypeGearPlural' dataType='gear'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 

--- a/templates/actor/parts/actor-gear.hbs
+++ b/templates/actor/parts/actor-gear.hbs
@@ -1,4 +1,8 @@
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.gears title='E20.ItemTypeGearPlural' dataType='gear'}}
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
+
   {{#*inline "chips" item}}
   <span class="chip" name="chip.gear.quantity">{{localize 'E20.GearQuantity'}}: {{item.system.quantity}}</span>
   {{#if item.system.toughness}}

--- a/templates/actor/parts/actor-perks.hbs
+++ b/templates/actor/parts/actor-perks.hbs
@@ -1,5 +1,5 @@
 {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.perks title='E20.ItemTypePerkPlural' dataType='perk'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.PerkPrerequisite'}}: {{item.system.prerequisite}}</div>
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}

--- a/templates/actor/parts/actor-perks.hbs
+++ b/templates/actor/parts/actor-perks.hbs
@@ -1,6 +1,7 @@
 {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.perks title='E20.ItemTypePerkPlural' dataType='perk'}}
   {{#*inline "additional-expand-details" item}}
   <div>{{localize 'E20.PerkPrerequisite'}}: {{item.system.prerequisite}}</div>
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 
   {{#*inline "chips" item}}

--- a/templates/actor/parts/actor-powers.hbs
+++ b/templates/actor/parts/actor-powers.hbs
@@ -12,7 +12,7 @@
 
 {{!-- Powers --}}
 {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.powers title='E20.ItemTypePowerPlural' dataType='power'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 

--- a/templates/actor/parts/actor-powers.hbs
+++ b/templates/actor/parts/actor-powers.hbs
@@ -12,6 +12,10 @@
 
 {{!-- Powers --}}
 {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.powers title='E20.ItemTypePowerPlural' dataType='power'}}
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
+
   {{#*inline "chips" item}}
   {{#if item.system.source}}
   <span class="chip" name="chip.source">{{item.system.source}}</span>

--- a/templates/actor/parts/actor-resources.hbs
+++ b/templates/actor/parts/actor-resources.hbs
@@ -1,0 +1,16 @@
+{{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.resources
+title='E20.ItemTypeResourcePlural' dataType='resource'}}
+  {{#*inline "item-label" item}}
+  {{item.name}}
+  <input class="one-digit-input inline-edit" data-field="system.uses.value" type="number"
+    name="item.system.uses.value" value="{{item.system.uses.value}}" />
+  /
+  <input class="one-digit-input inline-edit" data-field="system.uses.max" type="number" name="item.system.uses.max"
+    value="{{item.system.uses.max}}" />
+  </span>
+
+  {{/inline}}
+  {{#*inline "expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-traits.hbs
+++ b/templates/actor/parts/actor-traits.hbs
@@ -1,2 +1,6 @@
-{{> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.traits
+{{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.traits
 title='E20.ItemTypeTraitPlural' dataType='trait'}}
+  {{#*inline "additional-expand-details" item}}
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-traits.hbs
+++ b/templates/actor/parts/actor-traits.hbs
@@ -1,6 +1,6 @@
 {{#> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.traits
 title='E20.ItemTypeTraitPlural' dataType='trait'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
   <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-weapons.hbs
+++ b/templates/actor/parts/actor-weapons.hbs
@@ -1,5 +1,5 @@
 {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.weapons title='E20.ItemTypeWeaponPlural' dataType='weapon'}}
-  {{#*inline "additional-expand-details" item}}
+  {{#*inline "expand-details" item}}
     <div>{{localize 'E20.WeaponEffect'}}: {{item.system.effect}}</div>
     <div>{{localize 'E20.WeaponAlternateEffects'}}: {{item.system.alternateEffects}}</div>
     <div>{{localize 'E20.WeaponUpgrades'}}: {{item.system.upgrades}}</div>

--- a/templates/actor/parts/actor-weapons.hbs
+++ b/templates/actor/parts/actor-weapons.hbs
@@ -3,6 +3,7 @@
     <div>{{localize 'E20.WeaponEffect'}}: {{item.system.effect}}</div>
     <div>{{localize 'E20.WeaponAlternateEffects'}}: {{item.system.alternateEffects}}</div>
     <div>{{localize 'E20.WeaponUpgrades'}}: {{item.system.upgrades}}</div>
+    <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   {{/inline}}
 
   {{#*inline "roll-button" item}}


### PR DESCRIPTION
In this change
- Renaming additional-expand-details to just expand-details
- Moving description out of actor-collapsible-item-container.hbs and into each item
- Moving resources container to its own partial
- Reordering Origin fields to match book https://github.com/WookieeMatt/Essence20/issues/163

Testing
- Each expandable item in the PR sheet should look correct
- Origin field order is now correct