### PR TITLE
Fixing Zord/MFZ console warnings

### DIFF
--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -116,7 +116,7 @@ export const migrateActorData = function(actor) {
     };
   }
 
-  //Migrate Skills
+  // Migrate Skills
   if (actor.system.skills.strength) {
     const skillsForEssences = actor.system.skills
     const essenceList = ["any", "strength", "speed", "smarts", "social"];
@@ -129,7 +129,7 @@ export const migrateActorData = function(actor) {
             "modifier": fields.modifier,
             "shift": fields.shift,
             "shiftDown": fields.shiftDown,
-           "shiftUp": fields.shiftUp
+            "shiftUp": fields.shiftUp
           }
         }
       }
@@ -137,6 +137,24 @@ export const migrateActorData = function(actor) {
     updateData[`system.skills`] = newSkills;
   }
 
+  // Migrate Zord/MFZ essence
+  if (["zord", "megaformZord"].includes(actor.type)) {
+    const strength = actor.system.essences.strength;
+    if (typeof strength == 'number') {
+      updateData[`system.essences.strength`] = {
+        usesDrivers: false,
+        value: actor.system.essences.strength,
+      };
+    }
+
+    const speed = actor.system.essences.speed;
+    if (typeof speed == 'number') {
+      updateData[`system.essences.speed`] = {
+        usesDrivers: false,
+        value: actor.system.essences.speed,
+      };
+    }
+  }
 
   // Migrate Owned Items
   if (!actor.items) {

--- a/template.json
+++ b/template.json
@@ -12,6 +12,7 @@
     ],
     "templates": {
       "common": {
+        "color": "#b5b1b1",
         "conditioning": 0,
         "description": "",
         "health": {
@@ -317,7 +318,6 @@
           "toughness": 0,
           "willpower": 0
         },
-        "color": "#b5b1b1",
         "essences": {
           "strength": 3,
           "speed": 3,

--- a/templates/actor/parts/actor-zord-common.hbs
+++ b/templates/actor/parts/actor-zord-common.hbs
@@ -15,7 +15,7 @@
     </div>
     <div class="flexrow flex-group-center">
       <span class="essence-label">{{localize config.essences.speed}}</span>
-      <input class="two-digit-input" type="number" name="config.essences.speed.value" value="{{config.essences.speed.value}}" />
+      <input class="two-digit-input" type="number" name="system.essences.speed.value" value="{{system.essences.speed.value}}" />
     </div>
   </div>
 </div>

--- a/templates/actor/parts/actor-zord-common.hbs
+++ b/templates/actor/parts/actor-zord-common.hbs
@@ -11,12 +11,11 @@
   <div class="stats-container" style="min-width: fit-content; text-align: center; border-color: {{system.color}};">
     <div class="flexrow flex-group-center">
       <span class="essence-label">{{localize config.essences.strength}}</span>
-      <input class="two-digit-input" type="number" name="system.essences.strength"
-        value="{{system.essences.strength}}" />
+      <input class="two-digit-input" type="number" name="system.essences.strength.value" value="{{system.essences.strength.value}}" />
     </div>
     <div class="flexrow flex-group-center">
       <span class="essence-label">{{localize config.essences.speed}}</span>
-      <input class="two-digit-input" type="number" name="system.essences.speed" value="{{system.essences.speed}}" />
+      <input class="two-digit-input" type="number" name="config.essences.speed.value" value="{{config.essences.speed.value}}" />
     </div>
   </div>
 </div>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/376 and https://github.com/WookieeMatt/Essence20/issues/377 

In this PR:
- Moving `color` from `character` to `common` in the template since Zords need them
- Fixing the Zord/MFZ strength and speed accessors
- Migration to fix existing actors, otherwise the values will disappear from the sheets

Testing:
- Creating Zords/MFZs should show no console warnings
- Speed and Strength inputs should work normally
- Old Zords/MFZs should migrate and their speed/strength stays on their sheets