### PR TITLE
Adding button to expand/collapse all items within a container

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -86,6 +86,11 @@
   display: block;
 }
 
+.essence20 .header-accordion-label {
+  float: right;
+  margin-right: 8px;
+}
+
 /* Chevron icon. */
 .essence20 .accordion-icon {
   transition: all ease-in-out 0.25s;

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -320,16 +320,36 @@ export class Essence20ActorSheet extends ActorSheet {
         this.render();
       } else {
         parent.toggleClass('open');
+
+        // Check if the container header toggle should be flipped
+        let oneClosed = false;
+
+        // Look for a closed Item
+        const accordionLabels = el.closest('.collapsible-item-container').querySelectorAll('.accordion-wrapper');
+        for (const accordionLabel of accordionLabels) {
+          oneClosed = !$(accordionLabel).hasClass('open');
+          if (oneClosed) break;
+        }
+
+        // Set header state to open if all Items are open; closed otherwise
+        const container = el.closest('.collapsible-item-container').querySelector('.header-accordion-wrapper');
+        if (oneClosed) {
+          $(container).removeClass('open');
+        } else {
+          $(container).addClass('open');
+        }
       }
     });
 
     // Open and collapse all Item contents in container
     html.find('.header-accordion-label').click(ev => {
       const el = ev.currentTarget;
+      const isOpening = !$(el.closest('.header-accordion-wrapper')).hasClass('open');
+      $(el.closest('.header-accordion-wrapper')).toggleClass('open');
 
       const accordionLabels = el.closest('.collapsible-item-container').querySelectorAll('.accordion-wrapper');
       for (const accordionLabel of accordionLabels) {
-        $(accordionLabel).toggleClass('open');
+        isOpening ? $(accordionLabel).addClass('open') : $(accordionLabel).removeClass('open');
       }
     });
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -323,6 +323,16 @@ export class Essence20ActorSheet extends ActorSheet {
       }
     });
 
+    // Open and collapse all Item contents in container
+    html.find('.header-accordion-label').click(ev => {
+      const el = ev.currentTarget;
+
+      const accordionLabels = el.closest('.collapsible-item-container').querySelectorAll('.accordion-wrapper');
+      for (const accordionLabel of accordionLabels) {
+        $(accordionLabel).toggleClass('open');
+      }
+    });
+
     // Drag events for macros.
     if (this.actor.isOwner) {
       let handler = ev => this._onDragStart(ev);

--- a/sass/assets/_collapsible.scss
+++ b/sass/assets/_collapsible.scss
@@ -40,6 +40,11 @@
   display: block;
 }
 
+.essence20 .header-accordion-label {
+  float: right;
+  margin-right: 8px;
+}
+
 /* Chevron icon. */
 .essence20 .accordion-icon {
   transition: all ease-in-out 0.25s;

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -5,6 +5,11 @@
     <a class="item-create" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
       <i class="fas fa-plus"></i>
     </a>
+    <span class="accordion-wrapper">
+      <a class="header-accordion-label" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
+        <i class="accordion-icon fas fa-chevron-down"></i>
+      </a>
+    </span>
   </div>
 
   <ol class="items-list" style="border-color: {{system.color}};">

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -5,7 +5,7 @@
     <a class="item-create" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
       <i class="fas fa-plus"></i>
     </a>
-    <span class="accordion-wrapper">
+    <span class="header-accordion-wrapper">
       <a class="header-accordion-label" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
         <i class="accordion-icon fas fa-chevron-down"></i>
       </a>

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -1,18 +1,22 @@
 <div class="collapsible-item-container" style="border-color: {{system.color}};">
   {{!-- Header with + and v buttons --}}
-  <div class="flex-group-center">
-    {{localize title}}
-    <a class="item-create" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
-      <i class="fas fa-plus"></i>
-    </a>
+  <div class="flexrow">
+    <div></div>
 
-    {{#if items.length}}
+    <div style="flex-grow: 0; white-space: nowrap;">
+      {{localize title}}
+      <a class="item-create" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
+        <i class="fas fa-plus"></i>
+      </a>
+    </div>
+
     <span class="header-accordion-wrapper">
+      {{#if items.length}}
       <a class="header-accordion-label" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
         <i class="accordion-icon fas fa-chevron-down"></i>
       </a>
+      {{/if}}
     </span>
-    {{/if}}
   </div>
 
   <ol class="items-list" style="border-color: {{system.color}};">

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -1,15 +1,18 @@
 <div class="collapsible-item-container" style="border-color: {{system.color}};">
-  {{!-- Header with + button --}}
+  {{!-- Header with + and v buttons --}}
   <div class="flex-group-center">
     {{localize title}}
     <a class="item-create" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
       <i class="fas fa-plus"></i>
     </a>
+
+    {{#if items.length}}
     <span class="header-accordion-wrapper">
       <a class="header-accordion-label" data-type={{dataType}} title="{{ localize 'E20.ItemControlAdd' }}">
         <i class="accordion-icon fas fa-chevron-down"></i>
       </a>
     </span>
+    {{/if}}
   </div>
 
   <ol class="items-list" style="border-color: {{system.color}};">


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/415

##### In this PR
- Adding button to expand/collapse all items within a container
- The button will respond to the state of the items. The button will only be in the "opened" orientation if all items are opened, whether by using the header button or manually opening all items.
- It only appears if there are > 0 items in the container

##### Testing
- For any item container, the header `v` button should only appear if it contains > 0 items
- Clicking the button toggles all items between opened and closed
- The button should be in the "closed" orientation until all items are opened