### PR TITLE
Adding Spells to NPC sheet

### DIFF
--- a/templates/actor/actor-npc-sheet.hbs
+++ b/templates/actor/actor-npc-sheet.hbs
@@ -47,6 +47,7 @@
           {{> "systems/essence20/templates/actor/parts/items/threatPower/container.hbs"}}
           {{> "systems/essence20/templates/actor/parts/items/perk/container.hbs"}}
           {{> "systems/essence20/templates/actor/parts/items/gear/container.hbs"}}
+          {{> "systems/essence20/templates/actor/parts/items/spell/container.hbs"}}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adding Spell container to NPC Sheet as we added spellcasting but not the spells. 

Testing
Verify NPC sheet has the spell container at the bottom right. 