### PR TITLE
Approved: Creating separators for accordion skills by essences

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -552,7 +552,6 @@
   font-size: 1.125em;
   align-items: center;
   flex-wrap: nowrap;
-  margin-top: 5px;
 }
 
 .essence20 .skill-header .skill-roll {
@@ -739,15 +738,16 @@
 .essence20 .essence-header {
   text-align: center;
   margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.essence20 .essence-header.strength {
+  margin-bottom: 0;
 }
 
 .essence20 .essence-header .essence-label {
   font-size: 1.5em;
   vertical-align: middle;
-}
-
-.essence20 .essence-header .conditioning-label {
-  text-align: right;
 }
 
 .essence20 .essences {
@@ -852,6 +852,27 @@
 
 .essence20 .npc-column.items.zord {
   width: 78%;
+}
+
+.essence20 .skill-separator {
+  display: flex;
+  align-items: center;
+  text-align: center;
+}
+
+.essence20 .skill-separator::before,
+.essence20 .skill-separator::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid #b5b1b1;
+}
+
+.essence20 .skill-separator:not(:empty)::before {
+  margin-right: 0.25em;
+}
+
+.essence20 .skill-separator:not(:empty)::after {
+  margin-left: 0.25em;
 }
 
 .essence20 .stats-container {

--- a/sass/actors/_essence.scss
+++ b/sass/actors/_essence.scss
@@ -1,15 +1,16 @@
 .essence20 .essence-header {
   text-align: center;
   margin-top: 5px;
+  margin-bottom: 5px;
+}
+
+.essence20 .essence-header.strength {
+  margin-bottom: 0;
 }
 
 .essence20 .essence-header .essence-label {
   font-size: 1.5em;
   vertical-align: middle;
-}
-
-.essence20 .essence-header .conditioning-label {
-  text-align: right;
 }
 
 .essence20 .essences {

--- a/sass/actors/_npc.scss
+++ b/sass/actors/_npc.scss
@@ -66,3 +66,24 @@
 .essence20 .npc-column.items.zord {
   width: 78%;
 }
+
+.essence20 .skill-separator {
+  display: flex;
+  align-items: center;
+  text-align: center;
+}
+
+.essence20 .skill-separator::before,
+.essence20 .skill-separator::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid #b5b1b1;
+}
+
+.essence20 .skill-separator:not(:empty)::before {
+  margin-right: .25em;
+}
+
+.essence20 .skill-separator:not(:empty)::after {
+  margin-left: .25em;
+}

--- a/sass/assets/_skill.scss
+++ b/sass/assets/_skill.scss
@@ -4,7 +4,6 @@
   font-size: 1.125em;
   align-items: center;
   flex-wrap: nowrap;
-  margin-top: 5px;
 }
 
 .essence20 .skill-header .skill-roll {

--- a/templates/actor/parts/actor-accordion-skills.hbs
+++ b/templates/actor/parts/actor-accordion-skills.hbs
@@ -5,6 +5,8 @@
   </div>
 
   {{#each system.skills as |skills essence|}}
+    <div class="skill-separator">{{localize (lookup @root.config.essences essence)}}</div>
+
     {{#each skills as |fields skill|}}
       {{#if (lookup @root.displayedNpcSkills skill)}}
       <div>

--- a/templates/actor/parts/actor-pc-skills.hbs
+++ b/templates/actor/parts/actor-pc-skills.hbs
@@ -5,7 +5,7 @@
       <span class="essence-label">{{localize config.essences.strength}}</span>
       <input class="two-digit-input" type="number" name="system.essences.strength" value="{{system.essences.strength}}" />
     </div>
-    <div class="essence-header" style="margin-bottom: 5px;">
+    <div class="essence-header">
       <span>{{localize 'E20.ActorConditioning'}}</span>
       <input class="one-digit-input" type="number" name="system.conditioning" value="{{system.conditioning}}" />
     </div>

--- a/templates/actor/parts/actor-pc-skills.hbs
+++ b/templates/actor/parts/actor-pc-skills.hbs
@@ -1,11 +1,11 @@
 <div class="skillscontainer">
   {{!-- Strength --}}
   <div class="skills-container" style="border-color: {{system.color}};">
-    <div class="essence-header">
+    <div class="essence-header strength">
       <span class="essence-label">{{localize config.essences.strength}}</span>
       <input class="two-digit-input" type="number" name="system.essences.strength" value="{{system.essences.strength}}" />
     </div>
-    <div class="essence-header">
+    <div class="essence-header" style="margin-bottom: 5px;">
       <span>{{localize 'E20.ActorConditioning'}}</span>
       <input class="one-digit-input" type="number" name="system.conditioning" value="{{system.conditioning}}" />
     </div>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/267

In this MR:
- For non-PC sheets, this creates a labeled separator to show the user the essence groupings of the skills
- Example NPC (collapsed) and Zord (expanded)
![image](https://user-images.githubusercontent.com/41161497/218887047-f54acb76-3f69-400c-8c83-ffacf3a63bcf.png)
- Some related spacing adjustments
- Any suggestions to improve are welcome

Testing: Skills for all actor sheets look good!