### PR TITLE
Fixing item sheet label wrapping

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -149,7 +149,7 @@
     "EssenceStrength": "Strength",
     "FactionAutobots": "Autobots",
     "FactionDecepticons": "Decepticons",
-    "GearEffectArea": "Effect Area/Length/Radius",
+    "GearEffectArea": "Effect Area/Len/Rad",
     "GearEffectShape": "Effect Shape",
     "GearLightRange": "Light Range",
     "GearQuantity": "Quantity",

--- a/templates/item/parts/item-sheet-field.hbs
+++ b/templates/item/parts/item-sheet-field.hbs
@@ -1,6 +1,6 @@
 <div class="flexrow item-field">
   <div class="flexrow" style="align-items: center; gap: 5px;">
-    <label style="flex-grow: 0;">{{localize label}}</label>
+    <label style="flex-grow: 0; white-space: nowrap;">{{localize label}}</label>
     {{#> item-field-edit}}
     {{!-- Custom item field edit button goes here --}}
     {{/item-field-edit}}


### PR DESCRIPTION
Bad:
![image](https://user-images.githubusercontent.com/41161497/229947510-32143dec-a979-4c97-a0bc-e7ba910fb586.png)

Testing: All item sheets should have labels without text wrapping. Origin is currently being worked on in https://github.com/WookieeMatt/Essence20/pull/347, so leaving that alone for now.

