### PR TITLE
NPC sheet - Adding notes tab and gear

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -214,6 +214,7 @@
     "TabBackground": "Background",
     "TabCombat": "Combat",
     "TabGear": "Gear",
+    "TabMain": "Main",
     "TabNotes": "Notes",
     "TabPerks": "Perks",
     "TabPowers": "Powers",

--- a/template.json
+++ b/template.json
@@ -233,6 +233,7 @@
           "value": null
         }
       },
+      "notes": "",
       "threatLevel": 0
     },
     "vehicle": {

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -28,6 +28,8 @@
         {{> "systems/essence20/templates/actor/parts/actor-threat-powers.hbs"}}
         {{!-- Perks --}}
         {{> "systems/essence20/templates/actor/parts/actor-perks.hbs"}}
+        {{!-- Gear --}}
+        {{> "systems/essence20/templates/actor/parts/actor-gear.hbs"}}
       </div>
     </div>
   </section>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -2,35 +2,49 @@
   {{!-- Actor Sheet Header --}}
   {{> "systems/essence20/templates/actor/parts/headers/actor-npc-header.hbs"}}
 
+  {{!-- Tabs --}}
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <a class="item" style="border-color: {{system.color}};" data-tab="main"> {{ localize "E20.TabMain" }}</a>
+    <a class="item" style="border-color: {{system.color}};" data-tab="notes">{{ localize "E20.TabNotes" }}</a>
+  </nav>
+
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
-    {{!-- NPC Defenses --}}
-    {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+    {{!-- Main Tab --}}
+    <div class="tab main flexcol" data-group="primary" data-tab="main">
+      {{!-- NPC Defenses --}}
+      {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
 
-    <div class="flexrow stats-row">
-      {{!-- Initiative --}}
-      {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
+      <div class="flexrow stats-row">
+        {{!-- Initiative --}}
+        {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
 
-      {{!-- Movement --}}
-      {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
+        {{!-- Movement --}}
+        {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
+      </div>
+      <div class="npc-row">
+        <div class="npc-column-1">
+          {{!-- Skills --}}
+          {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
+        </div>
+        <div class="npc-column-2">
+          {{!-- Weapons --}}
+          {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
+          {{!-- Hang-ups --}}
+          {{> "systems/essence20/templates/actor/parts/actor-hang-ups.hbs"}}
+          {{!-- Threat Powers --}}
+          {{> "systems/essence20/templates/actor/parts/actor-threat-powers.hbs"}}
+          {{!-- Perks --}}
+          {{> "systems/essence20/templates/actor/parts/actor-perks.hbs"}}
+          {{!-- Gear --}}
+          {{> "systems/essence20/templates/actor/parts/actor-gear.hbs"}}
+        </div>
+      </div>
     </div>
-    <div class="npc-row">
-      <div class="npc-column-1">
-        {{!-- Skills --}}
-        {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
-      </div>
-      <div class="npc-column-2">
-        {{!-- Weapons --}}
-        {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
-        {{!-- Hang-ups --}}
-        {{> "systems/essence20/templates/actor/parts/actor-hang-ups.hbs"}}
-        {{!-- Threat Powers --}}
-        {{> "systems/essence20/templates/actor/parts/actor-threat-powers.hbs"}}
-        {{!-- Perks --}}
-        {{> "systems/essence20/templates/actor/parts/actor-perks.hbs"}}
-        {{!-- Gear --}}
-        {{> "systems/essence20/templates/actor/parts/actor-gear.hbs"}}
-      </div>
+
+    {{!-- Notes Tab --}}
+    <div class="tab notes" data-group="primary" data-tab="notes">
+      {{> "systems/essence20/templates/actor/parts/actor-notes.hbs"}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/222 and https://github.com/WookieeMatt/Essence20/issues/213

In this MR:
- Adding a Gear section to the `Main` NPC tab
- Adding a tab for Notes

Testing:
- NPCs should have functional tabs
- NPC gear and notes should work as expected