### PR TITLE
Fixes for weapon effect rolling

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -111,7 +111,7 @@ export class Essence20Item extends Item {
         flavor: label,
         content: content,
       });
-    } else if (['weapon', 'weaponEffect'].includes(this.type)) {
+    } else if (this.type == 'weaponEffect') {
       const skill = this.system.classification.skill;
       const shift = this.actor.system.skills[skill].shift;
       const shiftUp = this.actor.system.skills[skill].shiftUp;

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -115,7 +115,7 @@ export class Essence20Item extends Item {
       const skill = this.system.classification.skill;
       const shift = this.actor.system.skills[skill].shift;
       const shiftUp = this.actor.system.skills[skill].shiftUp;
-      const shiftDown = this.actor.system.skills[skill].shiftDown;
+      const shiftDown = this.actor.system.skills[skill].shiftDown + this.system.shiftDown;
       const weaponDataset = {
         ...dataset,
         shift,

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,5 +1,5 @@
 import { onManageActiveEffect, prepareActiveEffectCategories } from "../helpers/effects.mjs";
-import { searchCompendium } from "../helpers/utils.mjs";
+import { createItemCopies, searchCompendium } from "../helpers/utils.mjs";
 import { AlterationHandler } from "../sheet-handlers/alteration-handler.mjs";
 import { BackgroundHandler } from "../sheet-handlers/background-handler.mjs";
 import { CrossoverHandler } from "../sheet-handlers/crossover-handler.mjs";
@@ -579,8 +579,6 @@ export class Essence20ActorSheet extends ActorSheet {
       return await this._bgHandler.influenceUpdate(sourceItem, super._onDropItem.bind(this, event, data));
     case 'origin':
       return await this._bgHandler.originUpdate(sourceItem, super._onDropItem.bind(this, event, data));
-    case 'weaponEffect':
-      return this._atHandler.attachItem('weapon', super._onDropItem.bind(this, event, data));
     case 'upgrade':
       // Drones can only accept drone Upgrades
       if (this.actor.type == 'companion' && this.actor.system.type == 'drone' && sourceItem.system.type == 'drone') {
@@ -593,7 +591,15 @@ export class Essence20ActorSheet extends ActorSheet {
         ui.notifications.error(game.i18n.localize('E20.UpgradeDropError'));
         return false;
       }
-
+    case 'weapon':
+      const weaponList = await super._onDropItem(event, data);
+      const newWeapon = weaponList[0];
+      const oldWeaponEffectIds = newWeapon.system.weaponEffectIds;
+      const newWeaponEffectIds = await createItemCopies(oldWeaponEffectIds, this.actor);
+      await newWeapon.update({ ['system.weaponEffectIds']: newWeaponEffectIds });
+      return weaponList;
+    case 'weaponEffect':
+      return this._atHandler.attachItem('weapon', super._onDropItem.bind(this, event, data));
     default:
       return super._onDropItem(event, data);
     }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -580,29 +580,51 @@ export class Essence20ActorSheet extends ActorSheet {
     case 'origin':
       return await this._bgHandler.originUpdate(sourceItem, super._onDropItem.bind(this, event, data));
     case 'upgrade':
-      // Drones can only accept drone Upgrades
-      if (this.actor.type == 'companion' && this.actor.system.type == 'drone' && sourceItem.system.type == 'drone') {
-        return super._onDropItem(event, data);
-      } else if (this.actor.system.canTransform && sourceItem.system.type == 'armor') {
-        return super._onDropItem(event, data);
-      } else if (['armor', 'weapon'].includes(sourceItem.system.type)) {
-        return this._atHandler.attachItem(sourceItem.system.type, super._onDropItem.bind(this, event, data));
-      } else {
-        ui.notifications.error(game.i18n.localize('E20.UpgradeDropError'));
-        return false;
-      }
+      return await this._onDropUpgrade(event, data);
     case 'weapon':
-      const weaponList = await super._onDropItem(event, data);
-      const newWeapon = weaponList[0];
-      const oldWeaponEffectIds = newWeapon.system.weaponEffectIds;
-      const newWeaponEffectIds = await createItemCopies(oldWeaponEffectIds, this.actor);
-      await newWeapon.update({ ['system.weaponEffectIds']: newWeaponEffectIds });
-      return weaponList;
+      return await this._onDropWeapon(event, data);
     case 'weaponEffect':
       return this._atHandler.attachItem('weapon', super._onDropItem.bind(this, event, data));
     default:
       return super._onDropItem(event, data);
     }
+  }
+
+  /**
+   * Handle dropping of an Upgrade onto an Actor sheet
+   * @param {DragEvent} event           The concluding DragEvent which contains drop data
+   * @param {Object} data               The data transfer extracted from the event
+   * @returns {Promise<object|boolean>} A data object which describes the result of the drop, or false if the drop was
+   *                                    not permitted.
+   */
+  async _onDropUpgrade(event, data) {
+    // Drones can only accept drone Upgrades
+    if (this.actor.type == 'companion' && this.actor.system.type == 'drone' && sourceItem.system.type == 'drone') {
+      return super._onDropItem(event, data);
+    } else if (this.actor.system.canTransform && sourceItem.system.type == 'armor') {
+      return super._onDropItem(event, data);
+    } else if (['armor', 'weapon'].includes(sourceItem.system.type)) {
+      return this._atHandler.attachItem(sourceItem.system.type, super._onDropItem.bind(this, event, data));
+    } else {
+      ui.notifications.error(game.i18n.localize('E20.UpgradeDropError'));
+      return false;
+    }
+  }
+
+  /**
+   * Handle dropping of a Weapon onto an Actor sheet
+   * @param {DragEvent} event           The concluding DragEvent which contains drop data
+   * @param {Object} data               The data transfer extracted from the event
+   * @returns {Promise<object|boolean>} A data object which describes the result of the drop, or false if the drop was
+   *                                    not permitted.
+   */
+  async _onDropWeapon(event, data) {
+    const weaponList = await super._onDropItem(event, data);
+    const newWeapon = weaponList[0];
+    const oldWeaponEffectIds = newWeapon.system.weaponEffectIds;
+    const newWeaponEffectIds = await createItemCopies(oldWeaponEffectIds, this.actor);
+    await newWeapon.update({ ['system.weaponEffectIds']: newWeaponEffectIds });
+    return weaponList;
   }
 
   /**

--- a/template.json
+++ b/template.json
@@ -798,6 +798,20 @@
         "itemDescription"
       ]
     },
+    "upgrade": {
+      "templates": [
+        "itemDescription"
+      ],
+      "armorBonus": {
+        "defense": "toughness",
+        "value": 0
+      },
+      "availability": "standard",
+      "benefit": "",
+      "traits": [],
+      "type": "armor",
+      "prerequisite": null
+    },
     "weapon": {
       "templates": [
         "itemDescription"
@@ -805,11 +819,6 @@
       "classFeatureId": null,
       "alternateEffects": "",
       "availability": "standard",
-      "classification": {
-        "skill": "athletics",
-        "size": "medium",
-        "style": "melee"
-      },
       "custom": "",
       "effect": "",
       "equipped": true,
@@ -832,20 +841,6 @@
       "upgradeIds": [],
       "upgradeTraits": [],
       "weaponEffectIds": []
-    },
-    "upgrade": {
-      "templates": [
-        "itemDescription"
-      ],
-      "armorBonus": {
-        "defense": "toughness",
-        "value": 0
-      },
-      "availability": "standard",
-      "benefit": "",
-      "traits": [],
-      "type": "armor",
-      "prerequisite": null
     },
     "weaponEffect" : {
       "classification": {

--- a/templates/item/sheets/weapon.hbs
+++ b/templates/item/sheets/weapon.hbs
@@ -18,38 +18,12 @@
     {{/inline}}
     {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
-    {{!-- Skill --}}
-    {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponSkill'}}
-    {{#*inline "item-field-inputs"}}
-    <select class="item-field-inputs" name="system.classification.skill">
-      {{#select system.classification.skill}}
-      {{#each config.skills as |name type|}}
-      <option value="{{type}}">{{name}}</option>
-      {{/each}}
-      {{/select}}
-    </select>
-    {{/inline}}
-    {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
-
     {{!-- Size --}}
     {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponSize'}}
     {{#*inline "item-field-inputs"}}
     <select class="item-field-inputs" name="system.classification.size">
       {{#select system.classification.size}}
       {{#each config.weaponSizes as |name type|}}
-      <option value="{{type}}">{{localize name}}</option>
-      {{/each}}
-      {{/select}}
-    </select>
-    {{/inline}}
-    {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
-
-    {{!-- Style --}}
-    {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponStyle'}}
-    {{#*inline "item-field-inputs"}}
-    <select class="item-field-inputs" name="system.classification.style">
-      {{#select system.classification.style}}
-      {{#each config.weaponStyles as |name type|}}
       <option value="{{type}}">{{localize name}}</option>
       {{/each}}
       {{/select}}

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -6,6 +6,32 @@
   {{!-- Item Sheet Body --}}
   <section class="sheet-body item-sheet">
 
+    {{!-- Skill --}}
+    {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponSkill'}}
+    {{#*inline "item-field-inputs"}}
+    <select class="item-field-inputs" name="system.classification.skill">
+      {{#select system.classification.skill}}
+      {{#each config.skills as |name type|}}
+      <option value="{{type}}">{{name}}</option>
+      {{/each}}
+      {{/select}}
+    </select>
+    {{/inline}}
+    {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
+
+    {{!-- Style --}}
+    {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponStyle'}}
+    {{#*inline "item-field-inputs"}}
+    <select class="item-field-inputs" name="system.classification.style">
+      {{#select system.classification.style}}
+      {{#each config.weaponStyles as |name type|}}
+      <option value="{{type}}">{{localize name}}</option>
+      {{/each}}
+      {{/select}}
+    </select>
+    {{/inline}}
+    {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
+
     {{!-- Effect Damage --}}
     {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Damage'}}
     {{#*inline "item-field-inputs"}}


### PR DESCRIPTION
##### In this PR
- Removing fields from weapons that now belong to weapon effects
- Making WE rolls use the correct skill instead of the default
- Copies of WEs are now made when a weapon is dropped onto a sheet
- Fixing down shifts from WEs

##### Testing
- Rolling via WEs from an actor sheet should work for every scenario:
  1. Creating a weapon and effect directly on the actor sheet
  2. Dragging a weapon, but manually creating new effects
  3. Dragging a weapon with existing effects (which this change should fix)
- Try changing the skill on an effect and ensure it shows up correctly when rolled
- WE down shifts should show up in the roll dialog
