### PR TITLE
New morph/transform button layout

### DIFF
--- a/templates/actor/parts/misc/common.hbs
+++ b/templates/actor/parts/misc/common.hbs
@@ -1,8 +1,9 @@
 <div class="flexrow stats-row">
+  {{!-- Morph/Transform --}}
   {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
 
+  {{!-- Initiative --}}
   <div class="stats-container health-container" style="border-color: {{system.color}};">
-    {{!-- Initiative --}}
     {{> "systems/essence20/templates/actor/parts/misc/initiative.hbs"}}
   </div>
 

--- a/templates/actor/parts/misc/common.hbs
+++ b/templates/actor/parts/misc/common.hbs
@@ -1,4 +1,6 @@
 <div class="flexrow stats-row">
+  {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
+
   <div class="stats-container health-container" style="border-color: {{system.color}};">
     {{!-- Initiative --}}
     {{> "systems/essence20/templates/actor/parts/misc/initiative.hbs"}}

--- a/templates/actor/parts/misc/morph-transform.hbs
+++ b/templates/actor/parts/misc/morph-transform.hbs
@@ -1,14 +1,23 @@
-<div class="flexrow flex-group-center" style="border-color: {{system.color}};">
+<div class="stats-container flexcol" style="min-width: fit-content; border-color: {{system.color}};">
   {{#if system.canTransform}}
-    <button class="transform" type="button">{{ localize "E20.Transform" }}</button>
+  <div class="flexrow" style="gap: 5px; align-items: center; flex-wrap: nowrap; width: 100%">
+    <a class="transform" style="flex-grow: 0;"><i class="fas fa-steering-wheel"></i></a>
+    <span style="text-align: left;">
+      {{localize 'E20.Transform'}}
+    </span>
+  </div>
   {{/if}}
+
   {{#if system.canMorph}}
-    <button class="morph" type="button">
-    {{#if system.isMorphed}}
+  <div class="flexrow" style="gap: 5px; align-items: center; flex-wrap: nowrap; width: 100%">
+    <a class="morph" style="flex-grow: 0;"><i class="fas fa-sword"></i></a>
+    <span style="text-align: left;">
+      {{#if system.isMorphed}}
       {{localize 'E20.ButtonUnmorph'}}
-    {{else}}
+      {{else}}
       {{localize 'E20.ButtonMorph'}}
-    {{/if}}
-    </button>
+      {{/if}}
+    </span>
+  </div>
   {{/if}}
 </div>

--- a/templates/actor/sheets/giJoe.hbs
+++ b/templates/actor/sheets/giJoe.hbs
@@ -22,7 +22,6 @@
   <section class="sheet-body">
     {{!-- Skills Tab --}}
     <div class="tab skills flexcol" data-group="primary" data-tab="skills">
-      {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/defenses.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/common.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/pc-skills.hbs"}}

--- a/templates/actor/sheets/pony.hbs
+++ b/templates/actor/sheets/pony.hbs
@@ -23,7 +23,6 @@
   <section class="sheet-body">
     {{!-- Skills Tab --}}
     <div class="tab skills flexcol" data-group="primary" data-tab="skills">
-      {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/defenses.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/common.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/pc-skills.hbs"}}

--- a/templates/actor/sheets/powerRanger.hbs
+++ b/templates/actor/sheets/powerRanger.hbs
@@ -23,7 +23,6 @@
   <section class="sheet-body">
     {{!-- Skills Tab --}}
     <div class="tab skills flexcol" data-group="primary" data-tab="skills">
-      {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/defenses.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/common.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/pc-skills.hbs"}}

--- a/templates/actor/sheets/transformer.hbs
+++ b/templates/actor/sheets/transformer.hbs
@@ -20,7 +20,6 @@
   <section class="sheet-body">
     {{!-- Skills Tab --}}
     <div class="tab skills flexcol" data-group="primary" data-tab="skills">
-      {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/defenses.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/common.hbs"}}
       {{> "systems/essence20/templates/actor/parts/misc/pc-skills.hbs"}}


### PR DESCRIPTION
##### In this PR
- Changing morph and transform button layout, and moving them to the common row of stat containers

##### Testing
- PC sheets should have the new layout
- Buttons work correctly and still respect the crossover settings
