### PR TITLE
Fixing flex gap for item sheets that have tabs

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -907,6 +907,10 @@
   gap: 10px;
 }
 
+.essence20 .sheet-body.item-sheet .tab {
+  gap: 0px;
+}
+
 .essence20 .tabs .item {
   background: #5f5f5f;
   border: 1px solid;

--- a/sass/actors/_tabs.scss
+++ b/sass/actors/_tabs.scss
@@ -13,6 +13,10 @@
   gap: 10px;
 }
 
+.essence20 .sheet-body.item-sheet .tab {
+  gap: 0px;
+}
+
 .essence20 .tabs .item {
   background: v.$background-b;
   border: 1px solid;

--- a/templates/item/item-spell-sheet.hbs
+++ b/templates/item/item-spell-sheet.hbs
@@ -3,7 +3,7 @@
   {{!-- Item Sheet Header --}}
   {{> "systems/essence20/templates/item/parts/item-header.hbs"}}
 
-    {{!-- Tabs --}}
+  {{!-- Tabs --}}
   <nav class="sheet-tabs tabs" data-group="primary">
     <a class="item" data-tab="main">{{ localize "E20.TabMain" }}</a>
     <a class="item" data-tab="effects">{{ localize "E20.TabEffects" }}</a>
@@ -66,5 +66,6 @@
       {{!-- Effects Section --}}
       {{> "systems/essence20/templates/item/parts/item-active-effects.hbs"}}
     </div>
-  </section>  
+  </section>
+
 </form>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/299
![image](https://user-images.githubusercontent.com/41161497/227660230-c9d744dd-7314-45db-b809-34a08b7af8e8.png)
Having a `tab` div inside the `sheet-body` section caused a CSS selector to set `gap` to 10 for fields in some item sheets.  Normally it's only supposed to apply to actor sheets, so I create a more specific one for tabbed item sheets.

Testing: Items with tabs (such as spells) should have no gap between fields.