### PR TITLE
Deleting attachments when weapons/armor deleted

### DIFF
--- a/module/sheet-handlers/alteration-handler.mjs
+++ b/module/sheet-handlers/alteration-handler.mjs
@@ -397,7 +397,7 @@ export class AlterationHandler {
   * Handle the deleting of the alteration from a character
   * @param {Alteration} alteration The alteration
   */
-  async _onAlterationDelete(alteration) {
+  async onAlterationDelete(alteration) {
     if (alteration.system.movementCost) {
       let totalMovementDecrease = 0;
       for (const movementReductionType in alteration.system.movementCost) {

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -1,7 +1,7 @@
 import {
   getItemsOfType,
   itemDeleteById,
-  rememberOptions
+  rememberOptions,
 } from "../helpers/utils.mjs";
 
 export class AttachmentHandler {

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -1,4 +1,8 @@
-import { getItemsOfType, rememberOptions } from "../helpers/utils.mjs";
+import {
+  getItemsOfType,
+  itemDeleteById,
+  rememberOptions
+} from "../helpers/utils.mjs";
 
 export class AttachmentHandler {
   /**
@@ -80,6 +84,19 @@ export class AttachmentHandler {
       const itemAttachmentIds = item.system[`${newAttachment.type}Ids`];
       itemAttachmentIds.push(newAttachment._id);
       await item.update({ [`system.${newAttachment.type}Ids`]: itemAttachmentIds });
+    }
+  }
+
+  /**
+  * Handle deleting the attachments of an item from an Actor Sheet
+  * @param {Item} item                The Item
+  * @param {String[]} attachmentTypes The types of attachments the Item has
+  */
+  deleteAttachments(item, attachmentTypes) {
+    for (const attachmentType of attachmentTypes) {
+      for (const attachmentId of item.system[`${attachmentType}Ids`]) {
+        itemDeleteById(attachmentId, this._actor);
+      }
     }
   }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -619,7 +619,11 @@ export class Essence20ActorSheet extends ActorSheet {
     } else if (item.type == "altMode") {
       this._tfHandler.onAltModeDelete(item, this);
     } else if (item.type == "alteration") {
-      this._alHandler._onAlterationDelete(item);
+      this._alHandler.onAlterationDelete(item);
+    } else if (item.type == "weapon") {
+      this._atHandler.deleteAttachments(item, ["upgrade", "weaponEffect"]);
+    } else if (item.type == "armor") {
+      this._atHandler.deleteAttachments(item, ["upgrade"]);
     }
 
     item.delete();


### PR DESCRIPTION
##### In this PR
- Iterates over attachments when armor or weapons are deleted on an actor sheet
- `_onAlterationDelete()` is a public method (used by actor-sheet.mjs), so I'm removing the `_`

##### Testing
- Optional steps for some background
  - On `beta`, populate an actor sheet with a weapon and give it effects and upgrades
  - Delete the weapon
  - Do `game.actors.get('<actor ID>').items`. The weapon will be gone, but the weaponEffects and upgrades remain
- Follow the steps above on this branch. The weapon, weaponEffects, and upgrades will now be gone
- Do the same for armor