### PR TITLE
Moving dice to actor for TAH support

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,8 +1,16 @@
+import { Dice } from "../dice.mjs";
+import { RollDialog } from "../helpers/roll-dialog.mjs";
+
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
  * @extends {Actor}
  */
 export class Essence20Actor extends Actor {
+  constructor(...args) {
+    super(...args);
+    this._dice = new Dice(ChatMessage, new RollDialog());
+  }
+
   /** @override */
   static async create(data, options = {}) {
     const actor = await super.create(data, options);
@@ -99,7 +107,7 @@ export class Essence20Actor extends Actor {
   /**
    * Prepare GI JOE type specific data.
    */
-   _prepareGiJoeData() {
+  _prepareGiJoeData() {
     if (this.type !== 'giJoe') return;
 
     const system = this.system;
@@ -129,13 +137,13 @@ export class Essence20Actor extends Actor {
         value: system.base.cleverness + system.essences.social + system.bonuses.cleverness,
         bonus: system.bonuses.cleverness
       }
-    ];  
+    ];
   }
 
   /**
    * Prepare Power Ranger type specific data.
    */
-   _preparePowerRangerData() {
+  _preparePowerRangerData() {
     if (this.type !== 'powerRanger') return;
 
     const system = this.system;
@@ -188,9 +196,9 @@ export class Essence20Actor extends Actor {
     ];
   }
 
-/**
- * Prepare Transformers type specific data.
- */
+  /**
+   * Prepare Transformers type specific data.
+   */
   _prepareTransformerData() {
     if (this.type !== 'transformer') return;
 
@@ -221,7 +229,7 @@ export class Essence20Actor extends Actor {
         value: system.base.cleverness + system.essences.social + system.bonuses.cleverness,
         bonus: system.bonuses.cleverness
       }
-    ];     
+    ];
   }
 
   _preparePonyData() {
@@ -254,9 +262,9 @@ export class Essence20Actor extends Actor {
         value: system.base.cleverness + system.essences.social + system.bonuses.cleverness,
         bonus: system.bonuses.cleverness
       }
-    ];     
+    ];
   }
-  
+
   /**
    * Override getRollData() that's supplied to rolls.
    */
@@ -287,4 +295,10 @@ export class Essence20Actor extends Actor {
     // Process additional NPC data here.
   }
 
+  /**
+   * Perform a skill roll.
+   */
+  rollSkill(dataset) {
+    this._dice.rollSkill(dataset, this);
+  }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,17 +1,10 @@
 import { onManageActiveEffect, prepareActiveEffectCategories } from "../helpers/effects.mjs";
-import { Dice } from "../dice.mjs";
-import { RollDialog } from "../helpers/roll-dialog.mjs";
 
 /**
  * Extend the basic ActorSheet with some very simple modifications
  * @extends {ActorSheet}
  */
 export class Essence20ActorSheet extends ActorSheet {
-  constructor(actor, options) {
-    super(actor, options);
-    this._dice = new Dice(ChatMessage, new RollDialog());
-  }
-
   /** @override */
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
@@ -374,7 +367,7 @@ export class Essence20ActorSheet extends ActorSheet {
 
     // Handle type-specific rolls.
     if (rollType == 'skill') {
-      this._dice.rollSkill(dataset, this.actor);
+      this.actor.rollSkill(dataset);
     } else if (rollType == 'initiative') {
       this.actor.rollInitiative({createCombatants: true});
     } else { // Handle items


### PR DESCRIPTION
This allows us to simply do `actor.rollSkill()` in the TAH module.

Testing - Rolls should still work as normal