### PR TITLE
Moving auto Personal Power creation to Actor.create()

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -3,6 +3,24 @@
  * @extends {Actor}
  */
 export class Essence20Actor extends Actor {
+  /** @override */
+  static async create(data, options = {}) {
+    const actor = await super.create(data, options);
+
+    // Create Personal Power as a default class feature for Power Rangers
+    if (data.type == 'powerRanger') {
+      Item.create(
+        {
+          name: game.i18n.localize('E20.PowerRangerPersonalPower'),
+          type: 'classFeature',
+          data: {},
+        },
+        { parent: actor }
+      );
+    }
+
+    return actor;
+  }
 
   /** @override */
   prepareData() {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -9,18 +9,6 @@ export class Essence20ActorSheet extends ActorSheet {
   constructor(actor, options) {
     super(actor, options);
     this._dice = new Dice(game.i18n, CONFIG.E20, ChatMessage);
-
-    // Create Personal Power class feature for Power Rangers
-    if (actor.type == 'powerRanger') {
-      Item.create(
-        {
-          name: game.i18n.localize('E20.PowerRangerPersonalPower'),
-          type: 'classFeature',
-          data: {},
-        },
-        { parent: this.actor }
-      );
-    }
   }
 
   /** @override */


### PR DESCRIPTION
Moving the automatic creation of a Personal Power class feature out of the actor-sheet constructor, since that's called when you open the sheet. Instead, it's now in the Actor.create() override. This is only called once, when the Actor is created.

Testing: Creating a new PR should automatically have a Personal Power class feature and not add a new one if you refresh and reopen its sheet.