### PR TITLE
Fixing/unifying sheet and combat tracker initiative rolls

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -230,7 +230,7 @@
     "RollDialogShiftUp": "Shift up",
     "RollDialogSnag": "Snag",
     "RollDialogTimesToRoll": "Times to roll",
-    "RollDialogTitle": "Configure your skill roll",
+    "RollDialogTitle": "{actor} skill roll",
     "RollIsSpecialized": "Specialized",
     "RollRepeatText": "Roll {index} of {total}",
     "RollRollingFor": "Rolling for",

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -1,14 +1,24 @@
 export class Dice {
   /**
    * Dice constructor.
-   * @param {i18n} i18n   The i18n to use for text localization.
    * @param {Object} config   The config to use for constants.
    * @param {ChatMessage} chatMessage   The ChatMessage to use.
+   * @param {i18n} i18n   The i18n to use for text localization.
    */
-  constructor(i18n, config, chatMessage) {
+  constructor(config, chatMessage, i18n=null) {
     this._i18n = i18n;
     this._config = config;
     this._chatMessage = chatMessage;
+  }
+
+  /**
+   * Localizes the given text.
+   * @param {String} text   The text to localize.
+   * @returns {String}   The localized text.
+   * @private
+   */
+  _localize(text) {
+    return this._i18n ? this._localize(text) : game.i18n.localize(text);
   }
 
   /**
@@ -33,15 +43,15 @@ export class Dice {
 
     return new Promise(resolve => {
       const data = {
-        title: this._i18n.localize('E20.RollDialogTitle'),
+        title: this._localize('E20.RollDialogTitle'),
         content: html,
         buttons: {
           normal: {
-            label: this._i18n.localize('E20.RollDialogRollButton'),
+            label: this._localize('E20.RollDialogRollButton'),
             callback: html => resolve(this._processSkillRollOptions(html[0].querySelector("form"))),
           },
           cancel: {
-            label: this._i18n.localize('E20.RollDialogCancelButton'),
+            label: this._localize('E20.RollDialogCancelButton'),
             callback: html => resolve({ cancelled: true }),
           },
         },
@@ -180,8 +190,8 @@ export class Dice {
     const rolledSkill = dataset.skill;
     const rolledSkillStr = dataset.isSpecialized === 'true'
       ? dataset.specializationName
-      : this._i18n.localize(this._config.essenceSkills[rolledSkill]);
-    const rollingForStr = this._i18n.localize('E20.RollRollingFor')
+      : this._localize(this._config.essenceSkills[rolledSkill]);
+    const rollingForStr = this._localize('E20.RollRollingFor')
     return `${rollingForStr} ${rolledSkillStr}` + this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag);
   }
 
@@ -212,12 +222,12 @@ export class Dice {
    */
   _getWeaponRollLabel(dataset, skillRollOptions, actor, weapon) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = this._i18n.localize(this._config.essenceSkills[rolledSkill]);
-    const attackRollStr = this._i18n.localize('E20.RollTypeAttack');
-    const effectStr = this._i18n.localize('E20.WeaponEffect');
-    const alternateEffectsStr = this._i18n.localize('E20.WeaponAlternateEffects');
-    const classFeatureStr = this._i18n.localize('ITEM.TypeClassfeature');
-    const noneStr = this._i18n.localize('E20.None');
+    const rolledSkillStr = this._localize(this._config.essenceSkills[rolledSkill]);
+    const attackRollStr = this._localize('E20.RollTypeAttack');
+    const effectStr = this._localize('E20.WeaponEffect');
+    const alternateEffectsStr = this._localize('E20.WeaponAlternateEffects');
+    const classFeatureStr = this._localize('ITEM.TypeClassfeature');
+    const noneStr = this._localize('E20.None');
     const classFeatureId = weapon.system.classFeatureId;
 
     let label = `<b>${attackRollStr}</b> - ${weapon.name} (${rolledSkillStr})`
@@ -237,10 +247,10 @@ export class Dice {
    * @private
    */
   _getSpellRollLabel(skillRollOptions, spell) {
-    const rolledSkillStr = this._i18n.localize('E20.EssenceSkillSpellcasting');
-    const spellRollStr = this._i18n.localize('E20.RollTypeSpell');
-    const descStr = this._i18n.localize('E20.ItemDescription');
-    const noneStr = this._i18n.localize('E20.None');
+    const rolledSkillStr = this._localize('E20.EssenceSkillSpellcasting');
+    const spellRollStr = this._localize('E20.RollTypeSpell');
+    const descStr = this._localize('E20.ItemDescription');
+    const noneStr = this._localize('E20.None');
 
     let label = `<b>${spellRollStr}</b> - ${spell.name} (${rolledSkillStr})`
     label += `${this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag)}<br>`;
@@ -250,10 +260,10 @@ export class Dice {
   }
 
   _getMagicBaubleRollLabel(skillRollOptions, magicBauble) {
-    const rolledSkillStr = this._i18n.localize('E20.EssenceSkillSpellcasting');
-    const magicBaubleRollStr = this._i18n.localize('E20.RollTypeMagicBauble');
-    const descStr = this._i18n.localize('E20.ItemDescription');
-    const noneStr = this._i18n.localize('E20.None');
+    const rolledSkillStr = this._localize('E20.EssenceSkillSpellcasting');
+    const magicBaubleRollStr = this._localize('E20.RollTypeMagicBauble');
+    const descStr = this._localize('E20.ItemDescription');
+    const noneStr = this._localize('E20.None');
 
     let label = `<b>${magicBaubleRollStr}</b> - ${magicBauble.name} (${rolledSkillStr})`
     label += `${this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag)}<br>`;
@@ -299,10 +309,10 @@ export class Dice {
       };
       switch (skillShift) {
         case 'autoFail':
-          label += ` ${this._i18n.localize('E20.RollAutoFail')}`;
+          label += ` ${this._localize('E20.RollAutoFail')}`;
           break;
         case 'fumble':
-          label += ` ${this._i18n.localize('E20.RollAutoFailFumble')}`;
+          label += ` ${this._localize('E20.RollAutoFailFumble')}`;
           break;
       }
       chatData.content = label;
@@ -342,8 +352,8 @@ export class Dice {
 
     // Edge and Snag cancel eachother out
     if (edge != snag) {
-      const withAnEdge = this._i18n.localize('E20.RollWithAnEdge')
-      const withASnag = this._i18n.localize('E20.RollWithASnag')
+      const withAnEdge = this._localize('E20.RollWithAnEdge')
+      const withASnag = this._localize('E20.RollWithASnag')
       result = edge ? ` ${withAnEdge}` : ` ${withASnag}`;
     }
 

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -70,7 +70,7 @@ export class Dice {
       "system.initiative.formula": this._getFormula(
         skillRollOptions.isSpecialized, skillRollOptions, finalShift, actor.system.initiative.modifier),
     });
-    actor.rollInitiative({ createCombatants: true });
+    // actor.rollInitiative({ createCombatants: true });
   }
 
   /**

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -18,7 +18,7 @@ export class Dice {
    * @private
    */
   _localize(text) {
-    return this._i18n ? this._localize(text) : game.i18n.localize(text);
+    return this._i18n ? this._i18n.localize(text) : game.i18n.localize(text);
   }
 
   /**

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -6,9 +6,9 @@ export class Dice {
    * @param {i18n} i18n   The i18n to use for text localization.
    */
   constructor(config, chatMessage, i18n=null) {
-    this._i18n = i18n;
     this._config = config;
     this._chatMessage = chatMessage;
+    this._i18n = i18n;
   }
 
   /**
@@ -63,10 +63,10 @@ export class Dice {
   }
 
   /**
-   * Handles rolling initiative.
+   * Prepares the given actor for rolling initiative.
    * @param {Actor} actor   The actor performing the roll.
    */
-  async handleInitiativeRoll(actor) {
+  async prepareInitiativeRoll(actor) {
     const dataset = {
       shift: actor.system.initiative.shift,
       upshift: actor.system.initiative.shiftUp,

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -80,7 +80,6 @@ export class Dice {
       "system.initiative.formula": this._getFormula(
         skillRollOptions.isSpecialized, skillRollOptions, finalShift, actor.system.initiative.modifier),
     });
-    // actor.rollInitiative({ createCombatants: true });
   }
 
   /**

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -14,19 +14,25 @@ export class Dice {
   /**
    * Localizes the given text.
    * @param {String} text   The text to localize.
+   * @param {Object} fmtVars   Optional formatting variables.
    * @returns {String}   The localized text.
    * @private
    */
-  _localize(text) {
-    return this._i18n ? this._i18n.localize(text) : game.i18n.localize(text);
+  _localize(text, fmtVars=null) {
+    if (fmtVars) {
+      return this._i18n ? this._i18n.format(text, fmtVars) : game.i18n.format(text, fmtVars);
+    } else {
+      return this._i18n ? this._i18n.localize(text) : game.i18n.localize(text);
+    }
   }
 
   /**
    * Displays the dialog used for skill and specialization rolls.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
+   * @param {Actor} actor   The actor performing the roll.
    * @returns {Promise<Dialog>}   The dialog to be displayed.
    */
-  async getSkillRollOptions(dataset) {
+  async getSkillRollOptions(dataset, actor) {
     const template = "systems/essence20/templates/dialog/roll-dialog.hbs"
     const snag = this._config.skillShiftList.indexOf('d20') == this._config.skillShiftList.indexOf(dataset.shift);
     const html = await renderTemplate(
@@ -43,7 +49,7 @@ export class Dice {
 
     return new Promise(resolve => {
       const data = {
-        title: this._localize('E20.RollDialogTitle'),
+        title: this._localize('E20.RollDialogTitle', {actor: actor.name}),
         content: html,
         buttons: {
           normal: {
@@ -73,7 +79,7 @@ export class Dice {
       downshift: actor.system.initiative.shiftDown,
     };
 
-    const skillRollOptions = await this.getSkillRollOptions(dataset, this.actor);
+    const skillRollOptions = await this.getSkillRollOptions(dataset, actor);
     const finalShift = this._getFinalShift(
       skillRollOptions, actor.system.initiative.shift, this._config.initiativeShiftList)
     await actor.update({
@@ -201,7 +207,7 @@ export class Dice {
    * @param {Actor} actor   The actor performing the roll.
    */
   async handleSkillItemRoll(dataset, actor, item) {
-      const skillRollOptions = await this.getSkillRollOptions(dataset);
+      const skillRollOptions = await this.getSkillRollOptions(dataset, actor);
 
       if (skillRollOptions.cancelled) {
         return;

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -11,7 +11,7 @@ const chatMessage = jest.mock();
 chatMessage.getSpeaker = jest.fn();
 chatMessage.getSpeaker.mockReturnValue({});
 chatMessage.create = jest.fn();
-const dice = new Dice(new Mocki18n, E20, chatMessage);
+const dice = new Dice(E20, chatMessage, new Mocki18n);
 
 /* rollSkill */
 describe("rollSkill", () => {

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -1,7 +1,7 @@
 import { Dice } from "../dice.mjs";
 import { E20 } from "../helpers/config.mjs";
 
-const DICE = new Dice(game.i18n, E20, ChatMessage);
+const DICE = new Dice(E20, ChatMessage);
 
 export class Essence20Combat extends Combat {
   /** Roll initiative for PCs and NPCs using their prepared roll methods */
@@ -11,7 +11,7 @@ export class Essence20Combat extends Combat {
     );
 
     for (let combatant of combatants) {
-      DICE.handleInitiativeRoll(combatant.actor);
+      await DICE.handleInitiativeRoll(combatant.actor);
       await super.rollInitiative([combatant.id], options);
     }
   }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -7,7 +7,9 @@ export class Essence20Combat extends Combat {
     this._dice = new Dice(E20, ChatMessage);
   }
 
-  /** Roll initiative for PCs and NPCs using their prepared roll methods */
+  /**
+  * @override
+  */
   async rollInitiative(ids, options) {
     const combatants = ids.flatMap(
       (id) => this.combatants.get(id) ?? []

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -16,7 +16,7 @@ export class Essence20Combat extends Combat {
     );
 
     for (let combatant of combatants) {
-      await this._dice.handleInitiativeRoll(combatant.actor);
+      await this._dice.prepareInitiativeRoll(combatant.actor);
       await super.rollInitiative([combatant.id], options);
     }
   }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -1,9 +1,12 @@
 import { Dice } from "../dice.mjs";
 import { E20 } from "../helpers/config.mjs";
 
-const DICE = new Dice(E20, ChatMessage);
-
 export class Essence20Combat extends Combat {
+  constructor(data, context) {
+    super(data, context);
+    this._dice = new Dice(E20, ChatMessage);
+  }
+
   /** Roll initiative for PCs and NPCs using their prepared roll methods */
   async rollInitiative(ids, options) {
     const combatants = ids.flatMap(
@@ -11,7 +14,7 @@ export class Essence20Combat extends Combat {
     );
 
     for (let combatant of combatants) {
-      await DICE.handleInitiativeRoll(combatant.actor);
+      await this._dice.handleInitiativeRoll(combatant.actor);
       await super.rollInitiative([combatant.id], options);
     }
   }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -1,0 +1,18 @@
+import { Dice } from "../dice.mjs";
+import { E20 } from "../helpers/config.mjs";
+
+const DICE = new Dice(game.i18n, E20, ChatMessage);
+
+export class Essence20Combat extends Combat {
+  /** Roll initiative for PCs and NPCs using their prepared roll methods */
+  async rollInitiative(ids, options) {
+    const combatants = ids.flatMap(
+      (id) => this.combatants.get(id) ?? []
+    );
+
+    for (let combatant of combatants) {
+      DICE.handleInitiativeRoll(combatant.actor);
+      await super.rollInitiative([combatant.id], options);
+    }
+  }
+}

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -1,5 +1,6 @@
 // Import document classes.
 import { Essence20Actor } from "./documents/actor.mjs";
+import { Essence20Combat } from "./documents/combat.mjs";
 import { Essence20Combatant } from "./documents/combatant.mjs";
 import { Essence20Item } from "./documents/item.mjs";
 // Import sheet classes.
@@ -128,6 +129,7 @@ Hooks.once('init', async function () {
   // accessible in global contexts.
   game.essence20 = {
     Essence20Actor,
+    Essence20Combat,
     Essence20Combatant,
     Essence20Item,
     rollItemMacro
@@ -146,6 +148,7 @@ Hooks.once('init', async function () {
 
   // Define custom Document classes
   CONFIG.Actor.documentClass = Essence20Actor;
+  CONFIG.Combat.documentClass = Essence20Combat;
   CONFIG.Combatant.documentClass = Essence20Combatant;
   CONFIG.Item.documentClass = Essence20Item;
   CONFIG.statusEffects = foundry.utils.deepClone(statusEffects);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -383,7 +383,7 @@ export class Essence20ActorSheet extends ActorSheet {
 
       this._dice.rollSkill(dataset, skillRollOptions, this.actor);
     } else if (rollType == 'initiative') {
-      this._dice.handleInitiativeRoll(this.actor);
+      this.actor.rollInitiative({createCombatants: true});
     } else { // Handle items
       const itemId = element.closest('.item').dataset.itemId;
       const item = this.actor.items.get(itemId);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -8,7 +8,7 @@ import { Dice } from "../dice.mjs";
 export class Essence20ActorSheet extends ActorSheet {
   constructor(actor, options) {
     super(actor, options);
-    this._dice = new Dice(game.i18n, CONFIG.E20, ChatMessage);
+    this._dice = new Dice(CONFIG.E20, ChatMessage);
   }
 
   /** @override */


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/365

In this PR:
- Both the actor sheets and combat tracker kick off rolling initiative rolling via `Actor.rollInitiative()`. This eventually calls `Combat.rollInitiative()`, which is now being overridden to display the roll dialog for each actor before performing the roll.
- I don't love that `Essence20Combat` is using `Dice` to update the actor's initiative data. `Dice` is doing too much at this point and should be split up/refactored, but that will be a separate change.
- Made `i18n` an optional param for `Dice` since it can already access `game.i18n`

Testing
- Rolling initiatives from the sheets and sidebar should work as expected
- Try messing with the initiative shift values, too