### PR TITLE
Spells can now be specialized

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -388,7 +388,7 @@ export class Essence20ActorSheet extends ActorSheet {
         await item.update({ 'system.uses.value': Math.max(0, item.system.uses.value - 1) });
       }
 
-      if (item) return item.roll();
+      if (item) return item.roll(dataset);
     }
   }
 

--- a/template.json
+++ b/template.json
@@ -484,11 +484,12 @@
       "templates": [
         "itemDescription"
       ],
-      "tier": null,
       "circle": null,
       "cost": 0,
       "duration": "",
-      "range": 0
+      "isSpecialized": false,
+      "range": 0,
+      "tier": null
     },
     "threatPower": {
       "actionType": "",

--- a/templates/actor/parts/items/spell/container.hbs
+++ b/templates/actor/parts/items/spell/container.hbs
@@ -1,6 +1,9 @@
 {{#>"systems/essence20/templates/actor/parts/actor-collapsible-item-container.hbs" items=@root.spells title="E20.ItemTypeSpellPlural" dataType="spell"}}
   {{#*inline "roll-button" item}}
-    <a class="rollable" data-roll-type="spell" data-downshift={{item.system.cost}} title="{{localize 'E20.SpellRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
+    <div class="flexrow" style="flex-wrap: nowrap; gap: 5px;">
+      <a class="rollable" data-roll-type="spell" data-downshift={{item.system.cost}} data-is-specialized="{{item.system.isSpecialized}}" title="{{localize "E20.SpellRollTitle"}}"><i class="fas fa-dice-d20"></i></a>
+      <input class="inline-edit item-label-checkbox" data-field="system.isSpecialized" type="checkbox" name="spell.{{@index}}.isSpecialized" {{checked item.system.isSpecialized}} title="{{localize "E20.RollIsSpecialized"}}"/>
+    </div>
   {{/inline}}
 
   {{#*inline "expand-details" item}}


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/297

Added a checkbox next to Spells so they can be specialized

Testing: The roll dialog should populate the specialized checkbox if the spell is specialized