### PR TITLE
Fixing item sorting on actor sheets

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -760,7 +760,7 @@ export class Essence20ActorSheet extends ActorSheet {
     // Drones can only accept drone Upgrades
     const itemUuid = await parseId(data.uuid);
 
-    const droppedItemList = await super._onDropItem(event, data);
+    let droppedItemList = await super._onDropItem(event, data);
 
     if (isNewItem) {
       const newItem = droppedItemList[0];


### PR DESCRIPTION
##### In this PR
- Checks if the item being dropped already belongs to actor. If so, it will now allow sorting.

##### Testing
- Dragging items within a list should now allow sorting without adding new items
- Still able to drag items onto sheets as normal
