### PR TITLE
Implementing repeat skill roll option

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -170,6 +170,7 @@
     "RollDialogSnag": "Snag",
     "RollDialogTimesToRoll": "Times to roll",
     "RollDialogTitle": "Configure your skill roll",
+    "RollRepeatText": "Roll {index} of {total}",
     "RollRollingFor": "Rolling for",
     "RollSpecialized": "Specialized",
     "RollWithAnEdge": "with an Edge",

--- a/lang/en.json
+++ b/lang/en.json
@@ -168,6 +168,7 @@
     "RollDialogShiftDown": "Shift down",
     "RollDialogShiftUp": "Shift up",
     "RollDialogSnag": "Snag",
+    "RollDialogTimesToRoll": "Times to roll",
     "RollDialogTitle": "Configure your skill roll",
     "RollRollingFor": "Rolling for",
     "RollSpecialized": "Specialized",

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -110,13 +110,24 @@ export class Dice {
         }) + '<br>';
       }
 
-      let roll = new Roll(formula, actor.getRollData());
-      roll.toMessage({
-        speaker: this._chatMessage.getSpeaker({ actor }),
-        flavor: repeatText + label,
-        rollMode: game.settings.get('core', 'rollMode'),
-      });
+      this._rollSkillHelper(formula, actor, repeatText + label);
     }
