### PR TITLE
Specialization rework

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -174,7 +174,7 @@
     "RollDialogTitle": "Configure your skill roll",
     "RollRepeatText": "Roll {index} of {total}",
     "RollRollingFor": "Rolling for",
-    "RollSpecialized": "Specialized",
+    "RollIsSpecialized": "Specialized",
     "RollWithAnEdge": "with an Edge",
     "RollWithASnag": "with a Snag",
     "ShiftAutoFail": "Auto Fail",

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -93,7 +93,7 @@ export class Dice {
     }
 
     const isSpecialized = dataset.isSpecialized === 'true' || skillRollOptions.isSpecialized;
-    const modifier = isSpecialized ? 0 : actorSkillData[rolledEssence][rolledSkill].modifier || 0;
+    const modifier = actorSkillData[rolledEssence][rolledSkill].modifier || 0;
     const formula = this._getFormula(isSpecialized, skillRollOptions, finalShift, modifier);
 
     // Repeat the roll as many times as specified in the skill roll options dialog
@@ -136,7 +136,7 @@ export class Dice {
   _getSkillRollLabel(dataset, skillRollOptions) {
     const rolledSkill = dataset.skill;
     const rolledSkillStr = dataset.isSpecialized
-      ? dataset.skill
+      ? dataset.specializationName
       : this._i18n.localize(this._config.essenceSkills[rolledSkill]);
     const rollingForStr = this._i18n.localize('E20.RollRollingFor')
     return `${rollingForStr} ${rolledSkillStr}` + this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag);

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -26,7 +26,7 @@ export class Dice {
     const html = await renderTemplate(
       template,
       {
-        specialized: !!dataset.specialization,
+        specialized: dataset.specialized,
         snag,
         edge: false,
         normal: !snag

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -19,10 +19,7 @@ export class Dice {
    */
   async getSkillRollOptions(dataset, actor) {
     const template = "systems/essence20/templates/dialog/roll-dialog.hbs"
-    const rolledSkill = dataset.skill;
-    const rolledEssence = this._config.skillToEssence[rolledSkill];
-    const rolledShift = actor.system.skills[rolledEssence][rolledSkill].shift
-    const snag = this._config.skillShiftList.indexOf('d20') == this._config.skillShiftList.indexOf(rolledShift);
+    const snag = this._config.skillShiftList.indexOf('d20') == this._config.skillShiftList.indexOf(dataset.shift);
     const html = await renderTemplate(
       template,
       {
@@ -84,8 +81,7 @@ export class Dice {
     const rolledSkill = dataset.skill;
     const rolledEssence = this._config.skillToEssence[rolledSkill];
     const actorSkillData = actor.getRollData().skills;
-    const initialShift = actorSkillData[rolledEssence][rolledSkill].shift;
-    let finalShift = this._getFinalShift(skillRollOptions, initialShift);
+    let finalShift = this._getFinalShift(skillRollOptions, dataset.shift);
 
     if (this._handleAutoFail(finalShift, label, actor)) {
       return;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -23,7 +23,7 @@ export class Dice {
     const html = await renderTemplate(
       template,
       {
-        specialized: dataset.specialized === 'true',
+        isSpecialized: dataset.isSpecialized === 'true',
         snag,
         edge: false,
         normal: !snag
@@ -62,7 +62,7 @@ export class Dice {
       shiftDown: parseInt(form.shiftDown.value),
       shiftUp: parseInt(form.shiftUp.value),
       snag: form.snagEdge.value == 'snag',
-      specialized: form.specialized.checked,
+      isSpecialized: form.isSpecialized.checked,
       timesToRoll: parseInt(form.timesToRoll.value),
     }
   }
@@ -94,7 +94,7 @@ export class Dice {
 
     const modifier = actorSkillData[rolledEssence][rolledSkill].modifier || 0;
     const formula = this._getFormula(
-      !!dataset.specialization || skillRollOptions.specialized, skillRollOptions, finalShift, modifier);
+      !!dataset.specialization || skillRollOptions.isSpecialized, skillRollOptions, finalShift, modifier);
 
     // Repeat the roll as many times as specified in the skill roll options dialog
     for (let i = 0; i < skillRollOptions.timesToRoll; i++) {

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -92,9 +92,9 @@ export class Dice {
       finalShift = this._config.skillRollableShifts[this._config.skillRollableShifts.length - 1];
     }
 
-    const modifier = actorSkillData[rolledEssence][rolledSkill].modifier || 0;
-    const formula = this._getFormula(
-      !!dataset.specialization || skillRollOptions.isSpecialized, skillRollOptions, finalShift, modifier);
+    const isSpecialized = dataset.isSpecialized === 'true' || skillRollOptions.isSpecialized;
+    const modifier = isSpecialized ? 0 : actorSkillData[rolledEssence][rolledSkill].modifier || 0;
+    const formula = this._getFormula(isSpecialized, skillRollOptions, finalShift, modifier);
 
     // Repeat the roll as many times as specified in the skill roll options dialog
     for (let i = 0; i < skillRollOptions.timesToRoll; i++) {
@@ -135,8 +135,8 @@ export class Dice {
    */
   _getSkillRollLabel(dataset, skillRollOptions) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = dataset.specialization
-      ? dataset.specialization
+    const rolledSkillStr = dataset.isSpecialized
+      ? dataset.skill
       : this._i18n.localize(this._config.essenceSkills[rolledSkill]);
     const rollingForStr = this._i18n.localize('E20.RollRollingFor')
     return `${rollingForStr} ${rolledSkillStr}` + this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag);

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -23,7 +23,7 @@ export class Dice {
     const html = await renderTemplate(
       template,
       {
-        specialized: dataset.specialized,
+        specialized: dataset.specialized === 'true',
         snag,
         edge: false,
         normal: !snag

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -16,6 +16,8 @@ const dice = new Dice(new Mocki18n, E20, chatMessage);
 /* rollSkill */
 describe("rollSkill", () => {
   const dataset = {
+    isSpecialized: false,
+    shift: 'd20',
     skill: 'athletics',
   };
   const mockActor = jest.mock();
@@ -70,6 +72,10 @@ describe("rollSkill", () => {
   });
 
   test("auto success", () => {
+    const datasetCopy = {
+      ...dataset,
+      shift: 'autoSuccess',
+    }
     const skillRollOptions = {
       edge: false,
       snag: false,
@@ -89,7 +95,7 @@ describe("rollSkill", () => {
     }));
     dice._rollSkillHelper = jest.fn()
 
-    dice.rollSkill(dataset, skillRollOptions, mockActor, null);
+    dice.rollSkill(datasetCopy, skillRollOptions, mockActor, null);
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 3d6 + 0', mockActor, "E20.RollRollingFor E20.EssenceSkillAthletics");
   });
 });
@@ -131,20 +137,6 @@ describe("_getSkillRollLabel", () => {
       snag: true,
     }
     const expected = "E20.RollRollingFor E20.EssenceSkillAthletics E20.RollWithASnag";
-
-    expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
-  });
-
-  test("specialization roll", () => {
-    const dataset = {
-      skill: 'athletics',
-      specialization: "Foo Specialization",
-    };
-    const skillRollOptions = {
-      edge: false,
-      snag: false,
-    }
-    const expected = "E20.RollRollingFor Foo Specialization";
 
     expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
   });

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -98,6 +98,35 @@ describe("rollSkill", () => {
     dice.rollSkill(datasetCopy, skillRollOptions, mockActor, null);
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 3d6 + 0', mockActor, "E20.RollRollingFor E20.EssenceSkillAthletics");
   });
+
+  test("specialized skill roll", () => {
+    const datasetCopy = {
+      ...dataset,
+      isSpecialized: true,
+      specializationName: 'Foo Specialization',
+    }
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    }
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'strength': {
+          'athletics': {
+            modifier: '0',
+            shift: 'd20',
+          },
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn()
+
+    dice.rollSkill(datasetCopy, skillRollOptions, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor Foo Specialization");
+  });
 });
 
 /* _getSkillRollLabel */
@@ -137,6 +166,21 @@ describe("_getSkillRollLabel", () => {
       snag: true,
     }
     const expected = "E20.RollRollingFor E20.EssenceSkillAthletics E20.RollWithASnag";
+
+    expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
+  });
+
+  test("specialized skill roll", () => {
+    const dataset = {
+      skill: 'athletics',
+      isSpecialized: true,
+      specializationName: 'Foo Specialization'
+    };
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+    }
+    const expected = "E20.RollRollingFor Foo Specialization";
 
     expect(dice._getSkillRollLabel(dataset, skillRollOptions)).toEqual(expected);
   });

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -89,6 +89,10 @@ Handlebars.registerHelper('ifEquals', function (arg1, arg2, options) {
   return (arg1 == arg2) ? options.fn(this) : options.inverse(this);
 });
 
+Handlebars.registerHelper('inArray', function (array, value, options) {
+  return (array.includes(value)) ? options.fn(this) : options.inverse(this);
+});
+
 /* -------------------------------------------- */
 /*  Misc Hooks                                  */
 /* -------------------------------------------- */

--- a/template.json
+++ b/template.json
@@ -365,7 +365,11 @@
       ],
       "classFeatureId": null
     },
-    "specialization": {},
+    "specialization": {
+      "isSpecialized": true,
+      "shift": "d20",
+      "skill": "athletics"
+    },
     "threatPower": {
       "actionType": "",
       "charges": null,

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -1,7 +1,9 @@
 {{!-- Skill header and shift selector --}}
 <div class="flexrow skill-header" style="background-color: {{@root.system.color}}50">
   <span class="skill-roll">
-    <a class="rollable" data-roll-type="skill" data-skill="{{skill}}"><i class="fas fa-dice-d20"></i></a>
+    <a class="rollable" data-roll-type="skill" data-skill="{{skill}}" data-essence="{{essence}}" data-shift="{{fields.shift}}">
+      <i class="fas fa-dice-d20"></i>
+    </a>
   </span>
   <span class="skill-name">{{localize (lookup @root.config.essenceSkills skill)}}</span>
 </div>
@@ -21,6 +23,9 @@
     {{/ifEquals}}
   </div>
 
+  {{!-- Only PCs and NPCs get Specializations. Update this as new PC types are added. --}}
+  {{#inArray '["powerRanger", "npc"]' @root.actor.type}}
+
   {{!-- Specializations header --}}
   <div class="specializations-header">
     <span>{{localize 'E20.ItemTypeSpecializationPlural'}}</span>
@@ -35,7 +40,14 @@
     <li class="item specializations-list" data-item-id="{{specialization._id}}">
       <div class="flexrow specializations-item">
         <span class="item-button-container">
-          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-specialization="{{specialization.name}}" data-specialized="{{specialization.system.isSpecialized}}"><i class="fas fa-dice-d20"></i></a>
+          {{#ifEquals @root.actor.type 'npc'}}
+          {{!-- NPCs can have unspecialized specializations, but PCs are always specialized --}}
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-specialized="{{specialization.system.isSpecialized}}">
+          {{else}}
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-specialized="true">
+          {{/ifEquals}}
+            <i class="fas fa-dice-d20"></i>
+          </a>
         </span>
         <input class="inline-edit" data-field="name" type="text" name="{{../skill}}.{{specialization.name}}" value="{{specialization.name}}" />
         {{#ifEquals @root.actor.type 'npc'}}
@@ -49,4 +61,6 @@
     </li>
     {{/each}}
   </ol>
+
+  {{/inArray}}
 </div>

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -1,7 +1,7 @@
 {{!-- Skill header and shift selector --}}
 <div class="flexrow skill-header" style="background-color: {{@root.system.color}}50">
   <span class="skill-roll">
-    <a class="rollable" data-roll-type="skill" data-skill="{{skill}}" data-essence="{{essence}}" data-shift="{{fields.shift}}" data-specialized="{{fields.isSpecialized}}">
+    <a class="rollable" data-roll-type="skill" data-skill="{{skill}}" data-essence="{{essence}}" data-shift="{{fields.shift}}" data-is-specialized="{{fields.isSpecialized}}">
       <i class="fas fa-dice-d20"></i>
     </a>
   </span>
@@ -18,7 +18,7 @@
     <input class="one-digit-input" type="number" name="system.skills.{{essence}}.{{skill}}.modifier" value="{{fields.modifier}}"/>
 
     {{#ifEquals @root.actor.type 'npc'}}
-    <span class="specialized-label">{{localize 'E20.RollSpecialized'}}:</span>
+    <span class="specialized-label">{{localize 'E20.RollIsSpecialized'}}:</span>
     <input class="specialized-checkbox" type="checkbox" name="system.skills.{{essence}}.{{skill}}.isSpecialized" {{checked fields.isSpecialized}} data-dtype="Boolean"/>
     {{/ifEquals}}
   </div>
@@ -42,23 +42,23 @@
         <span class="item-button-container">
           {{#ifEquals @root.actor.type 'npc'}}
           {{!-- NPCs can have unspecialized specializations, but PCs are always specialized --}}
-          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-specialized="{{specialization.system.isSpecialized}}">
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-is-specialized="{{specialization.system.isSpecialized}}">
           {{else}}
-          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-specialized="true">
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-is-specialized="true">
           {{/ifEquals}}
             <i class="fas fa-dice-d20"></i>
           </a>
         </span>
         <input class="inline-edit" data-field="name" type="text" name="{{../skill}}.{{specialization.name}}" value="{{specialization.name}}" />
         {{#ifEquals @root.actor.type 'npc'}}
-        <select class="inline-edit" data-field="system.shift" name="system.shift">
+        <select class="inline-edit" style="flex-grow: 0;" data-field="system.shift" name="system.shift">
           {{#select specialization.system.shift}}
           {{#each @root.config.skillShifts as |text shift|}}
           <option value="{{shift}}">{{localize text}}</option>
           {{/each}}
           {{/select}}
         </select>
-        <span class="specialized-label" style="flex-grow: 0;">{{localize 'E20.RollSpecialized'}}:</span>
+        <span class="specialized-label" style="flex-grow: 0;">{{localize 'E20.RollIsSpecialized'}}:</span>
         <input class="inline-edit specialized-checkbox" type="checkbox" data-field="system.isSpecialized" name="specialization.system.isSpecialized" {{checked specialization.system.isSpecialized}} data-dtype="Boolean"/>
         {{/ifEquals}}
         <span class="item-button-container">

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -42,9 +42,9 @@
         <span class="item-button-container">
           {{#ifEquals @root.actor.type 'npc'}}
           {{!-- NPCs can have unspecialized specializations, but PCs are always specialized --}}
-          <a class="rollable" data-roll-type="skill" data-skill="{{specialization.name}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-is-specialized="{{specialization.system.isSpecialized}}">
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-specialization-name="{{specialization.name}}" data-is-specialized="{{specialization.system.isSpecialized}}">
           {{else}}
-          <a class="rollable" data-roll-type="skill" data-skill="{{specialization.name}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-is-specialized="true">
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-specialization-name="{{specialization.name}}" data-is-specialized="true">
           {{/ifEquals}}
             <i class="fas fa-dice-d20"></i>
           </a>

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -42,9 +42,9 @@
         <span class="item-button-container">
           {{#ifEquals @root.actor.type 'npc'}}
           {{!-- NPCs can have unspecialized specializations, but PCs are always specialized --}}
-          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-is-specialized="{{specialization.system.isSpecialized}}">
+          <a class="rollable" data-roll-type="skill" data-skill="{{specialization.name}}" data-essence="{{../essence}}" data-shift="{{specialization.system.shift}}" data-is-specialized="{{specialization.system.isSpecialized}}">
           {{else}}
-          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-is-specialized="true">
+          <a class="rollable" data-roll-type="skill" data-skill="{{specialization.name}}" data-essence="{{../essence}}" data-shift="{{../fields.shift}}" data-is-specialized="true">
           {{/ifEquals}}
             <i class="fas fa-dice-d20"></i>
           </a>

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -1,7 +1,7 @@
 {{!-- Skill header and shift selector --}}
 <div class="flexrow skill-header" style="background-color: {{@root.system.color}}50">
   <span class="skill-roll">
-    <a class="rollable" data-roll-type="skill" data-skill="{{skill}}" data-essence="{{essence}}" data-shift="{{fields.shift}}">
+    <a class="rollable" data-roll-type="skill" data-skill="{{skill}}" data-essence="{{essence}}" data-shift="{{fields.shift}}" data-specialized="{{fields.isSpecialized}}">
       <i class="fas fa-dice-d20"></i>
     </a>
   </span>
@@ -51,6 +51,13 @@
         </span>
         <input class="inline-edit" data-field="name" type="text" name="{{../skill}}.{{specialization.name}}" value="{{specialization.name}}" />
         {{#ifEquals @root.actor.type 'npc'}}
+        <select class="inline-edit" data-field="system.shift" name="system.shift">
+          {{#select specialization.system.shift}}
+          {{#each @root.config.skillShifts as |text shift|}}
+          <option value="{{shift}}">{{localize text}}</option>
+          {{/each}}
+          {{/select}}
+        </select>
         <span class="specialized-label" style="flex-grow: 0;">{{localize 'E20.RollSpecialized'}}:</span>
         <input class="inline-edit specialized-checkbox" type="checkbox" data-field="system.isSpecialized" name="specialization.system.isSpecialized" {{checked specialization.system.isSpecialized}} data-dtype="Boolean"/>
         {{/ifEquals}}

--- a/templates/actor/parts/actor-essence-skills.hbs
+++ b/templates/actor/parts/actor-essence-skills.hbs
@@ -24,7 +24,7 @@
   {{!-- Specializations header --}}
   <div class="specializations-header">
     <span>{{localize 'E20.ItemTypeSpecializationPlural'}}</span>
-    <a class="item-create" data-type="specialization" data-skill="{{skill}}" title="{{ localize 'E20.ItemControlAdd' }}">
+    <a class="item-create" data-type="specialization" data-skill="{{skill}}" data-shift="{{fields.shift}}" title="{{ localize 'E20.ItemControlAdd' }}">
       <i class="fas fa-plus"></i>
     </a>
   </div>
@@ -35,9 +35,13 @@
     <li class="item specializations-list" data-item-id="{{specialization._id}}">
       <div class="flexrow specializations-item">
         <span class="item-button-container">
-          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-specialization="{{specialization.name}}"><i class="fas fa-dice-d20"></i></a>
+          <a class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-specialization="{{specialization.name}}" data-specialized="{{specialization.system.isSpecialized}}"><i class="fas fa-dice-d20"></i></a>
         </span>
         <input class="inline-edit" data-field="name" type="text" name="{{../skill}}.{{specialization.name}}" value="{{specialization.name}}" />
+        {{#ifEquals @root.actor.type 'npc'}}
+        <span class="specialized-label" style="flex-grow: 0;">{{localize 'E20.RollSpecialized'}}:</span>
+        <input class="inline-edit specialized-checkbox" type="checkbox" data-field="system.isSpecialized" name="specialization.system.isSpecialized" {{checked specialization.system.isSpecialized}} data-dtype="Boolean"/>
+        {{/ifEquals}}
         <span class="item-button-container">
           <a class="item-control item-delete" title="{{localize 'E20.ItemControlDelete'}}"><i class="fas fa-trash"></i></a>
         </span>

--- a/templates/dialog/roll-dialog.hbs
+++ b/templates/dialog/roll-dialog.hbs
@@ -17,8 +17,8 @@
     </div>
     <div>
       <label>
-        <input type="checkbox" name="specialized" {{checked specialized}} />
-        <span>{{localize 'E20.RollSpecialized'}}</span>
+        <input type="checkbox" name="isSpecialized" {{checked isSpecialized}} />
+        <span>{{localize 'E20.RollIsSpecialized'}}</span>
       </label>
     </div>
     <div>


### PR DESCRIPTION
THIS IS A DRAFT
- From what I've seen it doesn't break current sheets, but it needs more testing. If it does I'll have to look into migration stuff.
- Might need to widen the default NPC sheet width, because the Specialization names get smushed
- Looking for early feedback

In this MR
- The primary purpose of this change is so that NPCs can have custom skills that aren't specialized. I tried a couple of things, but ultimately found just adding a `isSpecialized` field to the existing `Specialization` Item to be the best way to go so that every sheet can still use the same roll logic/templates/etc.
- I realize this is slightly confusing, because we now have Specializations that can be unspecialized. I may end up renaming `Specialization` to `CustomSkill` or something in the template, but that will be fairly involved.
- PC sheets work as normal, but NPC sheets now have a checkbox to specialize the custom skill, as well as its own selector to assign it a shift.
- Renaming `specialized` to `isSpecialized` everywhere to be consistent

Testing
- PC skill and specialization rolls should work as normal
- NPC skills should work as normal, but especially make sure the specialized checkbox rolls correctly
- Try making NPC specializations (including unspecialized ones) and ensure its shift selector rolls correctly
- Roll labels should be correct in the chat