### PR TITLE
Removing morph/TF container if actor can do neither

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -70,6 +70,7 @@ export class Essence20ActorSheet extends ActorSheet {
     this._prepareZords(context);
 
     context.accordionStates = this._accordionStates;
+    context.canMorphOrTransform = context.actor.system.canMorph || context.actor.system.canTransform;
 
     return context;
   }

--- a/templates/actor/parts/misc/morph-transform.hbs
+++ b/templates/actor/parts/misc/morph-transform.hbs
@@ -1,3 +1,4 @@
+{{#if canMorphOrTransform}}
 <div class="stats-container flexcol" style="min-width: fit-content; border-color: {{system.color}};">
   {{#if system.canTransform}}
   <div class="flexrow" style="gap: 5px; align-items: center; flex-wrap: nowrap; width: 100%">
@@ -21,3 +22,4 @@
   </div>
   {{/if}}
 </div>
+{{/if}}


### PR DESCRIPTION
##### Testing
- Open a PC actor that doesn't morph or transform (Joe, Pony). Morph/TF container shouldn't be there at all.
- Still respects crossover options
