### PR TITLE
Implementing Essence shifts

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -73,12 +73,12 @@ export class Dice {
     }
     const rolledSkill = dataset.skill;
     const rolledEssence = dataset.essence || E20.skillToEssence[rolledSkill];
-    const actorSkillData = actor.getRollData().skills[rolledSkill];
     const updatedShiftDataset = {
       ...dataset,
       shiftUp: dataset.shiftUp + actor.system.essenceShifts[rolledEssence].shiftUp,
       shiftDown: dataset.shiftDown + actor.system.essenceShifts[rolledEssence].shiftDown,
     };
+    const actorSkillData = actor.getRollData().skills[rolledSkill];
     const skillDataset = {
       edge: actorSkillData.edge,
       snag: actorSkillData.snag,
@@ -160,7 +160,7 @@ export class Dice {
    */
   _getSkillRollLabel(dataset, skillRollOptions) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = dataset.isSpecialized === 'true'
+    const rolledSkillStr = dataset.isSpecialized
       ? dataset.specializationName
       : this._localize(E20.skills[rolledSkill]);
     const rollingForStr = this._localize('E20.RollRollingFor')

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -73,10 +73,11 @@ export class Dice {
     }
     const rolledSkill = dataset.skill;
     const rolledEssence = dataset.essence || E20.skillToEssence[rolledSkill];
+    const essenceShifts = actor.system.essenceShifts;
     const updatedShiftDataset = {
       ...dataset,
-      shiftUp: dataset.shiftUp + actor.system.essenceShifts[rolledEssence].shiftUp,
-      shiftDown: dataset.shiftDown + actor.system.essenceShifts[rolledEssence].shiftDown,
+      shiftUp: dataset.shiftUp + essenceShifts[rolledEssence].shiftUp + essenceShifts.any.shiftUp,
+      shiftDown: dataset.shiftDown + essenceShifts[rolledEssence].shiftDown + essenceShifts.any.shiftDown,
     };
     const actorSkillData = actor.getRollData().skills[rolledSkill];
     const skillDataset = {

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -35,8 +35,8 @@ export class Dice {
   async prepareInitiativeRoll(actor) {
     const dataset = {
       shift: actor.system.initiative.shift,
-      shiftUp: actor.system.initiative.shiftUp,
-      shiftDown: actor.system.initiative.shiftDown,
+      shiftUp: actor.system.initiative.shiftUp + actor.system.essenceShifts.speed.shiftUp,
+      shiftDown: actor.system.initiative.shiftDown + actor.system.essenceShifts.speed.shiftDown,
     };
     const skillDataset = {
       edge: actor.system.initiative.edge,
@@ -60,37 +60,41 @@ export class Dice {
 
   /**
    * Handle skill and specialization rolls.
-   * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
+   * @param {Event.currentTarget.element.dataset} rawDataset   The dataset of the click event.
    * @param {Actor} actor   The actor performing the roll.
    * @param {Item} item   The item being used, if any.
    */
-  async rollSkill(dataset, actor, item) {
+  async rollSkill(rawDataset, actor, item) {
+    const dataset = { // Converting strings to usable types
+      ...rawDataset,
+      isSpecialized: rawDataset.isSpecialized === 'true',
+      shiftDown: parseInt(rawDataset.shiftDown),
+      shiftUp: parseInt(rawDataset.shiftUp),
+    }
     const rolledSkill = dataset.skill;
-    const actorSkillData = actor.getRollData().skills[rolledSkill];+6
+    const rolledEssence = dataset.essence || E20.skillToEssence[rolledSkill];
+    const actorSkillData = actor.getRollData().skills[rolledSkill];
+    const updatedShiftDataset = {
+      ...dataset,
+      shiftUp: dataset.shiftUp + actor.system.essenceShifts[rolledEssence].shiftUp,
+      shiftDown: dataset.shiftDown + actor.system.essenceShifts[rolledEssence].shiftDown,
+    };
     const skillDataset = {
       edge: actorSkillData.edge,
       snag: actorSkillData.snag,
     }
-    const skillRollOptions = await this._rollDialog.getSkillRollOptions(dataset, skillDataset, actor);
+    const skillRollOptions = await this._rollDialog.getSkillRollOptions(updatedShiftDataset, skillDataset, actor);
 
     if (skillRollOptions.cancelled) {
       return;
     }
 
-    const rolledEssence = dataset.essence || E20.skillToEssence[rolledSkill];
     const initialShift = dataset.shift || actorSkillData.shift;
-    const completeDataset = {
-      ...dataset,
-      // Weapon partial can't populate these easily
-      essence : rolledEssence,
-      shift: initialShift,
-    }
-
     let label = '';
 
     switch(item?.type) {
       case 'weapon':
-        label = this._getWeaponRollLabel(completeDataset, skillRollOptions, actor, item);
+        label = this._getWeaponRollLabel(dataset, skillRollOptions, actor, item);
         break;
       case 'spell':
           label = this._getSpellRollLabel(skillRollOptions, item);
@@ -99,7 +103,7 @@ export class Dice {
         label = this._getMagicBaubleRollLabel(skillRollOptions, item);
         break;
       default:
-        label = this._getSkillRollLabel(completeDataset, skillRollOptions);
+        label = this._getSkillRollLabel(dataset, skillRollOptions);
     }
 
     let finalShift = this._getFinalShift(skillRollOptions, initialShift);
@@ -113,7 +117,7 @@ export class Dice {
       finalShift = E20.skillRollableShifts[E20.skillRollableShifts.length - 1];
     }
 
-    const isSpecialized = dataset.isSpecialized === 'true' || skillRollOptions.isSpecialized;
+    const isSpecialized = dataset.isSpecialized || skillRollOptions.isSpecialized;
     const modifier = actorSkillData.modifier || 0;
     const formula = this._getFormula(isSpecialized, skillRollOptions, finalShift, modifier);
 

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -25,24 +25,47 @@ class Mocki18n {
   format(text, _) { return text; }
 }
 
+const mockActor = {
+  system: {
+    initiative: {
+      formula: "",
+      modifier: 0,
+      shift: "d20",
+      shiftDown: 0,
+      shiftUp: 0,
+    },
+    essenceShifts: {
+      any: {
+        shiftDown: 0,
+        shiftUp: 0,
+      },
+      strength: {
+        shiftDown: 0,
+        shiftUp: 0,
+      },
+      speed: {
+        shiftDown: 0,
+        shiftUp: 0,
+      },
+      smarts: {
+        shiftDown: 0,
+        shiftUp: 0,
+      },
+      social: {
+        shiftDown: 0,
+        shiftUp: 0,
+      },
+    },
+  },
+};
+
 const dice = new Dice(chatMessage, rollDialog, new Mocki18n());
 
 /* Begin Tests */
 
 /* prepareInitiativeRoll */
 describe("prepareInitiativeRoll", () => {
-  const mockActor = jest.mock();
-
   test("normal initiative roll", async () => {
-    mockActor.system = {};
-    mockActor.system.initiative = {
-      formula: "",
-      modifier: 0,
-      shift: "d20",
-      shiftDown: 0,
-      shiftUp: 0
-    };
-
     rollDialog.getSkillRollOptions.mockReturnValue({
       edge: false,
       shiftDown: 0,
@@ -51,11 +74,11 @@ describe("prepareInitiativeRoll", () => {
       isSpecialized: false,
       timesToRoll: 1,
     });
+    const mockInitActor = {...mockActor};
+    mockInitActor.update = jest.fn();
 
-    mockActor.update = jest.fn();
-    await dice.prepareInitiativeRoll(mockActor);
-
-    expect(mockActor.update).toHaveBeenCalledWith({
+    await dice.prepareInitiativeRoll(mockInitActor);
+    expect(mockInitActor.update).toHaveBeenCalledWith({
       "system.initiative.formula": "2d20kl + 0",
     });
   });
@@ -64,11 +87,13 @@ describe("prepareInitiativeRoll", () => {
 /* rollSkill */
 describe("rollSkill", () => {
   const dataset = {
-    isSpecialized: false,
+    essence: 'strength',
+    isSpecialized: 'false',
     shift: 'd20',
+    shiftDown: '0',
+    shiftUp: '0',
     skill: 'athletics',
   };
-  const mockActor = jest.mock();
 
   test("normal skill roll", async () => {
     rollDialog.getSkillRollOptions.mockReturnValue({
@@ -235,6 +260,51 @@ describe("rollSkill", () => {
 
     await dice.rollSkill(dataset, mockActor, spell);
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "<b>E20.RollTypeSpell</b> - Barreling Beam (E20.SkillSpellcasting)<br><b>E20.ItemDescription</b> - Some description<br>");
+  });
+
+  test.only("essence-shifted skill roll", async () => {
+    rollDialog.getSkillRollOptions.mockReturnValue({
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    });
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'athletics': {
+          modifier: '0',
+          shift: 'd20',
+        },
+      },
+    }));
+    const expectedDataset = {
+      ...dataset,
+      isSpecialized: false,
+      shiftUp: 1,
+      shiftDown: 1,
+    };
+    const expectedSkillDataset = {
+      edge: false,
+      snag: false,
+    }
+    const mockShiftedActor = {
+      ...mockActor,
+      getRollData: jest.fn().mockReturnValue({
+        skills: {
+          athletics: {
+            edge: false,
+            snag: false,
+          }
+        }
+      }),
+    };
+    mockShiftedActor.system.essenceShifts.strength.shiftDown = 1;
+    mockShiftedActor.system.essenceShifts.strength.shiftUp = 1;
+    dice._rollSkillHelper = jest.fn()
+
+    await dice.rollSkill(dataset, mockShiftedActor, null);
+    expect(rollDialog.getSkillRollOptions).toHaveBeenCalledWith(expectedDataset, expectedSkillDataset, mockShiftedActor);
   });
 });
 

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -282,7 +282,7 @@ describe("rollSkill", () => {
       ...dataset,
       isSpecialized: false,
       shiftUp: 1,
-      shiftDown: 1,
+      shiftDown: 2,
     };
     const expectedSkillDataset = {
       edge: false,
@@ -301,6 +301,7 @@ describe("rollSkill", () => {
     };
     mockShiftedActor.system.essenceShifts.strength.shiftDown = 1;
     mockShiftedActor.system.essenceShifts.strength.shiftUp = 1;
+    mockShiftedActor.system.essenceShifts.any.shiftDown = 1;
     dice._rollSkillHelper = jest.fn()
 
     await dice.rollSkill(dataset, mockShiftedActor, null);

--- a/template.json
+++ b/template.json
@@ -19,6 +19,10 @@
         "conditioning": 0,
         "description": "",
         "essenceShifts": {
+          "any": {
+            "shiftUp": 0,
+            "shiftDown": 0
+          },
           "smarts": {
             "shiftUp": 0,
             "shiftDown": 0

--- a/template.json
+++ b/template.json
@@ -18,6 +18,24 @@
         "color": "#b5b1b1",
         "conditioning": 0,
         "description": "",
+        "essenceShifts": {
+          "smarts": {
+            "shiftUp": 0,
+            "shiftDown": 0
+          },
+          "social": {
+            "shiftUp": 0,
+            "shiftDown": 0
+          },
+          "speed": {
+            "shiftUp": 0,
+            "shiftDown": 0
+          },
+          "strength": {
+            "shiftUp": 0,
+            "shiftDown": 0
+          }
+        },
         "health": {
           "max": 4,
           "min": 0,

--- a/templates/actor/parts/misc/essence-skills.hbs
+++ b/templates/actor/parts/misc/essence-skills.hbs
@@ -3,7 +3,7 @@
   <span class="skill-roll">
     <a
       class="rollable" data-roll-type="skill" data-skill="{{skill}}" data-essence="{{essence}}"
-      data-shiftUp ="{{fields.shiftUp}}" data-shiftDown ="{{fields.shiftDown}}"
+      data-shift-up ="{{fields.shiftUp}}" data-shift-down ="{{fields.shiftDown}}"
       data-shift="{{fields.shift}}" data-is-specialized="{{fields.isSpecialized}}"
     >
       <i class="fas fa-dice-d20"></i>
@@ -48,14 +48,14 @@
           {{!-- NPCs can have unspecialized specializations, but PCs are always specialized --}}
           <a
             class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}"
-            data-shiftUp ="{{../fields.shiftUp}}" data-shiftDown ="{{../fields.shiftDown}}"
+            data-shift-up ="{{../fields.shiftUp}}" data-shift-down ="{{../fields.shiftDown}}"
             data-shift="{{specialization.system.shift}}" data-specialization-name="{{specialization.name}}"
             data-is-specialized="{{specialization.system.isSpecialized}}"
           >
           {{else}}
           <a
             class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}"
-            data-shiftUp ="{{../fields.shiftDown}}" data-shiftDown ="{{../fields.shiftDown}}"
+            data-shift-up ="{{../fields.shiftDown}}" data-shift-down ="{{../fields.shiftDown}}"
             data-shift="{{../fields.shift}}" data-specialization-name="{{specialization.name}}" data-is-specialized="true"
           >
           {{/ifEquals}}

--- a/templates/actor/parts/misc/pc-skills.hbs
+++ b/templates/actor/parts/misc/pc-skills.hbs
@@ -10,7 +10,7 @@
       <input class="one-digit-input" type="number" name="system.conditioning" value="{{system.conditioning}}" />
     </div>
     {{#each @root.config.skillsByEssence.strength as |skill|}}
-      {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='social' skill=skill fields=(lookup @root.system.skills skill)}}
+      {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='strength' skill=skill fields=(lookup @root.system.skills skill)}}
     {{/each}}
   </div>
 
@@ -21,7 +21,7 @@
       <input class="two-digit-input" type="number" name="system.essences.speed" value="{{system.essences.speed}}" />
     </div>
     {{#each @root.config.skillsByEssence.speed as |skill|}}
-      {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='social' skill=skill fields=(lookup @root.system.skills skill)}}
+      {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='speed' skill=skill fields=(lookup @root.system.skills skill)}}
     {{/each}}
   </div>
 
@@ -32,7 +32,7 @@
       <input class="two-digit-input" type="number" name="system.essences.smarts" value="{{system.essences.smarts}}" />
     </div>
    {{#each @root.config.skillsByEssence.smarts as |skill|}}
-      {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='social' skill=skill fields=(lookup @root.system.skills skill)}}
+      {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='smarts' skill=skill fields=(lookup @root.system.skills skill)}}
     {{/each}}
   </div>
 
@@ -47,3 +47,4 @@
     {{/each}}
   </div>
 </div>
+D


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/386

##### In this PR
- Adding new `essenceShifts` field to the `common` template. For each essence, as well as for "any", there are shiftUp and shiftDown fields. For example, `system.essenceShifts.strength.shiftUp = 1` or `system.essenceShifts.any.shiftDown = 1`
- These shift values have been added to the shift totals that are passed into the roll dialog
- `dataset` param (now `rawDataset`) for `rollSkill` now has its string values converted into int/bool types right away, instead of having to deal with it everywhere
- Fixing every skill roll using Social essence
- `data-shiftUp`/`data-shiftDown` -> `data-shift-up`/`data-shift-down` in `essence-skills.hbs`, which corrects its capitalization elsewhere
- Fixing/adding tests. I'd like to go back and clean these up more, as I think I've been misusing jest.mock(). The `mockActor` was giving me problems, so I had to change the implementation.

##### Testing
- Add essenceShift AEs to an actor. The up/down shifts should correctly populate in the roll dialog
- Having an AE for an essence PLUS an "any" AE should sum both of them
