### PR TITLE
Approved: Swapping Smarts and Social for NPCs

### DIFF
--- a/template.json
+++ b/template.json
@@ -146,8 +146,8 @@
         "essences": {
           "strength": 3,
           "speed": 3,
-          "social": 3,
-          "smarts": 3
+          "smarts": 3,
+          "social": 3
         },
         "level": 1,
         "notes": ""
@@ -227,10 +227,10 @@
         "evasion": {
           "value": 10
         },
-        "willpower": {
+        "cleverness": {
           "value": null
         },
-        "cleverness": {
+        "willpower": {
           "value": null
         }
       },

--- a/template.json
+++ b/template.json
@@ -227,10 +227,10 @@
         "evasion": {
           "value": 10
         },
-        "cleverness": {
+        "willpower": {
           "value": null
         },
-        "willpower": {
+        "cleverness": {
           "value": null
         }
       },


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/272

In this PR:
- Social and Smarts were not in the "correct" order in `template.json` for NPC essences and, so when we iterated over them the order would be wrong there too
- Confirmed no migration needed

Testing:
- NPC essence order should be Strength -> Speed -> Smarts -> Social and work correctly