### PR TITLE
Fixing weapon rolls and skill labels

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -76,11 +76,12 @@ export class Dice {
    */
   rollSkill(dataset, skillRollOptions, actor, weapon) {
     const rolledSkill = dataset.skill;
-    const initialShift = dataset.shift;
+    const actorSkillData = actor.getRollData().skills;
     const rolledEssence = dataset.essence || this._config.skillToEssence[rolledSkill];
+    const initialShift = dataset.shift || actorSkillData[rolledEssence][rolledSkill].shift;
     const completeDataset = {
       ...dataset,
-      // Weapon item template can't populate these
+      // Weapon partial can't populate these easily
       essence : rolledEssence,
       shift: initialShift,
     }
@@ -100,7 +101,6 @@ export class Dice {
     }
 
     const isSpecialized = dataset.isSpecialized === 'true' || skillRollOptions.isSpecialized;
-    const actorSkillData = actor.getRollData().skills;
     const modifier = actorSkillData[rolledEssence][rolledSkill].modifier || 0;
     const formula = this._getFormula(isSpecialized, skillRollOptions, finalShift, modifier);
 

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -75,13 +75,19 @@ export class Dice {
    * @param {Item} weapon   The weapon being used, if any.
    */
   rollSkill(dataset, skillRollOptions, actor, weapon) {
-    let label = weapon
-      ? this._getWeaponRollLabel(dataset, skillRollOptions, weapon, actor)
-      : this._getSkillRollLabel(dataset, skillRollOptions);
     const rolledSkill = dataset.skill;
-    const rolledEssence = this._config.skillToEssence[rolledSkill];
-    const actorSkillData = actor.getRollData().skills;
-    const initialShift = actorSkillData[rolledEssence][rolledSkill].shift
+    const initialShift = dataset.shift;
+    const rolledEssence = dataset.essence || this._config.skillToEssence[rolledSkill];
+    const completeDataset = {
+      ...dataset,
+      // Weapon item template can't populate these
+      essence : rolledEssence,
+      shift: initialShift,
+    }
+
+    let label = weapon
+      ? this._getWeaponRollLabel(completeDataset, skillRollOptions, weapon, actor)
+      : this._getSkillRollLabel(completeDataset, skillRollOptions);
     let finalShift = this._getFinalShift(skillRollOptions, initialShift);
 
     if (this._handleAutoFail(finalShift, label, actor)) {
@@ -94,6 +100,7 @@ export class Dice {
     }
 
     const isSpecialized = dataset.isSpecialized === 'true' || skillRollOptions.isSpecialized;
+    const actorSkillData = actor.getRollData().skills;
     const modifier = actorSkillData[rolledEssence][rolledSkill].modifier || 0;
     const formula = this._getFormula(isSpecialized, skillRollOptions, finalShift, modifier);
 
@@ -136,7 +143,7 @@ export class Dice {
    */
   _getSkillRollLabel(dataset, skillRollOptions) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = dataset.isSpecialized
+    const rolledSkillStr = dataset.isSpecialized === 'true'
       ? dataset.specializationName
       : this._i18n.localize(this._config.essenceSkills[rolledSkill]);
     const rollingForStr = this._i18n.localize('E20.RollRollingFor')

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -81,7 +81,8 @@ export class Dice {
     const rolledSkill = dataset.skill;
     const rolledEssence = this._config.skillToEssence[rolledSkill];
     const actorSkillData = actor.getRollData().skills;
-    let finalShift = this._getFinalShift(skillRollOptions, dataset.shift);
+    const initialShift = actorSkillData[rolledEssence][rolledSkill].shift
+    let finalShift = this._getFinalShift(skillRollOptions, initialShift);
 
     if (this._handleAutoFail(finalShift, label, actor)) {
       return;

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -127,6 +127,34 @@ describe("rollSkill", () => {
     dice.rollSkill(datasetCopy, skillRollOptions, mockActor, null);
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor Foo Specialization");
   });
+
+  test("normal weapon skill roll", () => {
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    }
+    const weaponRollDataset = {
+      skill: 'athletics',
+      // shift not passed in for Weapons
+    }
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'strength': {
+          'athletics': {
+            modifier: '0',
+            shift: 'd20',
+          },
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn()
+
+    dice.rollSkill(weaponRollDataset, skillRollOptions, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor E20.EssenceSkillAthletics");
+  });
 });
 
 /* _getSkillRollLabel */

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -102,7 +102,7 @@ describe("rollSkill", () => {
   test("specialized skill roll", () => {
     const datasetCopy = {
       ...dataset,
-      isSpecialized: true,
+      isSpecialized: "true",
       specializationName: 'Foo Specialization',
     }
     const skillRollOptions = {
@@ -173,7 +173,7 @@ describe("_getSkillRollLabel", () => {
   test("specialized skill roll", () => {
     const dataset = {
       skill: 'athletics',
-      isSpecialized: true,
+      isSpecialized: "true",
       specializationName: 'Foo Specialization'
     };
     const skillRollOptions = {


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/240

In this PR:
- After the specialization rework, some data isn't available for the weapon item template (actor-related stuff) so the shift was missing. This eventually led to weapons always rolling at the maximum shift.
- Passing booleans into `dataset` for isSpecialized aren't really booleans, just strings. Maybe we're doing it incorrectly, but for now fixing it to just treat it as a string.

Testing:
- Rolls. Lots of rolls.
- Roll weapons, skills, specializations, different shifts
- Shifts and labels should be correct