### PR TITLE
Fixing initiative formula not updating

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -59,7 +59,9 @@ export class Dice {
   async handleInitiativeRoll(actor) {
     const skillRollOptions = await this.getSkillRollOptions({ shift: actor.system.initiative.shift}, this.actor);
     const finalShift = this._getFinalShift(skillRollOptions, actor.system.initiative.shift)
-    actor.system.initiative.formula = this._getFormula(false, skillRollOptions, finalShift, actor.system.initiative.modifier);
+    await actor.update({
+      "system.initiative.formula": this._getFormula(false, skillRollOptions, finalShift, actor.system.initiative.modifier),
+    });
     actor.rollInitiative({ createCombatants: true });
   }
 

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -82,7 +82,7 @@ const statusEffects = [
     id: 'unconscious',
     label: 'E20.StatusUnconscious'
   }
-]; 
+];
 
 function registerSystemSettings() {
   game.settings.register("essence20", "systemMigrationVersion", {
@@ -141,7 +141,7 @@ Hooks.once('init', async function () {
    * @type {String}
    */
   CONFIG.Combat.initiative = {
-    formula: "@initiativeFormula",
+    formula: "@initiative.formula",
   };
 
   // Define custom Document classes


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/344

Turns out we weren't actually updating the actor's initiative formula correctly when a roll was made. I think we can get rid of `initiativeFormula` in the template.json, but we can leave it for later.

Testing:
1. Make a PR character
2. Set initiative to non-d20
3. Put actor token on scene
4. Roll initiative from the actor sheet
5. Initiative formula should be correct
6. Probably test rolling from the token sheet as well, and any other ways you can think of breaking it.