### PR TITLE
Theme color tweaks

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -60,7 +60,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -105,7 +105,7 @@
 }
 
 .essence20 .editor-content {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -166,21 +166,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -198,17 +198,17 @@
 }
 
 .dialog .dialog-buttons button.default {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding-top: 6px;
 }
 
@@ -216,7 +216,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -227,7 +227,7 @@
 }
 
 .dialog input {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .app .window-app dialog {
@@ -235,7 +235,7 @@
 }
 
 #module-management .package-list .package-title {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .item-button-container {
@@ -248,39 +248,39 @@
 
 .rollable:hover,
 .rollable:focus {
-  color: rgb(0, 0, 0);
+  color: black;
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-sender {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-metadata {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -530,7 +530,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -549,7 +549,6 @@
   font-size: 1.125em;
   align-items: center;
   flex-wrap: nowrap;
-  background-color: #5f5f5f;
   margin-top: 5px;
 }
 
@@ -617,7 +616,7 @@
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -634,7 +633,7 @@
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -645,11 +644,11 @@
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .tox .tox-editor-container {
-  background: rgb(255, 255, 255);
+  background: white;
 }
 
 .essence20 .tox .tox-edit-area {
@@ -660,7 +659,7 @@
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -773,7 +772,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -797,7 +796,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -834,7 +833,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   background: none;
@@ -901,7 +900,7 @@
 }
 
 .essence20 .item {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 /* Generic Item Sheet Styling */
@@ -911,7 +910,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -976,7 +975,7 @@
   align-items: center;
   padding: 0 2px;
   border-bottom: 1px solid #b5b1b1;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .items-list .item:last-child {
@@ -1056,7 +1055,7 @@
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding: 6px;
   min-height: none;
 }
@@ -1073,7 +1072,7 @@
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: rgb(163, 163, 163);
+  color: #a3a3a3;
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1127,11 +1126,11 @@ option {
 
 form .notes,
 form .hint {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .span {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .sheet-body {

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -875,11 +875,11 @@
 }
 
 .essence20 .tabs .item.active {
-  text-shadow: 0 0 10px #00c2ff;
+  text-shadow: 0 0 10px #ffffff;
 }
 
 .essence20 a:hover {
-  text-shadow: 0 0 10px #00c2ff;
+  text-shadow: 0 0 10px #ffffff;
 }
 
 .sheet nav.sheet-tabs {

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -556,6 +556,7 @@
   flex-grow: 0;
   margin-right: 5px;
   margin-left: 5px;
+  padding-top: 4px;
 }
 
 .essence20 .skill-header .skill-name {

--- a/sass/actors/_tabs.scss
+++ b/sass/actors/_tabs.scss
@@ -26,11 +26,11 @@
 }
 
 .essence20 .tabs .item.active {
-  text-shadow: 0 0 10px #00c2ff;
+  text-shadow: 0 0 10px #ffffff;
 }
 
 .essence20 a:hover {
-  text-shadow: 0 0 10px #00c2ff;
+  text-shadow: 0 0 10px #ffffff;
 }
 
 .sheet nav.sheet-tabs {

--- a/sass/assets/_skill.scss
+++ b/sass/assets/_skill.scss
@@ -4,7 +4,6 @@
   font-size: 1.125em;
   align-items: center;
   flex-wrap: nowrap;
-  background-color: v.$background-b;
   margin-top: 5px;
 }
 

--- a/sass/assets/_skill.scss
+++ b/sass/assets/_skill.scss
@@ -11,6 +11,7 @@
   flex-grow: 0;
   margin-right: 5px;
   margin-left: 5px;
+  padding-top: 4px;
 }
 
 .essence20 .skill-header .skill-name {

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -1,5 +1,5 @@
 {{!-- Skill header and shift selector --}}
-<div class="flexrow skill-header">
+<div class="flexrow skill-header" style="background-color: {{@root.system.color}}50">
   <span class="skill-roll">
     <a class="rollable" data-roll-type="skill" data-skill="{{skill}}"><i class="fas fa-dice-d20"></i></a>
   </span>


### PR DESCRIPTION
In this change
- Using the theme color for skill headers, but making it more transparent. Two digits at the end of a hex indicates the alpha value, who knew!
- Using white for text shadows since it goes with any color
- Vertically aligning the skill roll icon. I used padding because it was being annoying, but if there's a better way I'm all ears.

Testing: PR sheet looks good.