### PR TITLE
Fixing collapsible details for WEs and upgrades

### DIFF
--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -370,7 +370,7 @@ E20.availabilities = {
 preLocalize("availabilities");
 
 // Damage Types
-E20.damageType = {
+E20.damageTypes = {
   blunt: "E20.DamageBlunt",
   element: "E20.DamageElement",
   maneuver: "E20.DamageManeuver",

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -87,6 +87,7 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/items/trait/details.hbs",
     "systems/essence20/templates/actor/parts/items/upgrade/container.hbs",
     "systems/essence20/templates/actor/parts/items/upgrade/details.hbs",
+    "systems/essence20/templates/actor/parts/items/weaponEffect/details.hbs",
     "systems/essence20/templates/actor/parts/items/weapon/container.hbs",
     "systems/essence20/templates/actor/parts/items/weapon/details.hbs",
 

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -43,16 +43,20 @@
           </div>
         </div>
       {{/inline}}
+
+      {{#*inline "expand-details" item}}
+        {{> "systems/essence20/templates/actor/parts/items/weaponEffect/details.hbs"}}
+      {{/inline}}
     {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
 
     {{!-- Upgrades --}}
     {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.upgrades title="E20.ItemTypeUpgradePlural" dataType="upgrade" parentId=parentItem._id}}
-      {{#*inline "expand-details" item}}
-        {{> "systems/essence20/templates/actor/parts/items/upgrade/details.hbs"}}
-      {{/inline}}
-
       {{#*inline "item-label" item}}
         {{item.name}}
+      {{/inline}}
+
+      {{#*inline "expand-details" item}}
+        {{> "systems/essence20/templates/actor/parts/items/upgrade/details.hbs"}}
       {{/inline}}
     {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
   {{/inline}}

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -5,7 +5,7 @@
   <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
   <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
   <span class="chip" name="chip.weapon.damageValue">{{localize 'E20.Damage'}}: {{item.system.damageValue}}</span>
-  <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{item.system.damageType}}</span>
+  <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{localize (lookup @root.config.damageTypes item.system.damageType)}}</span>
   {{#if item.system.shiftDown}}
   <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.system.shiftDown}}</span>
   {{/if}}

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -38,7 +38,7 @@
     <input type="number" name="system.damageValue" value="{{system.damageValue}}" />
     <select name="system.damageType">
       {{#select system.damageType}}
-        {{#each config.damageType as |name type|}}
+        {{#each config.damageTypes as |name type|}}
           <option value="{{type}}">{{localize name}}</option>
         {{/each}}
       {{/select}}


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/320

##### In this PR
- Adding expansion details to WEs and upgrades
- Localizing damage type
- Changing `E20.damageType` to `E20.damageTypes` for consistency

##### Testing
- Should be able to expand WEs and upgrades
- Damage type chip should be localized
