### PR TITLE
Fixing movement migration

### DIFF
--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -138,8 +138,26 @@ export const migrateActorData = function(actor) {
     updateData[`system.skills`] = newSkills;
   }
 
-  //Migrate to Base Movement
-  if (!actor.system.movement.aerial.base && !actor.system.movement.ground.base && !actor.system.movement.swim.base){
+  // Migrate to Base Movement
+  updateData[`system.movement.aerial.altMode`] = 0;
+  updateData[`system.movement.aerial.base`] = 0;
+  updateData[`system.movement.aerial.bonus`] = 0;
+  updateData[`system.movement.aerial.morphed`] = 0;
+  updateData[`system.movement.aerial.total`] = 0;
+
+  updateData[`system.movement.ground.altMode`] = 0;
+  updateData[`system.movement.ground.base`] = 0;
+  updateData[`system.movement.ground.bonus`] = 0;
+  updateData[`system.movement.ground.morphed`] = 0;
+  updateData[`system.movement.ground.total`] = 0;
+
+  updateData[`system.movement.swim.altMode`] = 0;
+  updateData[`system.movement.swim.base`] = 0;
+  updateData[`system.movement.swim.bonus`] = 0;
+  updateData[`system.movement.swim.morphed`] = 0;
+  updateData[`system.movement.swim.total`] = 0;
+
+  if (["giJoe", "pony", "powerRanger", "transformer"].includes(actor.type)) {
     for (const item of actor.items) {
       if (item.type == 'origin') {
         updateData[`system.movement.aerial.base`] = item.system.baseAerialMovement;
@@ -148,6 +166,10 @@ export const migrateActorData = function(actor) {
         break;
       }
     }
+  } else {
+    updateData[`system.movement.aerial.base`] = actor.system.movement.aerial;
+    updateData[`system.movement.ground.base`] = actor.system.movement.ground;
+    updateData[`system.movement.swim.base`] = actor.system.movement.swim;
   }
 
   // Migrate Zord/MFZ essence

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -166,10 +166,14 @@ export const migrateActorData = function(actor) {
         break;
       }
     }
-  } else {
-    updateData[`system.movement.aerial.base`] = actor.system.movement.aerial;
-    updateData[`system.movement.ground.base`] = actor.system.movement.ground;
-    updateData[`system.movement.swim.base`] = actor.system.movement.swim;
+  } else if (typeof actor.system.movement.aerial == 'number') {
+    updateData[`system.movement.aerial.total`] = actor.system.movement.aerial;
+    updateData[`system.movement.ground.total`] = actor.system.movement.ground;
+    updateData[`system.movement.swim.total`] = actor.system.movement.swim;
+  } else { // Movement fields are already objects
+    updateData[`system.movement.aerial.total`] = actor.system.movement.aerial.total;
+    updateData[`system.movement.ground.total`] = actor.system.movement.ground.total;
+    updateData[`system.movement.swim.total`] = actor.system.movement.swim.total;
   }
 
   // Migrate Zord/MFZ essence

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -166,11 +166,11 @@ export const migrateActorData = function(actor) {
         break;
       }
     }
