### PR TITLE
Avoid collapsing NPC skills container on rerender

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -5,6 +5,12 @@ import { onManageActiveEffect, prepareActiveEffectCategories } from "../helpers/
  * @extends {ActorSheet}
  */
 export class Essence20ActorSheet extends ActorSheet {
+  constructor(...args) {
+    super(...args);
+
+    this._accordionSkillsExpanded = false;
+  }
+
   /** @override */
   static get defaultOptions() {
     return mergeObject(super.defaultOptions, {
@@ -61,6 +67,8 @@ export class Essence20ActorSheet extends ActorSheet {
 
     // Prepare Zords for MFZs
     this._prepareZords(context);
+
+    context.accordionSkillsExpanded = this._accordionSkillsExpanded;
 
     return context;
   }
@@ -293,7 +301,19 @@ export class Essence20ActorSheet extends ActorSheet {
     html.find('.accordion-label').click(ev => {
       const el = ev.currentTarget;
       const parent = $(el).parents('.accordion-wrapper');
-      parent.toggleClass('open');
+
+      // Avoid collapsing NPC skills container on rerender
+      if (parent.hasClass('skills-container')) {
+        this._accordionSkillsExpanded = !this._accordionSkillsExpanded;
+
+        if (this._accordionSkillsExpanded) {
+          parent.addClass('open');
+        } else {
+          parent.removeClass('open');
+        }
+      } else {
+        parent.toggleClass('open');
+      }
     });
 
     // Drag events for macros.

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -8,7 +8,7 @@ export class Essence20ActorSheet extends ActorSheet {
   constructor(...args) {
     super(...args);
 
-    this._accordionSkillsExpanded = false;
+    this._accordionStates = { skills: '' };
   }
 
   /** @override */
@@ -68,7 +68,7 @@ export class Essence20ActorSheet extends ActorSheet {
     // Prepare Zords for MFZs
     this._prepareZords(context);
 
-    context.accordionSkillsExpanded = this._accordionSkillsExpanded;
+    context.accordionStates = this._accordionStates;
 
     return context;
   }
@@ -304,13 +304,9 @@ export class Essence20ActorSheet extends ActorSheet {
 
       // Avoid collapsing NPC skills container on rerender
       if (parent.hasClass('skills-container')) {
-        this._accordionSkillsExpanded = !this._accordionSkillsExpanded;
-
-        if (this._accordionSkillsExpanded) {
-          parent.addClass('open');
-        } else {
-          parent.removeClass('open');
-        }
+        const isOpen = this._accordionStates.skills;
+        this._accordionStates.skills = isOpen ? '' : 'open';
+        this.render();
       } else {
         parent.toggleClass('open');
       }

--- a/templates/actor/parts/actor-accordion-skills.hbs
+++ b/templates/actor/parts/actor-accordion-skills.hbs
@@ -1,4 +1,8 @@
+{{#if accordionSkillsExpanded}}
+<div class="skills-container accordion-wrapper open" style="border-color: {{system.color}};">
+{{else}}
 <div class="skills-container accordion-wrapper" style="border-color: {{system.color}};">
+{{/if}}
   <div class="flex-group-center accordion-label">
     <span>{{localize 'E20.AccordionSkillsTitle'}}</span>
     <a class="item-control"><i class="accordion-icon fas fa-chevron-down"></i></a>

--- a/templates/actor/parts/actor-accordion-skills.hbs
+++ b/templates/actor/parts/actor-accordion-skills.hbs
@@ -1,8 +1,4 @@
-{{#if accordionSkillsExpanded}}
-<div class="skills-container accordion-wrapper open" style="border-color: {{system.color}};">
-{{else}}
-<div class="skills-container accordion-wrapper" style="border-color: {{system.color}};">
-{{/if}}
+<div class="skills-container accordion-wrapper {{accordionStates.skills}}" style="border-color: {{system.color}};">
   <div class="flex-group-center accordion-label">
     <span>{{localize 'E20.AccordionSkillsTitle'}}</span>
     <a class="item-control"><i class="accordion-icon fas fa-chevron-down"></i></a>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/310

We can expand this to include items later as well.

Testing: Open an NPC sheet and expand the skills. Modifying any skill fields should no longer collapse the container. 