### PR TITLE
Approved: Improving layouts for Zord and MFZ sheets

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -63,7 +63,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -108,7 +108,7 @@
 }
 
 .essence20 .editor-content {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -169,21 +169,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -201,17 +201,17 @@
 }
 
 .dialog .dialog-buttons button.default {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding-top: 6px;
 }
 
@@ -219,7 +219,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -230,7 +230,7 @@
 }
 
 .dialog input {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .app .window-app dialog {
@@ -238,7 +238,7 @@
 }
 
 #module-management .package-list .package-title {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .item-button-container {
@@ -251,39 +251,39 @@
 
 .rollable:hover,
 .rollable:focus {
-  color: rgb(0, 0, 0);
+  color: black;
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-sender {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-metadata {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -533,7 +533,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -619,7 +619,7 @@
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -635,7 +635,7 @@
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -646,11 +646,11 @@
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .tox .tox-editor-container {
-  background: rgb(255, 255, 255);
+  background: white;
 }
 
 .essence20 .tox .tox-edit-area {
@@ -661,7 +661,7 @@
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -771,7 +771,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -875,15 +875,15 @@
 .essence20 .stats-container {
   list-style: none;
   padding: 6px;
-  height: 100%;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
   box-shadow: 4px 4px 0 black;
+  min-height: 72px;
 }
 
 .essence20 .stats-row {
@@ -949,7 +949,7 @@
 }
 
 .essence20 .item {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 /* Generic Item Sheet Styling */
@@ -959,7 +959,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1024,7 +1024,7 @@
   align-items: center;
   padding: 0 2px;
   border-bottom: 1px solid #b5b1b1;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .items-list .item:last-child {
@@ -1104,7 +1104,7 @@
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding: 6px;
   min-height: none;
 }
@@ -1121,7 +1121,7 @@
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: rgb(163, 163, 163);
+  color: #a3a3a3;
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1175,11 +1175,11 @@ option {
 
 form .notes,
 form .hint {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .span {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .sheet-body {

--- a/sass/actors/_stat-containers.scss
+++ b/sass/actors/_stat-containers.scss
@@ -3,7 +3,6 @@
 .essence20 .stats-container {
   list-style: none;
   padding: v.$padding;
-  height: 100%;
   overflow-y: auto;
   color: v.$textcolor1;
   flex-basis: auto;
@@ -12,6 +11,7 @@
   border: v.$border;
   border-radius: v.$border-radius;
   box-shadow: v.$boxshadow;
+  min-height: 72px;
 }
 
 .essence20 .stats-row {

--- a/templates/actor/actor-megaformZord-sheet.hbs
+++ b/templates/actor/actor-megaformZord-sheet.hbs
@@ -4,6 +4,9 @@
 
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
+    {{!-- Defenses --}}
+    {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+
     {{!-- Zord Common Stats --}}
     {{> "systems/essence20/templates/actor/parts/actor-zord-common.hbs"}}
 

--- a/templates/actor/actor-zord-sheet.hbs
+++ b/templates/actor/actor-zord-sheet.hbs
@@ -5,11 +5,14 @@
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
     <div class="npc-row">
-      {{!-- Defenses --}}
-      {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
-
-      {{!-- Health --}}
-      {{> "systems/essence20/templates/actor/parts/actor-health.hbs"}}
+      <div class="npc-defenses">
+        {{!-- Defenses --}}
+        {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+      </div>
+      <div class="npc-health">
+        {{!-- Health --}}
+        {{> "systems/essence20/templates/actor/parts/actor-health.hbs"}}
+      </div>
     </div>
 
     {{!-- Zord Common Stats --}}

--- a/templates/actor/actor-zord-sheet.hbs
+++ b/templates/actor/actor-zord-sheet.hbs
@@ -4,17 +4,12 @@
 
   {{!-- Actor Sheet Body --}}
   <section class="sheet-body flexcol">
-    <div class="sheet-body flexrow">
+    <div class="npc-row">
+      {{!-- Defenses --}}
+      {{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
+
       {{!-- Health --}}
       {{> "systems/essence20/templates/actor/parts/actor-health.hbs"}}
-
-      {{!-- Conditioning --}}
-      <div class="stats-container flex-group-center">
-        <div class="resource flexcol flex-group-center">
-          <span>{{localize 'E20.ActorConditioning'}}</span>
-          <input class="one-digit-input" type="number" name="system.conditioning" value="{{system.conditioning}}" />
-        </div>
-      </div>
     </div>
 
     {{!-- Zord Common Stats --}}

--- a/templates/actor/parts/actor-health.hbs
+++ b/templates/actor/parts/actor-health.hbs
@@ -1,5 +1,5 @@
 <div class="stats-container flexrow flex-group-center" style="border-color: {{system.color}};">
-  <div class="flexcol flex-group-center" style="height: 90%;">
+  <div class="flexcol flex-group-center">
     <label>{{localize 'E20.ActorHealth'}}</label>
     <div class="flexrow" style="align-items: center;">
       <input class="centered-input" type="number" name="system.health.value" value="{{system.health.value}}" />

--- a/templates/actor/parts/actor-zord-common.hbs
+++ b/templates/actor/parts/actor-zord-common.hbs
@@ -21,8 +21,6 @@
   </div>
 </div>
 
-{{!-- Defenses --}}
-{{> "systems/essence20/templates/actor/parts/actor-npc-defenses.hbs"}}
 <div class="npc-row">
   <div class="npc-skills zord">
     {{!-- Skills --}}

--- a/templates/actor/parts/headers/actor-zord-header.hbs
+++ b/templates/actor/parts/headers/actor-zord-header.hbs
@@ -8,7 +8,11 @@
   <label for="ranger" class="resource-label">{{ localize 'E20.ZordRanger' }}</label>
   <input type="text" name="system.ranger" value="{{system.ranger}}" />
 </div>
-<div class="flexcol">
+<div>
+  <label for="conditioning" class="resource-label">{{ localize 'E20.ActorConditioning' }}</label>
+  <input type="number" name="system.conditioning" value="{{system.conditioning}}" />
+</div>
+<div class="flexcol flex-group-center" style="flex-grow: 0;">
   <label for="iscombiner" class="resource-label">{{localize 'E20.MegaformZordCombiner'}}</label>
   <input type="checkbox" name="system.isCombiner" {{checked system.isCombiner}} />
 </div>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/265
Closes https://github.com/WookieeMatt/Essence20/issues/264

In this PR:
- Old layouts:
![image](https://user-images.githubusercontent.com/41161497/219880191-93e58748-68ce-4908-a8c8-765473b80e40.png)
- New layouts:
![image](https://user-images.githubusercontent.com/41161497/219880162-0db861d7-c8f9-4470-8e05-849f1a84d157.png)
- Also setting `stats-container` min height to 72px, which is how much the initiative container needs. This way none of them look weirdly short.

Testing: Zord and MFZ sheets look nice