### PR TITLE
Reverting remove traits change

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -30,7 +30,8 @@
     "TypePerk": "Perk",
     "TypePower": "Power",
     "TypeSpecialization": "Specialization",
-    "TypeSpell": "Spell"
+    "TypeSpell": "Spell",
+    "TypeTrait": "Trait"
   },
   "MIGRATION": {
     "begin": "Applying Essence20 System Migration for version {version}. Please be patient and do not close your game or shut down your server.",
@@ -193,6 +194,7 @@
     "ItemTypeSpecializationPlural": "Specializations",
     "ItemTypeSpellPlural": "Spells",
     "ItemTypeThreatPowerPlural": "Threat Powers",
+    "ItemTypeTraitPlural": "Traits",
     "ItemTypeUpgradePlural": "Upgrades",
     "ItemTypeWeaponPlural": "Weapons",
     "LightRangeBright": "Bright",

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -75,6 +75,8 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/items/spell/details.hbs",
     "systems/essence20/templates/actor/parts/items/threatPower/container.hbs",
     "systems/essence20/templates/actor/parts/items/threatPower/details.hbs",
+    "systems/essence20/templates/actor/parts/items/trait/container.hbs",
+    "systems/essence20/templates/actor/parts/items/trait/details.hbs",
     "systems/essence20/templates/actor/parts/items/upgrade/container.hbs",
     "systems/essence20/templates/actor/parts/items/upgrade/details.hbs",
     "systems/essence20/templates/actor/parts/items/weapon/container.hbs",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -223,6 +223,7 @@ export class Essence20ActorSheet extends ActorSheet {
     const spells = [];
     const threatPowers = [];
     const upgrades = [];
+    const traits = []; // Used by Vehicles
     const weapons = [];
     const classFeaturesById = {};
     let equippedArmorEvasion = 0;
@@ -297,9 +298,11 @@ export class Essence20ActorSheet extends ActorSheet {
         case 'threatPower':
           threatPowers.push(i);
           break;
+        case 'trait':
+          traits.push(i);
+          break;
         case 'upgrade':
           upgrades.push(i);
-          break;
         case 'weapon':
           weapons.push(i);
           break;
@@ -325,6 +328,7 @@ export class Essence20ActorSheet extends ActorSheet {
     context.spells = spells;
     context.specializations = specializations;
     context.threatPowers = threatPowers;
+    context.traits = traits;
     context.upgrades = upgrades;
     context.weapons = weapons;
 

--- a/template.json
+++ b/template.json
@@ -619,6 +619,7 @@
       "specialization",
       "spell",
       "threatPower",
+      "trait",
       "upgrade",
       "weapon"
     ],
@@ -765,6 +766,11 @@
       "charges": null,
       "cost": null,
       "limited": false
+    },
+    "trait": {
+      "templates": [
+        "itemDescription"
+      ]
     },
     "weapon": {
       "templates": [

--- a/templates/actor/parts/items/trait/container.hbs
+++ b/templates/actor/parts/items/trait/container.hbs
@@ -1,0 +1,5 @@
+{{#> "systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.traits title='E20.ItemTypeTraitPlural' dataType='trait'}}
+  {{#*inline "expand-details" item}}
+    {{> "systems/essence20/templates/actor/parts/items/trait/details.hbs"}}
+  {{/inline}}
+{{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs"}}

--- a/templates/actor/parts/items/trait/details.hbs
+++ b/templates/actor/parts/items/trait/details.hbs
@@ -1,0 +1,1 @@
+<div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>


### PR DESCRIPTION
Reverting most changes from https://github.com/WookieeMatt/Essence20/pull/406

##### In this PR
- Vehicles still use `trait`s, so we still need it
- Keeping the change that removes redundant `notes` from NPCs

##### Testing
- Should be able to open Vehicles again and traits work
