### PR TITLE
Class Feature selector tweaks

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -66,6 +66,7 @@
     "AvailabilityTheoretical": "Theoretical",
     "AvailabilityUnique": "Unique",
     "ClassFeatureUses": "Uses",
+    "ClassFeatureNone": "No Class Feature",
     "DefenseBase": "Base",
     "DefenseBonus": "Bonus",
     "DefenseCleverness": "Cleverness",

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -19,6 +19,7 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs",
     "systems/essence20/templates/actor/parts/actor-armor.hbs",
     "systems/essence20/templates/actor/parts/actor-background.hbs",
+    "systems/essence20/templates/actor/parts/actor-class-feature-selector.hbs",
     "systems/essence20/templates/actor/parts/actor-pc-skills.hbs",
     "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs",
     "systems/essence20/templates/actor/parts/actor-common.hbs",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -155,9 +155,7 @@ export class Essence20ActorSheet extends ActorSheet {
     const threatPowers = [];
     const traits = []; // Catchall for Megaform Zords, Vehicles, NPCs
     const weapons = [];
-    const classFeaturesById = {
-      "none": null,
-    };
+    const classFeaturesById = {};
 
     // // Iterate through items, allocating to containers
     for (let i of context.items) {

--- a/templates/actor/parts/actor-class-feature-selector.hbs
+++ b/templates/actor/parts/actor-class-feature-selector.hbs
@@ -1,0 +1,8 @@
+<select class="inline-edit" data-field="system.classFeatureId" name="system.classFeature">
+  {{#select item.system.classFeatureId}}
+  <option value="">{{localize 'E20.ClassFeatureNone'}}</option>
+  {{#each @root.classFeaturesById as |name id|}}
+  <option value="{{id}}">{{name}}</option>
+  {{/each}}
+  {{/select}}
+</select>

--- a/templates/actor/parts/actor-powers.hbs
+++ b/templates/actor/parts/actor-powers.hbs
@@ -9,13 +9,7 @@
   {{/inline}}
 
   {{#*inline "item-label" item}}
-    <select class="inline-edit" data-field="system.classFeatureId" name="system.classFeature">
-      {{#select item.system.classFeatureId}}
-      {{#each @root.classFeaturesById as |name id|}}
-      <option value="{{id}}">{{name}}</option>
-      {{/each}}
-      {{/select}}
-    </select>
+    {{>"systems/essence20/templates/actor/parts/actor-class-feature-selector.hbs"}}
     {{item.name}}
   {{/inline}}
 {{/"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs"}}

--- a/templates/actor/parts/actor-weapons.hbs
+++ b/templates/actor/parts/actor-weapons.hbs
@@ -12,14 +12,7 @@
 
   {{#*inline "item-label" item}}
     {{#ifEquals @root.actor.type 'powerRanger'}}
-    <select class="inline-edit" data-field="system.classFeatureId" name="system.classFeature">
-      {{#select item.system.classFeatureId}}
-      <option value="" disabled selected hidden>{{localize 'ITEM.TypeClassfeature'}}</option>
-      {{#each @root.classFeaturesById as |name id|}}
-      <option value="{{id}}">{{name}}</option>
-      {{/each}}
-      {{/select}}
-    </select>
+      {{>"systems/essence20/templates/actor/parts/actor-class-feature-selector.hbs"}}
     {{/ifEquals}}
 
     {{item.name}}

--- a/templates/actor/parts/actor-weapons.hbs
+++ b/templates/actor/parts/actor-weapons.hbs
@@ -11,13 +11,17 @@
   {{/inline}}
 
   {{#*inline "item-label" item}}
+    {{#ifEquals @root.actor.type 'powerRanger'}}
     <select class="inline-edit" data-field="system.classFeatureId" name="system.classFeature">
       {{#select item.system.classFeatureId}}
+      <option value="" disabled selected hidden>{{localize 'ITEM.TypeClassfeature'}}</option>
       {{#each @root.classFeaturesById as |name id|}}
       <option value="{{id}}">{{name}}</option>
       {{/each}}
       {{/select}}
     </select>
+    {{/ifEquals}}
+
     {{item.name}}
   {{/inline}}
 


### PR DESCRIPTION
In this change
- The CF selector on weapons only appears on the PR sheet now
- Putting the CF selector in a partial
- Adding a "no value" option

Testing: CF selector only appears on PF weapons and works normally

Note: I wanted to make the default/no value option a greyed out color, but couldn't figure it out. Maybe you can! Something like this https://www.tutorialrepublic.com/faq/how-to-make-a-placeholder-for-a-select-box-in-html.php. Specifically, `select:invalid` didn't seem to do anything.