### PR TITLE
Making room for NPC specialization names; normalizing npc-column use

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -60,7 +60,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -105,7 +105,7 @@
 }
 
 .essence20 .editor-content {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -166,21 +166,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -198,17 +198,17 @@
 }
 
 .dialog .dialog-buttons button.default {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding-top: 6px;
 }
 
@@ -216,7 +216,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -227,7 +227,7 @@
 }
 
 .dialog input {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .app .window-app dialog {
@@ -235,7 +235,7 @@
 }
 
 #module-management .package-list .package-title {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .item-button-container {
@@ -248,39 +248,39 @@
 
 .rollable:hover,
 .rollable:focus {
-  color: rgb(0, 0, 0);
+  color: black;
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-sender {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-metadata {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -530,7 +530,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -617,7 +617,7 @@
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -634,7 +634,7 @@
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -645,11 +645,11 @@
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .tox .tox-editor-container {
-  background: rgb(255, 255, 255);
+  background: white;
 }
 
 .essence20 .tox .tox-edit-area {
@@ -660,7 +660,7 @@
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -773,7 +773,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -794,10 +794,9 @@
 
 .essence20 .npc-defenses {
   list-style: none;
-  margin-right: 3px;
   padding: 6px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   justify-content: center;
@@ -808,20 +807,6 @@
   box-shadow: 4px 4px 0 black;
 }
 
-.essence20 .npc-column-1 {
-  gap: 5px;
-  width: 40%;
-  display: flex;
-  flex-direction: column;
-}
-
-.essence20 .npc-column-2 {
-  gap: 5px;
-  width: 60%;
-  display: flex;
-  flex-direction: column;
-}
-
 .essence20 .npc-row {
   display: flex;
   flex-direction: row;
@@ -829,11 +814,38 @@
   gap: 6px;
 }
 
+.essence20 .npc-column {
+  gap: 6px;
+  display: flex;
+  flex-direction: column;
+}
+
+.essence20 .npc-column.skills {
+  min-width: 290px;
+  max-width: 50%;
+}
+
+.essence20 .npc-column.items {
+  flex-grow: 1;
+}
+
+.essence20 .npc-column.defenses {
+  width: 60%;
+}
+
+.essence20 .npc-column.firepoints {
+  width: 60%;
+}
+
+.essence20 .npc-column.health {
+  width: 40%;
+}
+
 .essence20 .stats-container {
   list-style: none;
   padding: 6px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   background: none;
@@ -843,7 +855,7 @@
 }
 
 .essence20 .stats-row {
-  gap: 10px;
+  gap: 6px;
   flex-grow: 0;
   flex-wrap: nowrap;
 }
@@ -905,7 +917,7 @@
 }
 
 .essence20 .item {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 /* Generic Item Sheet Styling */
@@ -915,7 +927,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -980,7 +992,7 @@
   align-items: center;
   padding: 0 2px;
   border-bottom: 1px solid #b5b1b1;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .items-list .item:last-child {
@@ -1060,7 +1072,7 @@
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding: 6px;
   min-height: none;
 }
@@ -1077,7 +1089,7 @@
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: rgb(163, 163, 163);
+  color: #a3a3a3;
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1131,11 +1143,11 @@ option {
 
 form .notes,
 form .hint {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .span {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .sheet-body {

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -33,6 +33,7 @@
   width: fit-content;
   height: fit-content;
   text-size-adjust: 8;
+  white-space: nowrap;
 }
 
 .essence20 .chip-section {
@@ -41,6 +42,8 @@
   justify-content: flex-start;
   margin-top: 10px;
   margin-bottom: 10px;
+  flex-wrap: wrap;
+  row-gap: 3px;
 }
 
 /* Style the button that is used to open and close the collapsible content */
@@ -626,7 +629,6 @@
   box-shadow: 4px 4px 0 black;
   width: 100%;
   justify-content: left;
-  min-width: 200px;
   flex-grow: 0;
   flex-basis: auto;
 }
@@ -821,24 +823,35 @@
 }
 
 .essence20 .npc-column.skills {
-  min-width: 290px;
-  max-width: 50%;
+  width: 50%;
 }
 
 .essence20 .npc-column.items {
-  flex-grow: 1;
+  width: 50%;
 }
 
 .essence20 .npc-column.defenses {
   width: 60%;
 }
 
-.essence20 .npc-column.firepoints {
-  width: 60%;
-}
-
 .essence20 .npc-column.health {
   width: 40%;
+}
+
+.essence20 .npc-column.skills.vehicle {
+  width: 22%;
+}
+
+.essence20 .npc-column.items.vehicle {
+  width: 78%;
+}
+
+.essence20 .npc-column.skills.zord {
+  width: 22%;
+}
+
+.essence20 .npc-column.items.zord {
+  width: 78%;
 }
 
 .essence20 .stats-container {

--- a/sass/actors/_npc.scss
+++ b/sass/actors/_npc.scss
@@ -36,12 +36,11 @@
 }
 
 .essence20 .npc-column.skills {
-  min-width: 290px;
-  max-width: 50%;
+  width: 50%;
 }
 
 .essence20 .npc-column.items {
-  flex-grow: 1;
+  width: 50%;
 }
 
 .essence20 .npc-column.defenses {
@@ -50,4 +49,20 @@
 
 .essence20 .npc-column.health {
   width: 40%;
+}
+
+.essence20 .npc-column.skills.vehicle {
+  width: 22%;
+}
+
+.essence20 .npc-column.items.vehicle {
+  width: 78%;
+}
+
+.essence20 .npc-column.skills.zord {
+  width: 22%;
+}
+
+.essence20 .npc-column.items.zord {
+  width: 78%;
 }

--- a/sass/actors/_npc.scss
+++ b/sass/actors/_npc.scss
@@ -9,7 +9,6 @@
 
 .essence20 .npc-defenses {
   list-style: none;
-  margin-right: 3px;
   padding: v.$padding;
   overflow-y: auto;
   color: v.$textcolor1;
@@ -23,23 +22,32 @@
   box-shadow: v.$boxshadow;
 }
 
-.essence20 .npc-column-1 {
-  gap: 5px;
-  width: 40%;
-  display: flex;
-  flex-direction: column;
-}
-
-.essence20 .npc-column-2 {
-  gap: 5px;
-  width: 60%;
-  display: flex;
-  flex-direction: column; 
-}
-
 .essence20 .npc-row {
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
   gap: v.$padding;
+}
+
+.essence20 .npc-column {
+  gap: 6px;
+  display: flex;
+  flex-direction: column;
+}
+
+.essence20 .npc-column.skills {
+  min-width: 290px;
+  max-width: 50%;
+}
+
+.essence20 .npc-column.items {
+  flex-grow: 1;
+}
+
+.essence20 .npc-column.defenses {
+  width: 60%;
+}
+
+.essence20 .npc-column.health {
+  width: 40%;
 }

--- a/sass/actors/_stat-containers.scss
+++ b/sass/actors/_stat-containers.scss
@@ -14,7 +14,7 @@
 }
 
 .essence20 .stats-row {
-  gap: 10px;
+  gap: 6px;
   flex-grow: 0;
   flex-wrap: nowrap;
 }

--- a/sass/assets/_chip.scss
+++ b/sass/assets/_chip.scss
@@ -10,6 +10,7 @@
   width: fit-content;
   height: fit-content;
   text-size-adjust: 8;
+  white-space: nowrap;
 }
 
 .essence20 .chip-section {
@@ -18,4 +19,6 @@
   justify-content: flex-start;
   margin-top: 10px;
   margin-bottom: 10px;
+  flex-wrap: wrap;
+  row-gap: 3px;
 }

--- a/sass/assets/_skill.scss
+++ b/sass/assets/_skill.scss
@@ -81,7 +81,6 @@
   box-shadow: v.$boxshadow;
   width: 100%;
   justify-content: left;
-  min-width: 200px;
   flex-grow: 0;
   flex-basis: auto;
 }

--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -14,14 +14,14 @@
     {{!-- Main Tab --}}
     <div class="tab main flexcol" data-group="primary" data-tab="main">
       <div class="npc-row">
-        <div class="npc-column-2">
+        <div class="npc-column defenses">
           {{!-- NPC Essence Scores --}}
           {{> "systems/essence20/templates/actor/parts/actor-npc-essence-scores.hbs"}}
 
           {{!-- NPC Defenses --}}
           {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
         </div>
-        <div class="npc-column-1">
+        <div class="npc-column health">
           {{!-- NPC-Health --}}
           <div class="npc-health-container stats-container" style="border-color: {{system.color}};">
             <div class="resource flex-group-center">
@@ -39,11 +39,11 @@
       </div>
 
       <div class="npc-row">
-        <div class="npc-column-1">
+        <div class="npc-column skills">
           {{!-- Skills --}}
           {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
         </div>
-        <div class="npc-column-2">
+        <div class="npc-column items">
           {{!-- Weapons --}}
           {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
           {{!-- Hang-ups --}}

--- a/templates/actor/actor-vehicle-sheet.hbs
+++ b/templates/actor/actor-vehicle-sheet.hbs
@@ -31,11 +31,11 @@
       {{> "systems/essence20/templates/actor/parts/actor-common.hbs"}}
 
       <div class="npc-row">
-        <div class="npc-column skills">
+        <div class="npc-column skills vehicle">
           {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
         </div>
 
-        <div class="npc-column items">
+        <div class="npc-column items vehicle">
           {{!--NPC Weapons--}}
           {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
           {{!--NPC Traits--}}

--- a/templates/actor/actor-vehicle-sheet.hbs
+++ b/templates/actor/actor-vehicle-sheet.hbs
@@ -13,28 +13,29 @@
     {{!-- Main Tab --}}
     <div class="tab main flexcol" data-group="primary" data-tab="main">
       <div class="npc-row">
-        <div class="npc-column-1">
-          {{!--NPC Defenses--}}
+        {{!--NPC Defenses--}}
+        <div class="npc-column" style="width: 40%;">
           {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
         </div>
 
-        <div class="npc-column-2">
-          {{!--Firepoint Descriptions--}}
+        {{!--Firepoint Descriptions--}}
+        <div class="npc-column" style="width: 60%;">
           <div class="stats-container flexcol">
             <textarea name="system.firepoints.description"
               placeholder="{{localize 'E20.VehicleFirepointsDescription'}}">{{system.firepoints.description}}</textarea>
           </div>
         </div>
       </div>
+
       {{!--Common Details--}}
       {{> "systems/essence20/templates/actor/parts/actor-common.hbs"}}
 
       <div class="npc-row">
-        <div class="npc-column-1">
+        <div class="npc-column skills">
           {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
         </div>
 
-        <div class="npc-column-2">
+        <div class="npc-column items">
           {{!--NPC Weapons--}}
           {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
           {{!--NPC Traits--}}

--- a/templates/actor/actor-zord-sheet.hbs
+++ b/templates/actor/actor-zord-sheet.hbs
@@ -16,9 +16,5 @@
     </div>
     {{!-- Zord Common Stats --}}
     {{> "systems/essence20/templates/actor/parts/actor-zord-common.hbs"}}
-
-    {{!-- Megaform Traits --}}
-    {{>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.megaformTraits
-    title='E20.ItemTypeMegaformTraitPlural' dataType='megaformTrait'}}
   </section>
 </form>

--- a/templates/actor/parts/actor-zord-common.hbs
+++ b/templates/actor/parts/actor-zord-common.hbs
@@ -24,11 +24,11 @@
 {{!-- Defenses --}}
 {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
 <div class="npc-row">
-  <div class="npc-column skills">
+  <div class="npc-column skills zord">
     {{!-- Skills --}}
     {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
   </div>
-  <div class="npc-column items">
+  <div class="npc-column items zord">
     {{!-- Weapons --}}
     {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
     {{!-- Features --}}

--- a/templates/actor/parts/actor-zord-common.hbs
+++ b/templates/actor/parts/actor-zord-common.hbs
@@ -24,15 +24,18 @@
 {{!-- Defenses --}}
 {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
 <div class="npc-row">
-  <div class="npc-column-1">
+  <div class="npc-column skills">
     {{!-- Skills --}}
     {{> "systems/essence20/templates/actor/parts/actor-accordion-skills.hbs"}}
   </div>
-  <div class="npc-column-2">
+  <div class="npc-column items">
     {{!-- Weapons --}}
     {{> "systems/essence20/templates/actor/parts/actor-weapons.hbs"}}
     {{!-- Features --}}
-    {{> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.features
-    title='E20.ItemTypeFeaturePlural' dataType='feature'}}
+    {{> "systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.features title='E20.ItemTypeFeaturePlural' dataType='feature'}}
+    {{!-- Megaform Traits --}}
+    {{#ifEquals @root.actor.type 'zord'}}
+    {{>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.megaformTraits title='E20.ItemTypeMegaformTraitPlural' dataType='megaformTrait'}}
+    {{/ifEquals}}
   </div>
 </div>


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/254

In this PR:
- Fixes the input for NPC specialization names so they're not very small for the default window size
- Widths of NPC/vehicle/zord/mfz skills are only as wide as they need to be. For some it would probably look better to have the skill headers and inputs on the same line, but this would be a bit of work.
- Had to tweak wrapping behavior for item chips
- Normalizing the use of `npc-column` throughout
- Normalizing some gap sizes as well (6px)
- Put Megaform Traits in the same column as other Zord items

Testing:
- NPC, Vehicle, Zord, and MFZ sheets should look almost the same as before
- The accordion skill containers for these sheets now have an appropriate width
- Chips for items should wrap correctly