### PR TITLE
Removing weapon effect icons for NPCs

### DIFF
--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -32,31 +32,36 @@
             {{/each}}
             {{/select}}
           </select>
-          <div style="text-align: center;" title="{{item.system.numTargets}} {{localize "E20.WeaponTargets"}}">
-            {{item.system.numTargets}} <i class="fas fa-bullseye"></i>
-          </div>
-          <div style="text-align: center;" title="{{item.system.shiftDown}} {{localize "E20.ShiftDown"}}">
-            {{item.system.shiftDown}} <i class="fas fa-arrow-down"></i>
-          </div>
-          <div style="text-align: center;" title="{{item.system.numHands}} {{localize "E20.WeaponHands"}}">
-            {{item.system.numHands}} <i class="fas fa-hand"></i>
-          </div>
-          <div style="text-align: center;" title="{{item.system.damageValue}} {{localize (lookup @root.config.damageTypes item.system.damageType)}} {{localize "E20.Damage"}}">
-            {{item.system.damageValue}}
-            {{#ifEquals item.system.damageType 'sharp'}}
-              <i class="fas fa-sword"></i>
-            {{else ifEquals item.system.damageType 'blunt'}}
-              <i class="fas fa-hammer"></i>
-            {{else ifEquals item.system.damageType 'element'}}
-              <i class="fas fa-droplet"></i>
-            {{else ifEquals item.system.damageType 'maneuver'}}
-              <i class="fas fa-person-falling"></i>
-            {{else ifEquals item.system.damageType 'stun'}}
-              <i class="fas fa-face-spiral-eyes"></i>
-            {{else ifEquals item.system.damageType 'intimidate'}}
-              <i class="fas fa-person-harassing"></i>
-            {{/ifEquals}}
-          </div>
+
+          {{#ifEquals "npc" @root.actor.type}}
+            {{!-- NPCs don't have enough room for weapon effect icons --}}
+          {{else}}
+            <div style="text-align: center;" title="{{item.system.numTargets}} {{localize "E20.WeaponTargets"}}">
+              {{item.system.numTargets}} <i class="fas fa-bullseye"></i>
+            </div>
+            <div style="text-align: center;" title="{{item.system.shiftDown}} {{localize "E20.ShiftDown"}}">
+              {{item.system.shiftDown}} <i class="fas fa-arrow-down"></i>
+            </div>
+            <div style="text-align: center;" title="{{item.system.numHands}} {{localize "E20.WeaponHands"}}">
+              {{item.system.numHands}} <i class="fas fa-hand"></i>
+            </div>
+            <div style="text-align: center;" title="{{item.system.damageValue}} {{localize (lookup @root.config.damageTypes item.system.damageType)}} {{localize "E20.Damage"}}">
+              {{item.system.damageValue}}
+              {{#ifEquals item.system.damageType 'sharp'}}
+                <i class="fas fa-sword"></i>
+              {{else ifEquals item.system.damageType 'blunt'}}
+                <i class="fas fa-hammer"></i>
+              {{else ifEquals item.system.damageType 'element'}}
+                <i class="fas fa-droplet"></i>
+              {{else ifEquals item.system.damageType 'maneuver'}}
+                <i class="fas fa-person-falling"></i>
+              {{else ifEquals item.system.damageType 'stun'}}
+                <i class="fas fa-face-spiral-eyes"></i>
+              {{else ifEquals item.system.damageType 'intimidate'}}
+                <i class="fas fa-person-harassing"></i>
+              {{/ifEquals}}
+            </div>
+          {{/ifEquals}}
         </div>
       {{/inline}}
 


### PR DESCRIPTION
##### In this PR
- Removing weapon effect icons for NPCs since room is limited

##### Testing
- Icons should appear for all actors except for NPCs
