### PR TITLE
Fix color selector warning

### DIFF
--- a/template.json
+++ b/template.json
@@ -134,8 +134,7 @@
       "character": {
         "background": {
           "pronouns": "",
-          "role": "",
-          "color": ""
+          "role": ""
         },
         "bonuses": {
           "cleverness": 0,
@@ -143,6 +142,7 @@
           "toughness": 0,
           "willpower": 0
         },
+        "color": "#000000",
         "essences": {
           "strength": 3,
           "speed": 3,

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -23,7 +23,7 @@
         </div>
         <div class="npc-column-1">
           {{!-- NPC-Health --}}
-          <div class="npc-health-container stats-container">
+          <div class="npc-health-container stats-container" style="border-color: {{system.color}};">
             <div class="resource flex-group-center">
               <label for="system.health.value" class="resource-label">{{localize 'E20.ActorHealth'}}</label>
               <div class="resource-content flexrow flex-center flex-between">

--- a/templates/actor/parts/actor-accordion-skills.hbs
+++ b/templates/actor/parts/actor-accordion-skills.hbs
@@ -1,4 +1,4 @@
-<div class="skills-container accordion-wrapper">
+<div class="skills-container accordion-wrapper" style="border-color: {{system.color}};">
   <div class="flex-group-center accordion-label">
     <span>{{localize 'E20.AccordionSkillsTitle'}}</span>
     <a class="item-control"><i class="accordion-icon fas fa-chevron-down"></i></a>

--- a/templates/actor/parts/actor-npc-defenses.hbs
+++ b/templates/actor/parts/actor-npc-defenses.hbs
@@ -1,4 +1,4 @@
-<div class="stats-container" style="flex-grow: 0; height: 100%;">
+<div class="stats-container" style="border-color: {{system.color}}; flex-grow: 0; height: 100%;">
   <div class="flexrow">
     {{#each system.defenses as |fields defense|}}
     <div class="resource flexcol">

--- a/templates/actor/parts/actor-npc-essence-scores.hbs
+++ b/templates/actor/parts/actor-npc-essence-scores.hbs
@@ -1,5 +1,5 @@
 <div style="flex-grow: 0;">
-  <div class="npc-defenses">
+  <div class="npc-defenses" style="border-color: {{system.color}};">
     {{#each system.essences as |score skill|}}
     <div class="resource flexcol">
       <label class="resource flex-group-center">{{localize (lookup @root.config.essences skill)}}</label>


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/214

In this PR:
- Moving `color` out of `background` in the template and defaulting to black. The warnings occurred because it had been defaulted to an empty string.
- I realized the partials were using `system.color` instead of `system.background.color`, so the easiest solution was to just remove it from `background` to not worry about migrations.

Testing
- Open devtools console during testing and no warnings should come up
- Open the actor sheets to ensure the border colors look correct
- Color selector should still work normally
