### PR TITLE
Making Weapons auto snag like normal skill rolls

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -14,10 +14,9 @@ export class Dice {
   /**
    * Displays the dialog used for skill and specialization rolls.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
-   * @param {Actor} actor   The actor performing the roll.
    * @returns {Promise<Dialog>}   The dialog to be displayed.
    */
-  async getSkillRollOptions(dataset, actor) {
+  async getSkillRollOptions(dataset) {
     const template = "systems/essence20/templates/dialog/roll-dialog.hbs"
     const snag = this._config.skillShiftList.indexOf('d20') == this._config.skillShiftList.indexOf(dataset.shift);
     const html = await renderTemplate(

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -150,6 +150,20 @@ export class Dice {
   }
 
   /**
+   * Handles rolling weapons.
+   * @param {Actor} actor   The actor performing the roll.
+   */
+  async handleWeaponRoll(dataset, weapon, actor) {
+      const skillRollOptions = await this.getSkillRollOptions(dataset);
+
+      if (skillRollOptions.cancelled) {
+        return;
+      }
+
+      this.rollSkill(dataset, skillRollOptions, actor, weapon);
+  }
+
+  /**
    * Create weapon roll label.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -136,10 +136,16 @@ describe("rollSkill", () => {
       shiftDown: 0,
       timesToRoll: 1,
     }
-    const weaponRollDataset = {
-      skill: 'athletics',
-      // shift not passed in for Weapons
-    }
+    const weapon = {
+      name: 'Zeo Power Clubs',
+      system: {
+        alternateEffects: "Some alternate effects",
+        classification: {
+          skill: "athletics",
+        },
+        effect: "Some effect",
+      },
+    };
     mockActor.getRollData = jest.fn(() => ({
       skills: {
         'strength': {
@@ -152,8 +158,8 @@ describe("rollSkill", () => {
     }));
     dice._rollSkillHelper = jest.fn()
 
-    dice.rollSkill(weaponRollDataset, skillRollOptions, mockActor, null);
-    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor E20.EssenceSkillAthletics");
+    dice.rollSkill(dataset, skillRollOptions, mockActor, weapon);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "<b>E20.RollAttackRoll</b> - Zeo Power Clubs (E20.EssenceSkillAthletics)<br><b>E20.WeaponEffect</b> - Some effect<br><b>E20.WeaponAlternateEffects</b> - Some alternate effects<br><b>ITEM.TypeClassfeature</b> - E20.None");
   });
 });
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -76,15 +76,22 @@ export class Essence20Item extends Item {
         content: content,
       });
     } else if (this.type == 'weapon') {
-      const dataset = { skill: this.system.classification.skill };
-      const skillRollOptions = await this._dice.getSkillRollOptions(dataset, this.actor);
+      const skill = this.system.classification.skill;
+      const essence = CONFIG.E20.skillToEssence[skill];
+      const shift = this.actor.system.skills[essence][skill].shift
+      const weaponDataset = {
+        ...dataset,
+        shift,
+        skill,
+      };
+
+      const skillRollOptions = await this._dice.getSkillRollOptions(weaponDataset);
 
       if (skillRollOptions.cancelled) {
         return;
       }
 
-      const weapon = this.actor.items.get(this._id);
-      this._dice.rollSkill(dataset, skillRollOptions, this.actor, weapon);
+      this._dice.rollSkill(weaponDataset, skillRollOptions, this.actor, this);
 
       const classFeature = this.actor.items.get(weapon.system.classFeatureId);
       if (classFeature) {

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -78,22 +78,17 @@ export class Essence20Item extends Item {
     } else if (this.type == 'weapon') {
       const skill = this.system.classification.skill;
       const essence = CONFIG.E20.skillToEssence[skill];
-      const shift = this.actor.system.skills[essence][skill].shift
+      const shift = this.actor.system.skills[essence][skill].shift;
       const weaponDataset = {
         ...dataset,
         shift,
         skill,
       };
 
-      const skillRollOptions = await this._dice.getSkillRollOptions(weaponDataset);
+      this._dice.handleWeaponRoll(weaponDataset, this.actor, this);
 
-      if (skillRollOptions.cancelled) {
-        return;
-      }
-
-      this._dice.rollSkill(weaponDataset, skillRollOptions, this.actor, this);
-
-      const classFeature = this.actor.items.get(weapon.system.classFeatureId);
+      // Decrement class feature, if applicable
+      const classFeature = this.actor.items.get(this.system.classFeatureId);
       if (classFeature) {
         classFeature.update({ ["system.uses.value"]: Math.max(0, classFeature.system.uses.value - 1) });
       }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -360,7 +360,7 @@ export class Essence20ActorSheet extends ActorSheet {
 
     // Handle type-specific rolls.
     if (rollType == 'skill') {
-      const skillRollOptions = await this._dice.getSkillRollOptions(dataset, this.actor);
+      const skillRollOptions = await this._dice.getSkillRollOptions(dataset);
 
       if (skillRollOptions.cancelled) {
         return;

--- a/templates/actor/parts/actor-weapons.hbs
+++ b/templates/actor/parts/actor-weapons.hbs
@@ -7,7 +7,7 @@
   {{/inline}}
 
   {{#*inline "roll-button" item}}
-    <a class="rollable" data-roll-type="weapon" data-skill="{{item.system.classification.skill}}" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
+    <a class="rollable" data-roll-type="weapon" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
   {{/inline}}
 
   {{#*inline "item-label" item}}


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/244

In this PR:
- This fix makes weapons that use a d20 skill from an actor autoselect "Snag" in the skill roll dialog. This aligns weapons with normal skill roll behavior.
- Removing unused `actor` param from `getSkillRollOptions()`
- Fixing a weapon test

Testing: Weapons that use a d20 skill should select "Snag" in the skill roll dialog, otherwise "Normal" is selected