### PR TITLE
Adding "Other" as an option for TF faction

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -189,6 +189,7 @@
     "EssenceStrength": "Strength",
     "FactionAutobots": "Autobots",
     "FactionDecepticons": "Decepticons",
+    "FactionOther": "Other",
     "GearClothes": "Clothes",
     "GearComputers": "Computers & Electronics",
     "GearExploration": "Exploration Gear",

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -477,6 +477,7 @@ preLocalize("movementTypes");
 E20.transformerFactions = {
   autobots: "E20.FactionAutobots",
   decepticons: "E20.FactionDecepticons",
+  other: "E20.FactionOther",
 };
 preLocalize("transformerFactions");
 


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/463

##### In this PR
- Adding "Other" as an option for TF faction
- This was a whole discussion we had months ago, and it seems like we landed on just doing this. Open to adding other ones too.

##### Testing
- "Other" should be selectable as a TF faction
