### PR TITLE
Weapon effect damage icons; hover titles

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -161,6 +161,7 @@
     "Damage": "Damage",
     "DamageBlunt": "Blunt",
     "DamageElement": "Element",
+    "DamageIntimidate": "Intimidate",
     "DamageManeuver": "Maneuver",
     "DamageSharp": "Sharp",
     "DamageStun": "Stun",

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -373,6 +373,7 @@ preLocalize("availabilities");
 E20.damageTypes = {
   blunt: "E20.DamageBlunt",
   element: "E20.DamageElement",
+  intimidate: "E20.DamageIntimidate",
   maneuver: "E20.DamageManeuver",
   sharp: "E20.DamageSharp",
   stun: "E20.DamageStun",

--- a/template.json
+++ b/template.json
@@ -869,7 +869,7 @@
         "skill": "athletics",
         "style": "melee"
       },
-      "damageType": "",
+      "damageType": "blunt",
       "damageValue": 1,
       "shiftDown": 0,
       "numHands": 1,

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -32,14 +32,30 @@
             {{/each}}
             {{/select}}
           </select>
-          <div style="text-align: center;">
+          <div style="text-align: center;" title="{{item.system.numTargets}} {{localize "E20.WeaponTargets"}}">
             {{item.system.numTargets}} <i class="fas fa-bullseye"></i>
           </div>
-          <div style="text-align: center;">
+          <div style="text-align: center;" title="{{item.system.shiftDown}} {{localize "E20.ShiftDown"}}">
             {{item.system.shiftDown}} <i class="fas fa-arrow-down"></i>
           </div>
-          <div style="text-align: center;">
+          <div style="text-align: center;" title="{{item.system.numHands}} {{localize "E20.WeaponHands"}}">
             {{item.system.numHands}} <i class="fas fa-hand"></i>
+          </div>
+          <div style="text-align: center;" title="{{item.system.damageValue}} {{localize (lookup @root.config.damageTypes item.system.damageType)}} {{localize "E20.Damage"}}">
+            {{item.system.damageValue}}
+            {{#ifEquals item.system.damageType 'sharp'}}
+              <i class="fas fa-sword"></i>
+            {{else ifEquals item.system.damageType 'blunt'}}
+              <i class="fas fa-hammer"></i>
+            {{else ifEquals item.system.damageType 'element'}}
+              <i class="fas fa-droplet"></i>
+            {{else ifEquals item.system.damageType 'maneuver'}}
+              <i class="fas fa-person-falling"></i>
+            {{else ifEquals item.system.damageType 'stun'}}
+              <i class="fas fa-face-spiral-eyes"></i>
+            {{else ifEquals item.system.damageType 'intimidate'}}
+              <i class="fas fa-person-harassing"></i>
+            {{/ifEquals}}
           </div>
         </div>
       {{/inline}}

--- a/templates/actor/parts/items/weapon/details.hbs
+++ b/templates/actor/parts/items/weapon/details.hbs
@@ -1,6 +1,3 @@
-<div>{{localize 'E20.WeaponEffect'}}: {{item.system.effect}}</div>
-<div>{{localize 'E20.WeaponAlternateEffects'}}: {{item.system.alternateEffects}}</div>
-<div>{{localize 'E20.UpgradePlural'}}: {{item.system.upgrades}}</div>
 <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
 
 <div class="chip-section">

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -4,7 +4,9 @@
   <span class="chip" name="chip.weapon.classification">{{lookup @root.config.skills item.system.classification.skill}} {{lookup @root.config.weaponSizes item.system.classification.size}} {{lookup @root.config.weaponStyles item.system.classification.style}}</span>
   <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
   <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
+  {{#if item.system.damageValue}}
   <span class="chip" name="chip.weapon.damageValue">{{localize 'E20.Damage'}}: {{item.system.damageValue}}</span>
+  {{/if}}
   <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{localize (lookup @root.config.damageTypes item.system.damageType)}}</span>
   {{#if item.system.shiftDown}}
   <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.system.shiftDown}}</span>


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/320

##### In this PR
- Adding inline damage icons to WEs
- Adding Intimidate damage type
- Adding titles for icons
- Cleaning up weapon details
- Blunt is now the default damage type, instead of ""
- Damage chip for WE details only shows up if it's an actual value

##### Testing
- WE icons should appear as expected
- Titles appear when hovering icons
- The damage chip for WE details should only appear if it's not "" or 0