### PR TITLE
Fixing repeat rolls

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -8,7 +8,7 @@ import { RollDialog } from "../helpers/roll-dialog.mjs";
 export class Essence20Actor extends Actor {
   constructor(...args) {
     super(...args);
-    this._dice = new Dice(ChatMessage, new RollDialog());
+    this._dice = new Dice(ChatMessage, new RollDialog(), game.i18n);
   }
 
   /** @override */

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -4,7 +4,7 @@ import { RollDialog } from "../helpers/roll-dialog.mjs";
 export class Essence20Combat extends Combat {
   constructor(data, context) {
     super(data, context);
-    this._dice = new Dice(ChatMessage, new RollDialog());
+    this._dice = new Dice(ChatMessage, new RollDialog(), game.i18n);
   }
 
   /**

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -8,7 +8,7 @@ import { RollDialog } from "../helpers/roll-dialog.mjs";
 export class Essence20Item extends Item {
   constructor(item, options) {
     super(item, options);
-    this._dice = new Dice(ChatMessage, new RollDialog());
+    this._dice = new Dice(ChatMessage, new RollDialog(), game.i18n);
   }
 
   /**


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/464

##### In this PR
- The `i18n` object wasn't being passed in the Dice constructors, so it was erroring when it tried to localize for the repeat roll text. Now passing `game.i18n` into the Dice constructors so it can actually be used by the class. The reason we pass i18n in the first place is to make unit testing and mocking easier.

##### Testing
- Perform a roll that brings up the roll dialog. Using a repeat roll value of 1 or greater should work.
