### PR TITLE
Fixing role `text` inputs to be `number`

### DIFF
--- a/module/helpers/roll-dialog.mjs
+++ b/module/helpers/roll-dialog.mjs
@@ -66,7 +66,7 @@ export class RollDialog {
         default: "normal",
         close: () => resolve({ cancelled: true }),
       };
-      
+
       new Dialog(data, null).render(true);
     });
   }
@@ -79,11 +79,11 @@ export class RollDialog {
   _processSkillRollOptions(form) {
     return {
       edge: form.snagEdge.value == 'edge',
-      shiftDown: parseInt(form.shiftDown.value),
-      shiftUp: parseInt(form.shiftUp.value),
+      shiftDown: form.shiftDown.value,
+      shiftUp: form.shiftUp.value,
       snag: form.snagEdge.value == 'snag',
       isSpecialized: form.isSpecialized.checked,
-      timesToRoll: parseInt(form.timesToRoll.value),
+      timesToRoll: form.timesToRoll.value,
     };
   }
 }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -494,9 +494,9 @@ export async function setRoleValues(role, actor, newLevel=null, previousLevel=nu
   if (role.system.powers.personal.starting) {
     const totalChange = await roleValueChange(actor.system.level, role.system.powers.personal.levels, previousLevel);
     const newPersonalPowerMax =
-        parseInt(actor.system.powers.personal.max)
-      + newLevel ? 0 : parseInt(role.system.powers.personal.starting)
-      + parseInt(role.system.powers.personal.increase * totalChange);
+        actor.system.powers.personal.max
+      + newLevel ? 0 : role.system.powers.personal.starting
+      + role.system.powers.personal.increase * totalChange;
 
     await actor.update({
       "system.powers.personal.max": newPersonalPowerMax,

--- a/templates/item/sheets/role.hbs
+++ b/templates/item/sheets/role.hbs
@@ -112,14 +112,14 @@
           {{!-- Personal Power Starting Capacity --}}
           {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerPersonalStartingCapacity'}}
           {{#*inline "item-field-inputs"}}
-          <input type="text" name="system.powers.personal.starting" value="{{system.powers.personal.starting}}" />
+          <input type="number" name="system.powers.personal.starting" value="{{system.powers.personal.starting}}" />
           {{/inline}}
           {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
           {{!-- Personal Power Increase Amount --}}
           {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerPersonalIncrease'}}
           {{#*inline "item-field-inputs"}}
-          <input type="text" name="system.powers.personal.increase" value="{{system.powers.personal.increase}}" />
+          <input type="number" name="system.powers.personal.increase" value="{{system.powers.personal.increase}}" />
           {{/inline}}
           {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 


### PR DESCRIPTION
Draft: Need to re-export Roles

##### In this PR
- Changing `increase` and `starting` personal power inputs to be numbers for Roles, allowing us to remove `parseInt`
- `parseInt` also not needed for roll dialog

##### Testing
- Skill roles should still work as normal
- Roles should still work as normal
