### PR TITLE
Fixing final shift calculation, initiative

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -64,8 +64,10 @@ export class Dice {
     };
 
     const skillRollOptions = await this.getSkillRollOptions(dataset);
-    const finalShift = this._getFinalShift(skillRollOptions, actor.system.initiative.shift, this._config.initiativeShiftList)
-    actor.system.initiative.formula = this._getFormula(skillRollOptions.isSpecialized, skillRollOptions, finalShift, actor.system.initiative.modifier);
+    const finalShift = this._getFinalShift(
+      skillRollOptions, actor.system.initiative.shift, this._config.initiativeShiftList)
+    actor.system.initiative.formula = this._getFormula(
+      skillRollOptions.isSpecialized, skillRollOptions, finalShift, actor.system.initiative.modifier);
     actor.rollInitiative({ createCombatants: true });
   }
 
@@ -268,10 +270,11 @@ export class Dice {
    */
   _getFinalShift(skillRollOptions, initialShift, shiftList=this._config.skillShiftList) {
     // Apply the skill roll options dialog shifts to the roller's normal shift
+    const optionsShiftTotal = skillRollOptions.shiftUp - skillRollOptions.shiftDown;
     const initialShiftIndex = shiftList.findIndex(s => s == initialShift);
     const finalShiftIndex = Math.max(
       0,
-      Math.min(shiftList.length - 1, initialShiftIndex + skillRollOptions.shiftUp - skillRollOptions.shiftDown)
+      Math.min(shiftList.length - 1, initialShiftIndex - optionsShiftTotal)
     );
 
     return shiftList[finalShiftIndex];

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -64,7 +64,7 @@ export class Dice {
     };
 
     const skillRollOptions = await this.getSkillRollOptions(dataset);
-    const finalShift = this._getFinalShift(skillRollOptions, actor.system.initiative.shift)
+    const finalShift = this._getFinalShift(skillRollOptions, actor.system.initiative.shift, this._config.initiativeShiftList)
     actor.system.initiative.formula = this._getFormula(skillRollOptions.isSpecialized, skillRollOptions, finalShift, actor.system.initiative.modifier);
     actor.rollInitiative({ createCombatants: true });
   }
@@ -262,16 +262,19 @@ export class Dice {
    * Create final shift from actor skill shift + skill roll options.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().
    * @param {String} initialShift   The initial shift of the skill being rolled.
+   * @param {Object} shiftList   The result of getSkillRollOptions().
    * @returns {String}   The resultant shift.
    * @private
    */
-  _getFinalShift(skillRollOptions, initialShift) {
+  _getFinalShift(skillRollOptions, initialShift, shiftList=this._config.skillShiftList) {
     // Apply the skill roll options dialog shifts to the roller's normal shift
-    const optionsShiftTotal = skillRollOptions.shiftUp - skillRollOptions.shiftDown;
-    const initialShiftIndex = this._config.skillShiftList.findIndex(s => s == initialShift);
-    const finalShiftIndex = Math.max(0, Math.min(this._config.skillShiftList.length - 1, initialShiftIndex - optionsShiftTotal));
+    const initialShiftIndex = shiftList.findIndex(s => s == initialShift);
+    const finalShiftIndex = Math.max(
+      0,
+      Math.min(shiftList.length - 1, initialShiftIndex + skillRollOptions.shiftUp - skillRollOptions.shiftDown)
+    );
 
-    return this._config.skillShiftList[finalShiftIndex];
+    return shiftList[finalShiftIndex];
   }
 
   /**

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -262,7 +262,7 @@ export class Dice {
    * Create final shift from actor skill shift + skill roll options.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().
    * @param {String} initialShift   The initial shift of the skill being rolled.
-   * @param {Object} shiftList   The result of getSkillRollOptions().
+   * @param {Object} shiftList   The list of available shifts to use for this roll.
    * @returns {String}   The resultant shift.
    * @private
    */

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -436,6 +436,27 @@ describe("_getFinalShift", () => {
     expect(dice._getFinalShift(skillRollOptions, initialShift)).toEqual(expected);
   });
 
+  test("shifting down the lowest shift", () => {
+    const skillRollOptions = {
+      shiftUp: 0,
+      shiftDown: 1,
+    }
+    const expected = 'd20';
+    const shiftList = ['d2', 'd20'];
+    expect(dice._getFinalShift(skillRollOptions, initialShift, shiftList)).toEqual(expected);
+  });
+
+  test("shifting up the highest shift", () => {
+    const skillRollOptions = {
+      shiftUp: 1,
+      shiftDown: 0,
+    }
+    const initialShift = 'd2';
+    const expected = 'd2';
+    const shiftList = ['d2', 'd20'];
+    expect(dice._getFinalShift(skillRollOptions, initialShift, shiftList)).toEqual(expected);
+  });
+
   test("equal shifts cancelling", () => {
     const skillRollOptions = {
       shiftUp: 1,

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -217,15 +217,15 @@ E20.initiativeShifts = {
 
 // Shifts that are available for rolling initiative in list form
 E20.initiativeShiftList = [
-  "d20",
-  "d2",
-  "d4",
-  "d6",
-  "d8",
-  "d10",
-  "d12",
-  "2d8",
   "3d6",
+  "2d8",
+  "d12",
+  "d10",
+  "d8",
+  "d6",
+  "d4",
+  "d2",
+  "d20",
 ];
 
 // Shifts that are available for rolling skills and require making a roll

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -215,6 +215,19 @@ E20.initiativeShifts = {
   "3d6": "3d6",
 };
 
+// Shifts that are available for rolling initiative in list form
+E20.initiativeShiftList = [
+  "d20",
+  "d2",
+  "d4",
+  "d6",
+  "d8",
+  "d10",
+  "d12",
+  "2d8",
+  "3d6",
+];
+
 // Shifts that are available for rolling skills and require making a roll
 E20.skillRollableShifts = [
   "d2",


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/351

In this PR:
- Fixing final shift calculation for downshifts
- `_getFinalShift()` now accepts a list of shifts available for the roll as an optional param
- New tests

Testing:
- Attempt skill and initiative rolls using various shifts and upshifts/downshifts
- Downshifting d20 initiative should roll it as d20 with snag
- Upshifting 3d6 initiative should roll it as 3d6