### PR TITLE
Fixing chip spacing for TP and Weapon

### DIFF
--- a/templates/actor/parts/items/magicBauble/details.hbs
+++ b/templates/actor/parts/items/magicBauble/details.hbs
@@ -8,5 +8,4 @@
   {{#if item.system.range}}
   <span class="chip" name="chip.magicBauble.range">{{localize 'E20.MagicBaubleRange'}}: {{item.system.range}}</span>
   {{/if}}
-
 </div>

--- a/templates/actor/parts/items/spell/details.hbs
+++ b/templates/actor/parts/items/spell/details.hbs
@@ -8,5 +8,4 @@
   {{#if item.system.range}}
   <span class="chip" name="chip.spell.range">{{localize 'E20.SpellRange'}}: {{item.system.range}}</span>
   {{/if}}
-
 </div>

--- a/templates/actor/parts/items/threatPower/details.hbs
+++ b/templates/actor/parts/items/threatPower/details.hbs
@@ -1,11 +1,13 @@
 <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
 
-{{#if item.system.actionType}}
-<span class="chip" name="chip.actionType">{{item.system.actionType}}</span>
-{{/if}}
-{{#if item.system.cost}}
-<span class="chip" name="chip.cost">{{localize 'E20.ThreatPowerCost'}}: {{item.system.cost}}</span>
-{{/if}}
-{{#if item.system.limited}}
-<span class="chip" name="chip.limited">{{localize 'E20.ThreatPowerLimited'}}</span>
-{{/if}}
+<div class="chip-section">
+  {{#if item.system.actionType}}
+  <span class="chip" name="chip.actionType">{{item.system.actionType}}</span>
+  {{/if}}
+  {{#if item.system.cost}}
+  <span class="chip" name="chip.cost">{{localize 'E20.ThreatPowerCost'}}: {{item.system.cost}}</span>
+  {{/if}}
+  {{#if item.system.limited}}
+  <span class="chip" name="chip.limited">{{localize 'E20.ThreatPowerLimited'}}</span>
+  {{/if}}
+</div>

--- a/templates/actor/parts/items/weapon/details.hbs
+++ b/templates/actor/parts/items/weapon/details.hbs
@@ -3,7 +3,9 @@
 <div>{{localize 'E20.WeaponUpgrades'}}: {{item.system.upgrades}}</div>
 <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
 
-<span class="chip" name="chip.weapon.classification">{{localize (lookup @root.config.essenceSkills item.system.classification.skill)}} {{localize (lookup @root.config.weaponSizes item.system.classification.size)}} {{localize (lookup @root.config.weaponStyles item.system.classification.style)}}</span>
-<span class="chip" name="chip.weapon.availability">{{localize (lookup @root.config.availabilities item.system.availability)}}</span>
-<span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
-<span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
+<div class="chip-section">
+  <span class="chip" name="chip.weapon.classification">{{localize (lookup @root.config.essenceSkills item.system.classification.skill)}} {{localize (lookup @root.config.weaponSizes item.system.classification.size)}} {{localize (lookup @root.config.weaponStyles item.system.classification.style)}}</span>
+  <span class="chip" name="chip.weapon.availability">{{localize (lookup @root.config.availabilities item.system.availability)}}</span>
+  <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
+  <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
+</div>


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/41161497/227732044-490accc8-e8c0-4cda-a1ef-0408587df93a.png)
New:
![image](https://user-images.githubusercontent.com/41161497/227732030-1183f361-3503-40b9-bc56-e28badf15443.png)

Forgot to user `chip-section` for a couple items, which improves spacing.

Testing: Chips for TPs and Weapons should have better spacing in sheets and chat cards