### PR TITLE
Swapping social and smarts in NPC essence container

### DIFF
--- a/template.json
+++ b/template.json
@@ -146,8 +146,8 @@
         "essences": {
           "strength": 3,
           "speed": 3,
-          "social": 3,
-          "smarts": 3
+          "smarts": 3,
+          "social": 3
         },
         "level": 1,
         "notes": ""

--- a/templates/actor/parts/actor-npc-essence-scores.hbs
+++ b/templates/actor/parts/actor-npc-essence-scores.hbs
@@ -1,9 +1,9 @@
 <div style="flex-grow: 0;">
   <div class="npc-defenses" style="border-color: {{system.color}};">
-    {{#each system.essences as |score skill|}}
+    {{#each @root.config.essences as |name essence|}}
     <div class="resource flexcol">
-      <label class="resource flex-group-center">{{localize (lookup @root.config.essences skill)}}</label>
-      <input type="number" class="centered-input" name="system.essences.{{skill}}" value="{{score}}" />
+      <label class="resource flex-group-center">{{localize name}}</label>
+      <input type="number" class="centered-input" name="system.essences.{{essence}}" value="{{lookup @root.system.essences essence}}" />
     </div>
     {{/each}}
   </div>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/272

In this MR:
- Social and Smarts were not in the "correct" order in `template.json`, so when we iterated over it the order would be wrong there too
- Keys in an object shouldn't be relied upon for ordering, which we are doing a ton of for skills etc. Instead, a list of correctly ordered essences from `config.mjs` are now iterated over.
- Everything in `template.json` should really be alphabetical, so doing that for essences
- NPC essence scores are the only place I see `system.essences` iterated over, so we should be good elsewhere
- Not doing this for skills and everything else for now so this PR doesn't blow up, but I'll create an issue

Testing: NPC essence order should be Strength -> Speed -> Smarts -> Social and work correctly