### PR TITLE
Adding upgrades to companion sheet for drones

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -180,6 +180,7 @@
     "ItemTypeSpecializationPlural": "Specializations",
     "ItemTypeSpellPlural": "Spells",
     "ItemTypeThreatPowerPlural": "Threat Powers",
+    "ItemTypeUpgradePlural": "Upgrades",
     "ItemTypeWeaponPlural": "Weapons",
     "LightRangeBright": "Bright",
     "LightRangeDim": "Dim",

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -75,6 +75,8 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/items/threatPower/details.hbs",
     "systems/essence20/templates/actor/parts/items/trait/container.hbs",
     "systems/essence20/templates/actor/parts/items/trait/details.hbs",
+    "systems/essence20/templates/actor/parts/items/upgrade/container.hbs",
+    "systems/essence20/templates/actor/parts/items/upgrade/details.hbs",
     "systems/essence20/templates/actor/parts/items/weapon/container.hbs",
     "systems/essence20/templates/actor/parts/items/weapon/details.hbs",
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -440,6 +440,9 @@ export class Essence20ActorSheet extends ActorSheet {
       }
 
       await this._showOriginEssenceDialog(sourceItem, event, data);
+    } else if (this.actor.type == 'companion' && this.actor.system.type == 'drone' && sourceItem.type == 'upgrade' && sourceItem.system.type != 'drone') {
+      // Drones can only accept drone upgrades
+      return;
     } else {
       super._onDropItem(event, data);
     }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -156,6 +156,7 @@ export class Essence20ActorSheet extends ActorSheet {
     const specializations = {};
     const spells = [];
     const threatPowers = [];
+    const upgrades = [];
     const weapons = [];
     const classFeaturesById = {};
     let equippedArmorEvasion = 0;
@@ -227,6 +228,9 @@ export class Essence20ActorSheet extends ActorSheet {
         case 'threatPower':
           threatPowers.push(i);
           break;
+        case 'upgrade':
+          upgrades.push(i);
+          break;
         case 'weapon':
           weapons.push(i);
           break;
@@ -253,6 +257,7 @@ export class Essence20ActorSheet extends ActorSheet {
     context.spells = spells;
     context.specializations = specializations;
     context.threatPowers = threatPowers;
+    context.upgrades = upgrades;
     context.weapons = weapons;
   }
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -431,20 +431,24 @@ export class Essence20ActorSheet extends ActorSheet {
     const sourceItem = await fromUuid(data.uuid);
     if (!sourceItem) return false;
 
-    if (sourceItem.type == 'origin') {
-      for (let actorItem of this.actor.items) {
-        if(actorItem.type == 'origin') {
-          ui.notifications.error(game.i18n.format(game.i18n.localize('E20.MulitpleOriginError')));
-          return false
+    switch (sourceItem.type) {
+      case 'origin':
+        for (let actorItem of this.actor.items) {
+          if(actorItem.type == 'origin') {
+            ui.notifications.error(game.i18n.format(game.i18n.localize('E20.MulitpleOriginError')));
+            return false;
+          }
         }
-      }
 
-      await this._showOriginEssenceDialog(sourceItem, event, data);
-    } else if (this.actor.type == 'companion' && this.actor.system.type == 'drone' && sourceItem.type == 'upgrade' && sourceItem.system.type != 'drone') {
-      // Drones can only accept drone upgrades
-      return;
-    } else {
-      super._onDropItem(event, data);
+        await this._showOriginEssenceDialog(sourceItem, event, data);
+        break;
+      case 'upgrade':
+        // Drones can only accept drone upgrades
+        if (this.actor.type == 'companion' && this.actor.system.type == 'drone' && sourceItem.system.type != 'drone') {
+          return false;
+        }
+      default:
+        super._onDropItem(event, data);
     }
   };
 

--- a/templates/actor/parts/items/upgrade/container.hbs
+++ b/templates/actor/parts/items/upgrade/container.hbs
@@ -1,0 +1,9 @@
+{{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.upgrades title="E20.ItemTypeUpgradePlural" dataType="upgrade"}}
+  {{#*inline "expand-details" item}}
+    {{> "systems/essence20/templates/actor/parts/items/upgrade/details.hbs"}}
+  {{/inline}}
+
+  {{#*inline "item-label" item}}
+    {{item.name}}
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs"}}

--- a/templates/actor/parts/items/upgrade/details.hbs
+++ b/templates/actor/parts/items/upgrade/details.hbs
@@ -1,0 +1,14 @@
+<div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+<div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.system.prerequisite}}}</div>
+<div>{{localize 'E20.UpgradeBenefit'}}: {{{item.system.benefit}}}</div>
+
+<div class="chip-section">
+  <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.system.type}}</span>
+  <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.system.availability}}</span>
+  {{#if item.system.armorBonus.value}}
+  <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.system.armorBonus.defense}}: {{item.system.armorBonus.value}}</span>
+  {{/if}}
+  {{#each item.system.traits as |trait|}}
+  <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.armorTraits trait}}</span>
+  {{/each}}
+</div>

--- a/templates/actor/sheets/companion.hbs
+++ b/templates/actor/sheets/companion.hbs
@@ -48,6 +48,10 @@
           {{> "systems/essence20/templates/actor/parts/items/weapon/container.hbs"}}
           {{> "systems/essence20/templates/actor/parts/items/perk/container.hbs"}}
           {{> "systems/essence20/templates/actor/parts/items/power/container.hbs"}}
+
+          {{#ifEquals system.type "drone"}}
+          {{> "systems/essence20/templates/actor/parts/items/upgrade/container.hbs"}}
+          {{/ifEquals}}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/342

##### In this PR
- Adding upgrades section to drone companion sheet

##### Testing
- Upgrade section on companion sheet should only show up for drones and work as expected
- Chips look good
- Only drone-type upgrades can be dropped onto drone sheets
