### PR TITLE
Ready for Review: Adding essence scores to NPC sheet

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,6 +9,13 @@
       "type": "shell",
       "command": "sass sass/essence20.scss css/essence20.css",
       "group": "build"
+    },
+    {
+      "type": "npm",
+      "script": "sass",
+      "problemMatcher": [],
+      "label": "npm: sass",
+      "detail": "npx sass -s compressed ./sass/*.scss ./css/*.css"
     }
   ]
 }

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -60,7 +60,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -105,7 +105,7 @@
 }
 
 .essence20 .editor-content {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -166,21 +166,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -198,17 +198,17 @@
 }
 
 .dialog .dialog-buttons button.default {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   padding-top: 6px;
 }
 
@@ -216,7 +216,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -227,7 +227,7 @@
 }
 
 .dialog input {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .app .window-app dialog {
@@ -235,7 +235,7 @@
 }
 
 #module-management .package-list .package-title {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .item-button-container {
@@ -248,39 +248,39 @@
 
 .rollable:hover,
 .rollable:focus {
-  color: black;
+  color: rgb(0, 0, 0);
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .chat-message .message-sender {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .chat-message .message-metadata {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -530,7 +530,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -617,7 +617,7 @@
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -634,7 +634,7 @@
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -645,11 +645,11 @@
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .essence20 .tox .tox-editor-container {
-  background: white;
+  background: rgb(255, 255, 255);
 }
 
 .essence20 .tox .tox-edit-area {
@@ -660,7 +660,7 @@
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -773,7 +773,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -797,7 +797,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -834,7 +834,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: auto;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   flex-basis: auto;
   justify-content: center;
   background: none;
@@ -906,7 +906,7 @@
 }
 
 .essence20 .item {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 /* Generic Item Sheet Styling */
@@ -916,7 +916,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -981,7 +981,7 @@
   align-items: center;
   padding: 0 2px;
   border-bottom: 1px solid #b5b1b1;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .essence20 .items-list .item:last-child {
@@ -1061,7 +1061,7 @@
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
   padding: 6px;
   min-height: none;
 }
@@ -1078,7 +1078,7 @@
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: #a3a3a3;
+  color: rgb(163, 163, 163);
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1132,11 +1132,11 @@ option {
 
 form .notes,
 form .hint {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .essence20 .span {
-  color: #c7c4c4;
+  color: rgb(199, 196, 196);
 }
 
 .essence20 .sheet-body {

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -33,6 +33,7 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/actor-movement.hbs",
     "systems/essence20/templates/actor/parts/actor-notes.hbs",
     "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs",
+    "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs",
     "systems/essence20/templates/actor/parts/actor-pc-skills.hbs",
     "systems/essence20/templates/actor/parts/actor-perks.hbs",
     "systems/essence20/templates/actor/parts/actor-powers.hbs",

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -5,23 +5,24 @@
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
     <div class="npc-row">
-      <div class="npc-column-1">
+      <div class="npc-column-2">
         {{!-- NPC Essence Scores --}}
         {{> "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs"}}
-      </div>
-      <div class="npc-column-2">
-        {{!-- NPC Defenses --}}
         {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
       </div>
-    </div>
-
-    <div class="npc-row">
       <div class="npc-column-1">
-        {{!-- Initiative --}}
-        {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
-      </div>
-      <div class="npc-column-2">
-        {{!-- Movement --}}
+        {{!-- NPC-Health --}}
+        <div class="npc-health-container stats-container">
+          <div class="resource flex-group-center">
+            <label for="system.health.value" class="resource-label">{{localize 'E20.ActorHealth'}}</label>
+            <div class="resource-content flexrow flex-center flex-between">
+              <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
+              <span>/</span>
+              <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
+            </div>
+          </div>
+        </div>
+        {{!-- MOvement --}}
         {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
       </div>
     </div>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -16,6 +16,8 @@
         <div class="npc-column-2">
           {{!-- NPC Essence Scores --}}
           {{> "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs"}}
+
+          {{!-- NPC Defenses --}}
           {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
         </div>
         <div class="npc-column-1">
@@ -49,7 +51,6 @@
           {{> "systems/essence20/templates/actor/parts/actor-threat-powers.hbs"}}
           {{!-- Perks --}}
           {{> "systems/essence20/templates/actor/parts/actor-perks.hbs"}}
-
           {{!-- Gear --}}
           {{> "systems/essence20/templates/actor/parts/actor-gear.hbs"}}
         </div>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -4,16 +4,28 @@
 
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
-    {{!-- NPC Defenses --}}
-    {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
-
-    <div class="flexrow stats-row">
-      {{!-- Initiative --}}
-      {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
-
-      {{!-- Movement --}}
-      {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
+    <div class="npc-row">
+      <div class="npc-column-1">
+        {{!-- NPC Essence Scores --}}
+        {{> "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs"}}
+      </div>
+      <div class="npc-column-2">
+        {{!-- NPC Defenses --}}
+        {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+      </div>
     </div>
+
+    <div class="npc-row">
+      <div class="npc-column-1">
+        {{!-- Initiative --}}
+        {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
+      </div>
+      <div class="npc-column-2">
+        {{!-- Movement --}}
+        {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
+      </div>
+    </div>
+
     <div class="npc-row">
       <div class="npc-column-1">
         {{!-- Skills --}}

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -2,46 +2,59 @@
   {{!-- Actor Sheet Header --}}
   {{> "systems/essence20/templates/actor/parts/headers/actor-npc-header.hbs"}}
 
+  {{!-- Tabs --}}
+  <nav class="sheet-tabs tabs" data-group="primary">
+    <a class="item" style="border-color: {{system.color}};" data-tab="main"> {{ localize "E20.TabMain" }}</a>
+    <a class="item" style="border-color: {{system.color}};" data-tab="notes">{{ localize "E20.TabNotes" }}</a>
+  </nav>
+
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
-    <div class="npc-row">
-      <div class="npc-column-2">
-        {{!-- NPC Essence Scores --}}
-        {{> "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs"}}
-        {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
-      </div>
-      <div class="npc-column-1">
-        {{!-- NPC-Health --}}
-        <div class="npc-health-container stats-container">
-          <div class="resource flex-group-center">
-            <label for="system.health.value" class="resource-label">{{localize 'E20.ActorHealth'}}</label>
-            <div class="resource-content flexrow flex-center flex-between">
-              <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
-              <span>/</span>
-              <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
+    {{!-- Main Tab --}}
+    <div class="tab main flexcol" data-group="primary" data-tab="main">
+      <div class="npc-row">
+        <div class="npc-column-2">
+          {{!-- NPC Essence Scores --}}
+          {{> "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs"}}
+          {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+        </div>
+        <div class="npc-column-1">
+          {{!-- NPC-Health --}}
+          <div class="npc-health-container stats-container">
+            <div class="resource flex-group-center">
+              <label for="system.health.value" class="resource-label">{{localize 'E20.ActorHealth'}}</label>
+              <div class="resource-content flexrow flex-center flex-between">
+                <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
+                <span>/</span>
+                <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
+              </div>
             </div>
           </div>
+          {{!-- MOvement --}}
+          {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
         </div>
-        {{!-- MOvement --}}
-        {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
+      </div>
+
+
+      <div class="npc-row">
+        <div class="npc-column-1">
+          {{!-- Skills --}}
+          {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
+        </div>
+        <div class="npc-column-2">
+          {{!-- Weapons --}}
+          {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
+          {{!-- Hang-ups --}}
+          {{> "systems/essence20/templates/actor/parts/actor-hang-ups.hbs"}}
+          {{!-- Threat Powers --}}
+          {{> "systems/essence20/templates/actor/parts/actor-threat-powers.hbs"}}
+          {{!-- Perks --}}
+          {{> "systems/essence20/templates/actor/parts/actor-perks.hbs"}}
+        </div>
       </div>
     </div>
-
-    <div class="npc-row">
-      <div class="npc-column-1">
-        {{!-- Skills --}}
-        {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
-      </div>
-      <div class="npc-column-2">
-        {{!-- Weapons --}}
-        {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
-        {{!-- Hang-ups --}}
-        {{> "systems/essence20/templates/actor/parts/actor-hang-ups.hbs"}}
-        {{!-- Threat Powers --}}
-        {{> "systems/essence20/templates/actor/parts/actor-threat-powers.hbs"}}
-        {{!-- Perks --}}
-        {{> "systems/essence20/templates/actor/parts/actor-perks.hbs"}}
-      </div>
+    <div class="tab notes" data-group="primary" data-tab="notes">
+      {{> "systems/essence20/templates/actor/parts/actor-notes.hbs"}}
     </div>
   </section>
 </form>

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -32,7 +32,7 @@
               </div>
             </div>
           </div>
-          {{!-- MOvement --}}
+          {{!-- Movement --}}
           {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}
         </div>
       </div>

--- a/templates/actor/parts/actor-common.hbs
+++ b/templates/actor/parts/actor-common.hbs
@@ -1,6 +1,8 @@
 <div class="flexrow stats-row">
+  <div class="stats-container" style="border-color: {{system.color}}; flex-grow: 0.25;">
   {{!-- Initiative --}}
   {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
+  </div>
 
   {{!-- Movement --}}
   {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}

--- a/templates/actor/parts/actor-common.hbs
+++ b/templates/actor/parts/actor-common.hbs
@@ -1,7 +1,7 @@
 <div class="flexrow stats-row">
   <div class="stats-container" style="border-color: {{system.color}}; flex-grow: 0.25;">
-  {{!-- Initiative --}}
-  {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
+    {{!-- Initiative --}}
+    {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
   </div>
 
   {{!-- Movement --}}

--- a/templates/actor/parts/actor-health.hbs
+++ b/templates/actor/parts/actor-health.hbs
@@ -1,4 +1,4 @@
-<div class="stats-container" style="border-color: {{system.color}};">
+<div class="stats-container" style="border-color: {{system.color}}; flex-grow: 0;">
   <div class="resource flex-group-center">
     <label for="system.health.value" class="resource-label">{{localize 'E20.ActorHealth'}}</label>
     <div class="resource-content flexrow flex-center flex-between">

--- a/templates/actor/parts/actor-initiative.hbs
+++ b/templates/actor/parts/actor-initiative.hbs
@@ -1,4 +1,4 @@
-<div class="stats-container initiative" style="border-color: {{system.color}};">
+<div class="resource initiative" style="border-color: {{system.color}};">
   <span>{{localize 'E20.ActorInitiative'}}</span>
   <div class="initiative-dropdown flex-group-center">
     <select name="system.initiative">

--- a/templates/actor/parts/actor-movement.hbs
+++ b/templates/actor/parts/actor-movement.hbs
@@ -1,4 +1,4 @@
-<div class="npc-defenses" style="flex-grow: 0; border-color: {{system.color}};">
+<div class="npc-defenses" style="flex-grow: 1; border-color: {{system.color}};">
   <div class="flexrow">
     <div class="resource flexcol">
       <label class="resource flex-group-center">{{localize @root.config.movementTypes.aerial}}</label>

--- a/templates/actor/parts/actor-movement.hbs
+++ b/templates/actor/parts/actor-movement.hbs
@@ -1,4 +1,4 @@
-<div class="stats-container" style="flex-grow: 0; border-color: {{system.color}};">
+<div class="npc-defenses" style="flex-grow: 0; border-color: {{system.color}};">
   <div class="flexrow">
     <div class="resource flexcol">
       <label class="resource flex-group-center">{{localize @root.config.movementTypes.aerial}}</label>

--- a/templates/actor/parts/actor-npc-essence-scores.hbs
+++ b/templates/actor/parts/actor-npc-essence-scores.hbs
@@ -1,0 +1,10 @@
+<div style="flex-grow: 0;">
+  <div class="npc-defenses">
+    {{#each system.essences as |score skill|}}
+    <div class="resource flexcol">
+      <label class="resource flex-group-center">{{localize (lookup @root.config.essences skill)}}</label>
+      <input type="number" class="centered-input" name="system.essences.{{skill}}" value="{{score}}" />
+    </div>
+    {{/each}}
+  </div>
+</div>

--- a/templates/actor/parts/actor-zord-common.hbs
+++ b/templates/actor/parts/actor-zord-common.hbs
@@ -1,6 +1,8 @@
 <div class="flexrow stats-row">
-  {{!-- Initiative --}}
-  {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
+  <div class="stats-container" style="border-color: {{system.color}}; flex-grow: 0.25;">
+    {{!-- Initiative --}}
+    {{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
+  </div>
 
   {{!-- Movement --}}
   {{> "systems/essence20/templates/actor/parts/actor-movement.hbs"}}

--- a/templates/actor/parts/headers/actor-npc-header.hbs
+++ b/templates/actor/parts/headers/actor-npc-header.hbs
@@ -1,18 +1,9 @@
 {{#>"systems/essence20/templates/actor/parts/headers/actor-header.hbs"}}
 {{#*inline "secondary-fields"}}
-<div class="resource">
+<div class="resource2">
   <label for="name" class="resource-label">{{localize 'E20.NpcThreatLevel'}}</label>
   <input type="number" name="system.threatLevel" value="{{system.threatLevel}}" />
 </div>
-<div class="npc-health-container">
-  <div class="resource flex-group-center">
-    <label for="system.health.value" class="resource-label">{{localize 'E20.ActorHealth'}}</label>
-    <div class="resource-content flexrow flex-center flex-between">
-      <input type="text" name="system.health.value" value="{{system.health.value}}" data-dtype="Number" />
-      <span>/</span>
-      <input type="text" name="system.health.max" value="{{system.health.max}}" data-dtype="Number" />
-    </div>
-  </div>
-</div>
+{{> "systems/essence20/templates/actor/parts/actor-initiative.hbs"}}
 {{/inline}}
 {{/"systems/essence20/templates/actor/parts/headers/actor-header.hbs"}}

--- a/templates/actor/parts/headers/actor-npc-header.hbs
+++ b/templates/actor/parts/headers/actor-npc-header.hbs
@@ -1,6 +1,6 @@
 {{#>"systems/essence20/templates/actor/parts/headers/actor-header.hbs"}}
 {{#*inline "secondary-fields"}}
-<div class="resource2">
+<div class="resource">
   <label for="name" class="resource-label">{{localize 'E20.NpcThreatLevel'}}</label>
   <input type="number" name="system.threatLevel" value="{{system.threatLevel}}" />
 </div>


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/234

In this MR:
- Adding essence scores to NPC sheets. They're already part of a template that NPC inherits, so no change to template.json needed.
- General improvements to NPC sheet layout

Testing:
- NPC sheet should have essence scores and function as expected