### PR TITLE
Misc PR color and spacing tweaks

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -482,11 +482,13 @@
 .essence20 .skill-header .skill-roll {
   flex-grow: 0;
   margin-right: 5px;
+  margin-left: 5px;
 }
 
 .essence20 .skill-header .skill-name {
   white-space: nowrap;
   overflow: hidden;
+  color: white;
 }
 
 .essence20 .skill-body {
@@ -542,7 +544,6 @@
   list-style: none;
   overflow-y: auto;
   color: #c7c4c4;
-  padding: 8px;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: #03129c80;
@@ -606,6 +607,7 @@
 .essence20 .defense-container table thead {
   background-color: inherit;
   border-bottom: 4px solid #b5b1b1;
+  color: inherit;
 }
 
 .essence20 .defense-container tr:nth-child(even) {
@@ -994,10 +996,6 @@
 .window-content .journal-sheet-container .editable {
   background: #10024e;
   border-radius: 10px white;
-}
-
-.essence20 .resource-label {
-  font-weight: bold;
 }
 
 select {

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -942,6 +942,7 @@
 .essence20 .item-label {
   align-items: center;
   gap: 5px;
+  margin-bottom: 5px;
 }
 
 .essence20 .item-formula {

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -1049,4 +1049,8 @@ form .hint {
   gap: 10px;
 }
 
+.essence20 table {
+  background-color: rgba(0, 0, 0, 0);
+}
+
 /*# sourceMappingURL=essence20.css.map */

--- a/lang/en.json
+++ b/lang/en.json
@@ -114,6 +114,7 @@
     "ItemSource": "Source",
     "ItemSourceBook": "Book",
     "ItemSourcePage": "Page",
+    "ItemToggleEquipped": "Toggle equipped",
     "ItemTypeArmorPlural": "Armor",
     "ItemTypeBondPlural": "Bonds",
     "ItemTypeClassFeaturePlural": "Class Features",

--- a/sass/actors/_defense-containers.scss
+++ b/sass/actors/_defense-containers.scss
@@ -8,6 +8,7 @@
 .essence20 .defense-container table thead {
   background-color: inherit;
   border-bottom: v.$border;
+  color: inherit;
 }
 
 .essence20 .defense-container tr:nth-child(even) {

--- a/sass/assets/_skill.scss
+++ b/sass/assets/_skill.scss
@@ -11,11 +11,13 @@
 .essence20 .skill-header .skill-roll {
   flex-grow: 0;
   margin-right: 5px;
+  margin-left: 5px;
 }
 
 .essence20 .skill-header .skill-name {
   white-space: nowrap;
   overflow: hidden;
+  color: white;
 }
 
 .essence20 .skill-body {
@@ -71,7 +73,6 @@
   list-style: none;
   overflow-y: auto;
   color: v.$textcolor1;
-  padding: 8px;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: v.$background-b;

--- a/sass/essence20.scss
+++ b/sass/essence20.scss
@@ -56,3 +56,7 @@ form .hint {
   min-height: fit-content;
   gap: 10px;
 }
+
+.essence20 table {
+  background-color:rgba(0, 0, 0, 0);
+}

--- a/sass/items/_item-styling.scss
+++ b/sass/items/_item-styling.scss
@@ -129,6 +129,7 @@
 .essence20 .item-label {
   align-items: center;
   gap: 5px;
+  margin-bottom: 5px;
 }
 
 .essence20 .item-formula {

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -21,7 +21,7 @@
         {{#if (isdefined item.system.equipped)}}
         <div style="flex-grow: 0;">
           <input class="inline-edit item-label-checkbox" data-field="system.equipped" type="checkbox"
-            name="armor.{{@index}}.equipped" {{checked item.system.equipped}}/>
+            name="armor.{{@index}}.equipped" {{checked item.system.equipped}} title="{{localize 'E20.ItemToggleEquipped'}}"/>
         </div>
         {{/if}}
         <div>


### PR DESCRIPTION
In this change
- Making PR defense header text the same color as everything else
- Marking PR defense table transparent. It was very slightly off from our normal blue backgrounds because of its default behavior.
- Making PR skill names white so they stand out more
- Making PR skill rows extend to the sides of their container
- Better space between collapsed items
- Tooltip for the equipped checkbox

Testing:
- PR defense container, skills container, and items container all look good
- Tooltip for the equipped checkbox