-  } else if (typeof actor.system.movement.aerial == 'number') {
+  } else if (typeof actor.system.movement.aerial == 'string') { // Non-PCs
     updateData[`system.movement.aerial.total`] = actor.system.movement.aerial;
     updateData[`system.movement.ground.total`] = actor.system.movement.ground;
     updateData[`system.movement.swim.total`] = actor.system.movement.swim;
-  } else { // Movement fields are already objects
+  } else { // Non-PCs where movement fields are already objects
     updateData[`system.movement.aerial.total`] = actor.system.movement.aerial.total;
     updateData[`system.movement.ground.total`] = actor.system.movement.ground.total;
     updateData[`system.movement.swim.total`] = actor.system.movement.swim.total;

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -139,41 +139,43 @@ export const migrateActorData = function(actor) {
   }
 
   // Migrate to Base Movement
-  updateData[`system.movement.aerial.altMode`] = 0;
-  updateData[`system.movement.aerial.base`] = 0;
-  updateData[`system.movement.aerial.bonus`] = 0;
-  updateData[`system.movement.aerial.morphed`] = 0;
-  updateData[`system.movement.aerial.total`] = 0;
+  if (Object.keys(actor.system.movement.aerial).sort() != ['altMode', 'base', 'bonus', 'morphed', 'total']) {
+    updateData[`system.movement.aerial.altMode`] = 0;
+    updateData[`system.movement.aerial.base`] = 0;
+    updateData[`system.movement.aerial.bonus`] = 0;
+    updateData[`system.movement.aerial.morphed`] = 0;
+    updateData[`system.movement.aerial.total`] = 0;
 
-  updateData[`system.movement.ground.altMode`] = 0;
-  updateData[`system.movement.ground.base`] = 0;
-  updateData[`system.movement.ground.bonus`] = 0;
-  updateData[`system.movement.ground.morphed`] = 0;
-  updateData[`system.movement.ground.total`] = 0;
+    updateData[`system.movement.ground.altMode`] = 0;
+    updateData[`system.movement.ground.base`] = 0;
+    updateData[`system.movement.ground.bonus`] = 0;
+    updateData[`system.movement.ground.morphed`] = 0;
+    updateData[`system.movement.ground.total`] = 0;
 
-  updateData[`system.movement.swim.altMode`] = 0;
-  updateData[`system.movement.swim.base`] = 0;
-  updateData[`system.movement.swim.bonus`] = 0;
-  updateData[`system.movement.swim.morphed`] = 0;
-  updateData[`system.movement.swim.total`] = 0;
+    updateData[`system.movement.swim.altMode`] = 0;
+    updateData[`system.movement.swim.base`] = 0;
+    updateData[`system.movement.swim.bonus`] = 0;
+    updateData[`system.movement.swim.morphed`] = 0;
+    updateData[`system.movement.swim.total`] = 0;
 
-  if (["giJoe", "pony", "powerRanger", "transformer"].includes(actor.type)) {
-    for (const item of actor.items) {
-      if (item.type == 'origin') {
-        updateData[`system.movement.aerial.base`] = item.system.baseAerialMovement;
-        updateData[`system.movement.ground.base`] = item.system.baseGroundMovement;
-        updateData[`system.movement.swim.base`] = item.system.baseAquaticMovement;
-        break;
+    if (["giJoe", "pony", "powerRanger", "transformer"].includes(actor.type)) {
+      for (const item of actor.items) {
+        if (item.type == 'origin') {
+          updateData[`system.movement.aerial.base`] = item.system.baseAerialMovement;
+          updateData[`system.movement.ground.base`] = item.system.baseGroundMovement;
+          updateData[`system.movement.swim.base`] = item.system.baseAquaticMovement;
+          break;
+        }
       }
+    } else if (typeof actor.system.movement.aerial == 'string') { // Non-PCs
+      updateData[`system.movement.aerial.total`] = actor.system.movement.aerial;
+      updateData[`system.movement.ground.total`] = actor.system.movement.ground;
+      updateData[`system.movement.swim.total`] = actor.system.movement.swim;
+    } else { // Non-PCs where movement fields are already objects
+      updateData[`system.movement.aerial.total`] = actor.system.movement.aerial.total;
+      updateData[`system.movement.ground.total`] = actor.system.movement.ground.total;
+      updateData[`system.movement.swim.total`] = actor.system.movement.swim.total;
     }
-  } else if (typeof actor.system.movement.aerial == 'string') { // Non-PCs
-    updateData[`system.movement.aerial.total`] = actor.system.movement.aerial;
-    updateData[`system.movement.ground.total`] = actor.system.movement.ground;
-    updateData[`system.movement.swim.total`] = actor.system.movement.swim;
-  } else { // Non-PCs where movement fields are already objects
-    updateData[`system.movement.aerial.total`] = actor.system.movement.aerial.total;
-    updateData[`system.movement.ground.total`] = actor.system.movement.ground.total;
-    updateData[`system.movement.swim.total`] = actor.system.movement.swim.total;
   }
 
   // Migrate Zord/MFZ essence

--- a/system.json
+++ b/system.json
@@ -312,6 +312,6 @@
     "verified": "10"
   },
   "flags": {
-    "needsMigrationVersion": "3.1.4"
+    "needsMigrationVersion": "3.2.0"
   }
 }


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/446, https://github.com/WookieeMatt/Essence20/issues/445

##### In this PR
- Bumping needsMigrationVersion to 3.2.0
- Setting all movement fields in the migration

##### Testing
- Checkout `main`
- Create a PC with an origin, and one without
- Also create a non-PC
- Checkout `movement-migration-fix`
- Reload the server the the migration should run successfully
- Movement should be correct for actors created
