### PR TITLE
Draft: Moving roll button from weapons to weaponEffects

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -151,6 +151,7 @@
     "DamageManeuver": "Maneuver",
     "DamageSharp": "Sharp",
     "DamageStun": "Stun",
+    "DamageType": "Damage Type",
     "DefenseArmor": "Armor",
     "DefenseBase": "Base",
     "DefenseCleverness": "Cleverness",

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -111,7 +111,7 @@ export class Essence20Item extends Item {
         flavor: label,
         content: content,
       });
-    } else if (this.type == 'weapon') {
+    } else if (['weapon', 'weaponEffect'].includes(this.type)) {
       const skill = this.system.classification.skill;
       const shift = this.actor.system.skills[skill].shift;
       const shiftUp = this.actor.system.skills[skill].shiftUp;

--- a/template.json
+++ b/template.json
@@ -846,11 +846,15 @@
       "prerequisite": null
     },
     "weaponEffect" : {
+      "classification": {
+        "skill": "athletics",
+        "style": "melee"
+      },
       "damageType": "",
-      "damageValue": 0,
-      "downshift": 0,
+      "damageValue": 1,
+      "shiftDown": 0,
       "numHands": 1,
-      "numTargets": 0,
+      "numTargets": 1,
       "radius": 0,
       "range": {
         "min": null,

--- a/templates/actor/parts/items/classFeature/container.hbs
+++ b/templates/actor/parts/items/classFeature/container.hbs
@@ -1,14 +1,14 @@
 {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.classFeatures title='E20.ItemTypeClassFeaturePlural' dataType='classFeature'}}
   {{#*inline "item-label" item}}
-  {{item.name}}
-  <input class="one-digit-input inline-edit" data-field="system.uses.value" type="number"
-    name="item.system.uses.value" value="{{item.system.uses.value}}" />
-  /
-  <input class="one-digit-input inline-edit" data-field="system.uses.max" type="number" name="item.system.uses.max"
-    value="{{item.system.uses.max}}" />
-  </span>
-
+    {{item.name}}
+    <input class="one-digit-input inline-edit" data-field="system.uses.value" type="number"
+      name="item.system.uses.value" value="{{item.system.uses.value}}" />
+    /
+    <input class="one-digit-input inline-edit" data-field="system.uses.max" type="number" name="item.system.uses.max"
+      value="{{item.system.uses.max}}" />
+    </span>
   {{/inline}}
+
   {{#*inline "expand-details" item}}
     {{> "systems/essence20/templates/actor/parts/items/classFeature/details.hbs"}}
   {{/inline}}

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -3,10 +3,6 @@
     {{> "systems/essence20/templates/actor/parts/items/weapon/details.hbs"}}
   {{/inline}}
 
-  {{#*inline "roll-button" item}}
-    <a class="rollable" data-roll-type="weapon" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
-  {{/inline}}
-
   {{#*inline "item-label" item}}
     {{#ifEquals @root.actor.type 'powerRanger'}}
       {{>"systems/essence20/templates/actor/parts/items/classFeature/selector.hbs"}}

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -1,0 +1,12 @@
+<div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+
+<div class="chip-section">
+  <span class="chip" name="chip.weapon.classification">{{lookup @root.config.skills item.system.classification.skill}} {{lookup @root.config.weaponSizes item.system.classification.size}} {{lookup @root.config.weaponStyles item.system.classification.style}}</span>
+  <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
+  <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
+  <span class="chip" name="chip.weapon.damageValue">{{localize 'E20.Damage'}}: {{item.system.damageValue}}</span>
+  <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{item.system.damageType}}</span>
+  {{#if item.system.shiftDown}}
+  <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.system.shiftDown}}</span>
+  {{/if}}
+</div>

--- a/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs
@@ -3,7 +3,7 @@
     <div class="flexrow" style="flex-wrap: nowrap; gap: 5px;">
       <a class="rollable" data-roll-type="info" title="{{localize 'E20.ItemRollTitle'}}"><i
           class="fas fa-message-lines"></i></a>
-      {{#> roll-button item=item}}
+      {{#> roll-button}}
       {{!-- Custom roll button here --}}
       {{/roll-button}}
     </div>

--- a/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs
@@ -1,8 +1,9 @@
 <div class="flexrow item-label">
   <div class="item-image" style="flex-grow: 0;">
     <div class="flexrow" style="flex-wrap: nowrap; gap: 5px;">
-      <a class="rollable" data-roll-type="info" title="{{localize 'E20.ItemRollTitle'}}"><i
-          class="fas fa-message-lines"></i></a>
+      <a class="rollable" data-roll-type="info" title="{{localize 'E20.ItemRollTitle'}}">
+        <i class="fas fa-message-lines"></i>
+      </a>
       {{#> roll-button}}
       {{!-- Custom roll button here --}}
       {{/roll-button}}

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -6,7 +6,7 @@
     {{#each items as |item|}}
     <li class="item accordion-wrapper flexcol" data-item-id="{{item._id}}" data-parent-id="{{../parentId}}">
       {{!-- Item label and buttons --}}
-      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs"}}
+      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
 
       {{!-- Item content --}}
       {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item}}

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -6,7 +6,7 @@
     {{#each items as |item|}}
     <li class="item accordion-wrapper flexcol" data-item-id="{{item._id}}" data-parent-id="{{../parentId}}">
       {{!-- Item label and buttons --}}
-      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
+      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs"}}
 
       {{!-- Item content --}}
       {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item}}

--- a/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
+++ b/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
@@ -6,7 +6,11 @@
     {{#each items as |item|}}
     <li class="item accordion-wrapper" data-item-id="{{item._id}}" data-parent-id="{{../parentId}}">
       {{!-- Item label and buttons --}}
-      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
+      {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
+        {{#*inline "roll-button"}}
+          <a class="rollable" data-roll-type="weaponEffect" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
+        {{/inline}}
+      {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs"}}
 
       {{!-- Item content --}}
       {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item}}

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -34,10 +34,10 @@
     {{/inline}}
     {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
-    {{!-- Downshift --}}
+    {{!-- Shift Down --}}
     {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ShiftDown'}}
     {{#*inline "item-field-inputs"}}
-    <input type="number" name="system.downshift" value="{{system.downshift}}" />
+    <input type="number" name="system.shiftDown" value="{{system.shiftDown}}" />
     {{/inline}}
     {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 


### PR DESCRIPTION
Contributes to https://github.com/WookieeMatt/Essence20/issues/320

Note: Instead of migrating existing weapons for this change, which would not really be feasible, we'll be adding weapons to the compendium.

##### In this PR
- Moving roll buttons off of weapons and onto weapon effects
- Adding `skill` and `style` to weaponEffects. Not removing them from weapons yet.
- Changing `downshift` to `shiftDown` to match codebase

##### Testing
- Weapon effects should roll correctly on sheets (just new ones for now until migration is done)
- Description buttons should also work
