### PR TITLE
Weapon effect inline icons, skill selector

### DIFF
--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -14,20 +14,43 @@
   {{/inline}}
 
   {{#*inline "subcontainers" parentItem}}
-  {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.weaponEffects title="E20.ItemTypeWeaponEffectPlural" dataType="weaponEffect" parentId=parentItem._id}}
-    {{#*inline "item-label" item}}
-      {{item.name}}
-    {{/inline}}
-  {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
+    {{!-- Weapon Effects --}}
+    {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.weaponEffects title="E20.ItemTypeWeaponEffectPlural" dataType="weaponEffect" parentId=parentItem._id}}
+      {{#*inline "item-label" item}}
+        <div class="flexrow" style="align-items: center;">
+          <div style="flex-grow: 1.5;">
+            {{item.name}}
+          </div>
+          <select class="inline-edit" data-field="system.classification.skill" name="system.classification.skill">
+            {{#select item.system.classification.skill}}
+            {{#each @root.config.skills as |name type|}}
+            <option value="{{type}}">{{name}}</option>
+            {{/each}}
+            {{/select}}
+          </select>
+          <div style="text-align: center;">
+            {{item.system.numTargets}} <i class="fas fa-bullseye"></i>
+          </div>
+          <div style="text-align: center;">
+            {{item.system.shiftDown}} <i class="fas fa-arrow-down"></i>
+          </div>
+          <div style="text-align: center;">
+            {{item.system.numHands}} <i class="fas fa-hand"></i>
+          </div>
+        </div>
+      {{/inline}}
+    {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
 
-  {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.upgrades title="E20.ItemTypeUpgradePlural" dataType="upgrade" parentId=parentItem._id}}
-    {{#*inline "expand-details" item}}
-      {{> "systems/essence20/templates/actor/parts/items/upgrade/details.hbs"}}
-    {{/inline}}
+    {{!-- Upgrades --}}
+    {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.upgrades title="E20.ItemTypeUpgradePlural" dataType="upgrade" parentId=parentItem._id}}
+      {{#*inline "expand-details" item}}
+        {{> "systems/essence20/templates/actor/parts/items/upgrade/details.hbs"}}
+      {{/inline}}
 
-    {{#*inline "item-label" item}}
-      {{item.name}}
-    {{/inline}}
-  {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
+      {{#*inline "item-label" item}}
+        {{item.name}}
+      {{/inline}}
+    {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
   {{/inline}}
+
 {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs"}}

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -16,6 +16,10 @@
   {{#*inline "subcontainers" parentItem}}
     {{!-- Weapon Effects --}}
     {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.weaponEffects title="E20.ItemTypeWeaponEffectPlural" dataType="weaponEffect" parentId=parentItem._id}}
+      {{#*inline "roll-button"}}
+        <a class="rollable" data-roll-type="weaponEffect" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
+      {{/inline}}
+
       {{#*inline "item-label" item}}
         <div class="flexrow" style="align-items: center;">
           <div style="flex-grow: 1.5;">

--- a/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
+++ b/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
@@ -7,9 +7,9 @@
     <li class="item accordion-wrapper" data-item-id="{{item._id}}" data-parent-id="{{../parentId}}">
       {{!-- Item label and buttons --}}
       {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
-        {{#*inline "roll-button"}}
-          <a class="rollable" data-roll-type="weaponEffect" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
-        {{/inline}}
+        {{#> roll-button}}
+        {{!-- Custom roll button here --}}
+        {{/roll-button}}
 
         {{#> item-label item=item}}
         {{!-- Custom item label here --}}

--- a/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
+++ b/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
@@ -10,6 +10,10 @@
         {{#*inline "roll-button"}}
           <a class="rollable" data-roll-type="weaponEffect" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
         {{/inline}}
+
+        {{#> item-label item=item}}
+        {{!-- Custom item label here --}}
+        {{/item-label}}
       {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs"}}
 
       {{!-- Item content --}}


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/320

##### In this PR
- Adding inline icons and skill selector to weapon effects
- Fixing subcontainer buttons, otherwise upgrades had attack roll buttons

##### Testing
- Weapon effects on actor sheets should have inline icons for targets, downshift, and hands
- Numbers next to these icons should be correct
- Upgrades should no longer have attack roll buttons