+  }
+
+  /**
+   * Executes the skill roll.
+   * @param {String} formula   The formula to be rolled.
+   * @param {Actor} actor   The actor performing the roll.
+   * @param {String} flavor   The html to use for the roll message.
+   * @private
+   */
+  _rollSkillHelper(formula, actor, flavor) {
+    let roll = new Roll(formula, actor.getRollData());
+    roll.toMessage({
+      speaker: this._chatMessage.getSpeaker({ actor }),
+      flavor,
+      rollMode: game.settings.get('core', 'rollMode'),
+    });
   }
 
   /**
@@ -139,8 +150,9 @@ export class Dice {
    * Create weapon roll label.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().
-   * @returns {String}   The resultant roll label.
    * @param {Item} weapon   The weapon being used.
+   * @param {Actor} actor   The actor performing the roll.
+   * @returns {String}   The resultant roll label.
    * @private
    */
   _getWeaponRollLabel(dataset, skillRollOptions, weapon, actor) {

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -104,7 +104,7 @@ export class Dice {
     for (let i = 0; i < skillRollOptions.timesToRoll; i++) {
       let repeatText = '';
       if (skillRollOptions.timesToRoll > 1) {
-        repeatText = game.i18n.format("E20.RollRepeatText", {
+        repeatText = this._i18n.format("E20.RollRepeatText", {
           index: i + 1,
           total: skillRollOptions.timesToRoll,
         }) + '<br>';

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -1,9 +1,10 @@
-import {Dice} from "./dice.mjs";
-import {E20} from "./helpers/config.mjs";
-import {jest} from '@jest/globals'
+import { Dice } from "./dice.mjs";
+import { E20 } from "./helpers/config.mjs";
+import { jest } from '@jest/globals'
 
 class Mocki18n {
   localize(text) { return text; }
+  format(text, _) { return text; }
 }
 
 const chatMessage = jest.mock();
@@ -11,6 +12,87 @@ chatMessage.getSpeaker = jest.fn();
 chatMessage.getSpeaker.mockReturnValue({});
 chatMessage.create = jest.fn();
 const dice = new Dice(new Mocki18n, E20, chatMessage);
+
+/* rollSkill */
+describe("rollSkill", () => {
+  const dataset = {
+    skill: 'athletics',
+  };
+  const mockActor = jest.mock();
+
+  test("normal skill roll", () => {
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    }
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'strength': {
+          'athletics': {
+            modifier: '0',
+            shift: 'd20',
+          },
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn()
+
+    dice.rollSkill(dataset, skillRollOptions, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor E20.EssenceSkillAthletics");
+  });
+
+  test("repeated normal skill roll", () => {
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 2,
+    }
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'strength': {
+          'athletics': {
+            modifier: '0',
+            shift: 'd20',
+          },
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn()
+
+    dice.rollSkill(dataset, skillRollOptions, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRepeatText<br>E20.RollRollingFor E20.EssenceSkillAthletics");
+    expect(dice._rollSkillHelper.mock.calls.length).toBe(2);
+  });
+
+  test("auto success", () => {
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    }
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'strength': {
+          'athletics': {
+            modifier: '0',
+            shift: 'autoSuccess',
+          },
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn()
+
+    dice.rollSkill(dataset, skillRollOptions, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 3d6 + 0', mockActor, "E20.RollRollingFor E20.EssenceSkillAthletics");
+  });
+});
 
 /* _getSkillRollLabel */
 describe("_getSkillRollLabel", () => {
@@ -86,10 +168,10 @@ describe("_getWeaponRollLabel", () => {
       },
     };
     const expected =
-     "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics)<br>" +
-     "<b>E20.WeaponEffect</b> - Some effect<br>" +
-     "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
-     "<b>ITEM.TypeClassfeature</b> - E20.None";
+      "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics)<br>" +
+      "<b>E20.WeaponEffect</b> - Some effect<br>" +
+      "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
+      "<b>ITEM.TypeClassfeature</b> - E20.None";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
   });
@@ -110,10 +192,10 @@ describe("_getWeaponRollLabel", () => {
       },
     };
     const expected =
-     "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics) E20.RollWithAnEdge<br>" +
-     "<b>E20.WeaponEffect</b> - Some effect<br>" +
-     "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
-     "<b>ITEM.TypeClassfeature</b> - E20.None";
+      "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics) E20.RollWithAnEdge<br>" +
+      "<b>E20.WeaponEffect</b> - Some effect<br>" +
+      "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
+      "<b>ITEM.TypeClassfeature</b> - E20.None";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
   });
@@ -134,10 +216,10 @@ describe("_getWeaponRollLabel", () => {
       },
     };
     const expected =
-     "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics) E20.RollWithASnag<br>" +
-     "<b>E20.WeaponEffect</b> - Some effect<br>" +
-     "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
-     "<b>ITEM.TypeClassfeature</b> - E20.None";
+      "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics) E20.RollWithASnag<br>" +
+      "<b>E20.WeaponEffect</b> - Some effect<br>" +
+      "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
+      "<b>ITEM.TypeClassfeature</b> - E20.None";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
   });
@@ -158,10 +240,10 @@ describe("_getWeaponRollLabel", () => {
       },
     };
     const expected =
-     "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics)<br>" +
-     "<b>E20.WeaponEffect</b> - E20.None<br>" +
-     "<b>E20.WeaponAlternateEffects</b> - E20.None<br>" +
-     "<b>ITEM.TypeClassfeature</b> - E20.None";
+      "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics)<br>" +
+      "<b>E20.WeaponEffect</b> - E20.None<br>" +
+      "<b>E20.WeaponAlternateEffects</b> - E20.None<br>" +
+      "<b>ITEM.TypeClassfeature</b> - E20.None";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weapon)).toEqual(expected);
   });
@@ -241,7 +323,7 @@ describe("_handleAutoFail", () => {
 
     expect(dice._handleAutoFail(skillShift, label, actor)).toBe(true);
     expect(chatMessage.getSpeaker).toHaveBeenCalled();
-    expect(chatMessage.create).toHaveBeenCalledWith({content: " E20.RollAutoFail", speaker: {}});
+    expect(chatMessage.create).toHaveBeenCalledWith({ content: " E20.RollAutoFail", speaker: {} });
   });
 
   test("auto fail", () => {
@@ -251,7 +333,7 @@ describe("_handleAutoFail", () => {
 
     expect(dice._handleAutoFail(skillShift, label, actor)).toBe(true);
     expect(chatMessage.getSpeaker).toHaveBeenCalled();
-    expect(chatMessage.create).toHaveBeenCalledWith({content: " E20.RollAutoFailFumble", speaker: {}});
+    expect(chatMessage.create).toHaveBeenCalledWith({ content: " E20.RollAutoFailFumble", speaker: {} });
   });
 });
 

--- a/templates/dialog/roll-dialog.hbs
+++ b/templates/dialog/roll-dialog.hbs
@@ -23,6 +23,6 @@
   </div>
   <div>
     {{localize 'E20.RollDialogTimesToRoll'}}
-    <input type="number" name="timesToRoll" value=0 />
+    <input type="number" name="timesToRoll" value=1 />
   </div>
 </form>

--- a/templates/dialog/roll-dialog.hbs
+++ b/templates/dialog/roll-dialog.hbs
@@ -8,14 +8,21 @@
     <input type="number" name="shiftDown" value=0 />
   </div>
   <div>
-    <input type="radio" name="snagEdge" value="snag" data-dtype="String" {{checked snag}}/> {{localize 'E20.RollDialogSnag'}}
-    <input type="radio" name="snagEdge" value="normal" data-dtype="String" {{checked normal}}/> {{localize 'E20.RollDialogNormal'}}
-    <input type="radio" name="snagEdge" value="edge" data-dtype="String" {{checked edge}}/> {{localize 'E20.RollDialogEdge'}}
+    <input type="radio" name="snagEdge" value="snag" data-dtype="String" {{checked snag}} /> {{localize
+    'E20.RollDialogSnag'}}
+    <input type="radio" name="snagEdge" value="normal" data-dtype="String" {{checked normal}} /> {{localize
+    'E20.RollDialogNormal'}}
+    <input type="radio" name="snagEdge" value="edge" data-dtype="String" {{checked edge}} /> {{localize
+    'E20.RollDialogEdge'}}
   </div>
   <div>
     <label>
       <input type="checkbox" name="specialized" {{checked specialized}} />
       <span>{{localize 'E20.RollSpecialized'}}</span>
     </label>
+  </div>
+  <div>
+    {{localize 'E20.RollDialogTimesToRoll'}}
+    <input type="number" name="timesToRoll" value=0 />
   </div>
 </form>


### PR DESCRIPTION
In this change
- Addresses https://github.com/WookieeMatt/Essence20/issues/183
- Adding a number input to the skill roll dialog where you can specify how many times you want the roll to repeat (1 by default)
- If > 1, extra text is added to the roll message so you can tell they belong to a single roll event
- Refactoring slightly so I can add some tests for `rollSkill()`

Testing: Roll a skill with different repeat values and it should work as expected