### PR TITLE
Adding snag/edge to skills and initiative

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -38,8 +38,11 @@ export class Dice {
       shiftUp: actor.system.initiative.shiftUp,
       shiftDown: actor.system.initiative.shiftDown,
     };
-
-    const skillRollOptions = await this._rollDialog.getSkillRollOptions(dataset, actor);
+    const skillDataset = {
+      edge: actor.system.initiative.edge,
+      snag: actor.system.initiative.snag,
+    }
+    const skillRollOptions = await this._rollDialog.getSkillRollOptions(dataset, skillDataset, actor);
 
     if (skillRollOptions.cancelled) {
       return false;
@@ -62,16 +65,20 @@ export class Dice {
    * @param {Item} item   The item being used, if any.
    */
   async rollSkill(dataset, actor, item) {
-    const skillRollOptions = await this._rollDialog.getSkillRollOptions(dataset, actor);
+    const rolledSkill = dataset.skill;
+    const actorSkillData = actor.getRollData().skills[rolledSkill];+6
+    const skillDataset = {
+      edge: actorSkillData.edge,
+      snag: actorSkillData.snag,
+    }
+    const skillRollOptions = await this._rollDialog.getSkillRollOptions(dataset, skillDataset, actor);
 
     if (skillRollOptions.cancelled) {
       return;
     }
 
-    const rolledSkill = dataset.skill;
-    const actorSkillData = actor.getRollData().skills;
     const rolledEssence = dataset.essence || E20.skillToEssence[rolledSkill];
-    const initialShift = dataset.shift || actorSkillData[rolledSkill].shift;
+    const initialShift = dataset.shift || actorSkillData.shift;
     const completeDataset = {
       ...dataset,
       // Weapon partial can't populate these easily
@@ -107,7 +114,7 @@ export class Dice {
     }
 
     const isSpecialized = dataset.isSpecialized === 'true' || skillRollOptions.isSpecialized;
-    const modifier = actorSkillData[rolledSkill].modifier || 0;
+    const modifier = actorSkillData.modifier || 0;
     const formula = this._getFormula(isSpecialized, skillRollOptions, finalShift, modifier);
 
     // Repeat the roll as many times as specified in the skill roll options dialog

--- a/module/helpers/roll-dialog.mjs
+++ b/module/helpers/roll-dialog.mjs
@@ -30,18 +30,21 @@ export class RollDialog {
    * @param {Actor} actor   The actor performing the roll.
    * @returns {Promise<Dialog>}   The dialog to be displayed.
    */
-  async getSkillRollOptions(dataset, actor) {
+  async getSkillRollOptions(dataset, skillDataset, actor) {
     const template = "systems/essence20/templates/dialog/roll-dialog.hbs"
-    const snag = E20.skillShiftList.indexOf('d20') == E20.skillShiftList.indexOf(dataset.shift);
+    const snag =
+      skillDataset.snag ||
+      E20.skillShiftList.indexOf('d20') == E20.skillShiftList.indexOf(dataset.shift);
+    const edge = skillDataset.edge;
     const html = await renderTemplate(
       template,
       {
         shiftUp: dataset.shiftUp || 0,
         shiftDown: dataset.shiftDown || 0,
         isSpecialized: dataset.isSpecialized === 'true',
-        snag,
-        edge: false,
-        normal: !snag
+        snag: snag && !edge,
+        edge: edge && !snag,
+        normal: edge == snag,
       }
     );
 

--- a/template.json
+++ b/template.json
@@ -24,8 +24,10 @@
           "value": 4
         },
         "initiative": {
+          "edge": false,
           "formula": "2d20kl + 0",
           "modifier": 0,
+          "snag": false,
           "shift": "d20",
           "shiftDown": 0,
           "shiftUp": 0
@@ -64,11 +66,13 @@
               "speed": true,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "alertness": {
             "essences": {
@@ -77,11 +81,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "animalHandling": {
             "essences": {
@@ -90,11 +96,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "athletics": {
             "essences": {
@@ -103,11 +111,13 @@
               "speed": false,
               "strength": true
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "brawn": {
             "essences": {
@@ -116,11 +126,13 @@
               "speed": false,
               "strength": true
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "culture": {
             "essences": {
@@ -129,11 +141,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "deception": {
             "essences": {
@@ -142,11 +156,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "driving": {
             "essences": {
@@ -155,11 +171,13 @@
               "speed": true,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "finesse": {
             "essences": {
@@ -168,11 +186,13 @@
               "speed": true,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "infiltration": {
             "essences": {
@@ -181,11 +201,13 @@
               "speed": true,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "intimidation": {
             "essences": {
@@ -194,11 +216,13 @@
               "speed": false,
               "strength": true
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "might": {
             "essences": {
@@ -207,11 +231,13 @@
               "speed": false,
               "strength": true
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "performance": {
             "essences": {
@@ -220,11 +246,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "persuasion": {
             "essences": {
@@ -233,11 +261,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "science": {
             "essences": {
@@ -246,11 +276,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "spellcasting": {
             "essences": {
@@ -259,11 +291,13 @@
               "speed": true,
               "strength": true
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "streetwise": {
             "essences": {
@@ -272,11 +306,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "survival": {
             "essences": {
@@ -285,11 +321,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "targeting": {
             "essences": {
@@ -298,11 +336,13 @@
               "speed": true,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           },
           "technology": {
             "essences": {
@@ -311,11 +351,13 @@
               "speed": false,
               "strength": false
             },
+            "edge": false,
             "isSpecialized": false,
             "modifier": 0,
             "shift": "d20",
             "shiftDown": 0,
-            "shiftUp": 0
+            "shiftUp": 0,
+            "snag": false
           }
         },
         "stun": {


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/328

##### In this PR
- Adding snag and edge booleans to skills and initiative. This way they can be granted via AEs.

##### Testing
- Add AEs like `system.skills.athletics.snag`,  `system.skills.athletics.edge`, and similar for `system.initiative`
- The roll dialog Snag/Normal/Edge radios should be preselected as expected
