### PR TITLE
All items in collapsible containers now have info buttons

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,7 +1,5 @@
 import { Dice } from "../dice.mjs";
 
-const STANDARD_CHAT_CARD_ITEMS = ['altMode', 'armor', 'bond', 'classFeature', 'feature', 'gear', 'hangUp', 'megaformTrait', 'origin', 'threatPower', 'trait'];
-
 /**
  * Extend the basic Item with some very simple modifications.
  * @extends {Item}
@@ -40,7 +38,25 @@ export class Essence20Item extends Item {
    * @private
    */
   async roll(dataset) {
-    if (this.type == 'perk') {
+    if (dataset.rollType == 'info') {
+      // Initialize chat data.
+      const speaker = ChatMessage.getSpeaker({ actor: this.actor });
+      const rollMode = game.settings.get('core', 'rollMode');
+      const label = `[${this.type}] ${this.name}`;
+
+      const template = `systems/essence20/templates/actor/parts/items/${this.type}/details.hbs`;
+      const templateData = {
+        config: CONFIG.E20,
+        item: this,
+      }
+
+      ChatMessage.create({
+        speaker: speaker,
+        rollMode: rollMode,
+        flavor: label,
+        content: await renderTemplate(template, templateData),
+      });
+    } else if (this.type == 'perk') {
       // Initialize chat data.
       const speaker = ChatMessage.getSpeaker({ actor: this.actor });
       const rollMode = game.settings.get('core', 'rollMode');
@@ -76,24 +92,6 @@ export class Essence20Item extends Item {
         rollMode: rollMode,
         flavor: label,
         content: content,
-      });
-    } else if (STANDARD_CHAT_CARD_ITEMS.includes(this.type)) {
-      // Initialize chat data.
-      const speaker = ChatMessage.getSpeaker({ actor: this.actor });
-      const rollMode = game.settings.get('core', 'rollMode');
-      const label = `[${this.type}] ${this.name}`;
-
-      const template = `systems/essence20/templates/actor/parts/items/${this.type}/details.hbs`;
-      const templateData = {
-        config: CONFIG.E20,
-        item: this,
-      }
-
-      ChatMessage.create({
-        speaker: speaker,
-        rollMode: rollMode,
-        flavor: label,
-        content: await renderTemplate(template, templateData),
       });
     } else if (this.type == 'weapon') {
       const skill = this.system.classification.skill;

--- a/templates/actor/parts/actor-collapsible-item-container.hbs
+++ b/templates/actor/parts/actor-collapsible-item-container.hbs
@@ -13,10 +13,12 @@
       {{!-- Item label and buttons --}}
       <div class="flexrow item-label">
         <div class="item-image" style="flex-grow: 0;">
-          {{#> roll-button item=item}}
-          {{!-- Custom roll button here, or use default below --}}
-          <a class="rollable" data-roll-type={{item.type}} title="{{localize 'E20.ItemRollTitle'}}"><i class="fas fa-message-lines"></i></a>
-          {{/roll-button}}
+          <div class="flexrow" style="flex-wrap: nowrap; gap: 5px;">
+            <a class="rollable" data-roll-type="info" title="{{localize 'E20.ItemRollTitle'}}"><i class="fas fa-message-lines"></i></a>
+            {{#> roll-button item=item}}
+            {{!-- Custom roll button here --}}
+            {{/roll-button}}
+          </div>
         </div>
         {{#if (isdefined item.system.equipped)}}
         <div style="flex-grow: 0;">


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/305

In this PR:
- Instead of an info button being the default for items, it's now moved out of the inline partial. This way it's present for all items, most notably Weapons, Spells, and Baubles, in case you don't want to actually roll them.
- Uses a new `rollType` of `info` to differentiate from actual rolls

Testing:
- All items in collapsible info containers should have info buttons
- Clicking them should display whatever is displayed when you expand the item on the actor sheet
- Normal rolls should not be affected