### PR TITLE
Replacing numeric inputs with `numberInput` for items

### DIFF
--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -494,9 +494,9 @@ export async function setRoleValues(role, actor, newLevel=null, previousLevel=nu
   if (role.system.powers.personal.starting) {
     const totalChange = await roleValueChange(actor.system.level, role.system.powers.personal.levels, previousLevel);
     const newPersonalPowerMax =
-        parseInt(actor.system.powers.personal.max)
-      + newLevel ? 0 : parseInt(role.system.powers.personal.starting)
-      + parseInt(role.system.powers.personal.increase * totalChange);
+        actor.system.powers.personal.max
+      + newLevel ? 0 : role.system.powers.personal.starting
+      + role.system.powers.personal.increase * totalChange;
 
     await actor.update({
       "system.powers.personal.max": newPersonalPowerMax,

--- a/templates/actor/parts/headers/gijoe.hbs
+++ b/templates/actor/parts/headers/gijoe.hbs
@@ -16,7 +16,7 @@
 </div>
 <div class="pr-header-level">
   <label for="system.level" class="resource-label">{{localize 'E20.ActorLevel'}}</label>
-  {{numberInput system.level name="system.level"}}
+  {{numberInput system.level name="system.level" min=0 step=1}}
 </div>
 <div class="pr-header-color flex-group-center">
   <label for="system.color" class="resource-label">{{localize 'E20.ActorColor'}}</label>

--- a/templates/actor/parts/headers/pony.hbs
+++ b/templates/actor/parts/headers/pony.hbs
@@ -13,7 +13,7 @@
 </div>
 <div class="pr-header-level">
   <label for="system.level" class="resource-label">{{localize 'E20.ActorLevel'}}</label>
-  {{numberInput system.level name="system.level"}}
+  {{numberInput system.level name="system.level" min=0 step=1}}
 </div>
 <div class="pr-header-color flex-group-center">
   <label for="system.color" class="resource-label">{{localize 'E20.ActorColor'}}</label>

--- a/templates/actor/parts/headers/pr.hbs
+++ b/templates/actor/parts/headers/pr.hbs
@@ -16,7 +16,7 @@
 
 <div class="pr-header-level">
   <label for="system.level" class="resource-label">{{localize 'E20.ActorLevel'}}</label>
-  {{numberInput system.level name="system.level"}}
+  {{numberInput system.level name="system.level" min=0 step=1}}
 </div>
 
 <div class="pr-header-color flex-group-center">

--- a/templates/actor/parts/headers/transformer.hbs
+++ b/templates/actor/parts/headers/transformer.hbs
@@ -22,7 +22,7 @@
 </div>
 <div class="pr-header-level">
   <label for="system.level" class="resource-label">{{localize 'E20.ActorLevel'}}</label>
-  {{numberInput system.level name="system.level"}}
+  {{numberInput system.level name="system.level" min=0 step=1}}
 </div>
 <div class="pr-header-color flex-group-center">
   <label for="system.color" class="resource-label">{{localize 'E20.ActorColor'}}</label>

--- a/templates/item/parts/description.hbs
+++ b/templates/item/parts/description.hbs
@@ -2,7 +2,7 @@
 {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ItemSource'}}
 {{#*inline "item-field-inputs"}}
 <input type="text" name="system.source.book" value="{{system.source.book}}" placeholder="{{localize 'E20.ItemSourceBook'}}"/>
-<input class="two-digit-input" type="number" name="system.source.page" value="{{system.source.page}}" placeholder="{{localize 'E20.ItemSourcePage'}}" />
+<input class="two-digit-input" type="number" name="system.source.page" value="{{system.source.page}}" placeholder="{{localize 'E20.ItemSourcePage'}}" min="0" step="1"/>
 {{/inline}}
 {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/parts/role-perk-drop.hbs
+++ b/templates/item/parts/role-perk-drop.hbs
@@ -9,7 +9,7 @@
             <li class="item">
             <div class="flexrow" style="align-items: center; flex-wrap: nowrap">
               <label style="white-space: nowrap; overflow: hidden;">{{item.name}}</label>
-              <input type="number" class="level" placeholder="Level" value="{{item.level}}" name="system.items.{{@key}}.level" />
+              <input type="number" class="level" placeholder="Level" value="{{item.level}}" name="system.items.{{@key}}.level" min="0" step="1" />
               <div class="item-controls">
                 <a class="item-control {{../className}}-delete flex-right" title="{{localize 'E20.DeleteItem'}}">
                   <i class="fas fa-trash"></i>

--- a/templates/item/sheets/altMode.hbs
+++ b/templates/item/sheets/altMode.hbs
@@ -54,14 +54,14 @@
       {{!-- Alt Mode Crew --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeCrew'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.altModeCrew name="system.altModeCrew" min=0}}
+      {{numberInput system.altModeCrew name="system.altModeCrew" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Alt Mode Firepoints --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeFirepoints'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.altModeFirepoints name="system.altModeFirepoints" min=0}}
+      {{numberInput system.altModeFirepoints name="system.altModeFirepoints" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/altMode.hbs
+++ b/templates/item/sheets/altMode.hbs
@@ -20,21 +20,21 @@
       {{!-- Alt Mode Movement Aerial --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeMovementAerial'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.altModeMovement.aerial name="system.altModeMovement.aerial" min=0}}
+      {{numberInput system.altModeMovement.aerial name="system.altModeMovement.aerial" min=0 step=5}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Alt Movement Aquatic --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeMovementAquatic'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.altModeMovement.aquatic name="system.altModeMovement.aquatic" min=0}}
+      {{numberInput system.altModeMovement.aquatic name="system.altModeMovement.aquatic" min=0 step=5}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Alt Movement Ground --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeMovementGround'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.altModeMovement.ground name="system.altModeMovement.ground" min=0}}
+      {{numberInput system.altModeMovement.ground name="system.altModeMovement.ground" min=0 step=5}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/altMode.hbs
+++ b/templates/item/sheets/altMode.hbs
@@ -20,21 +20,21 @@
       {{!-- Alt Mode Movement Aerial --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeMovementAerial'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.altModeMovement.aerial" value="{{system.altModeMovement.aerial}}" />
+      {{numberInput system.altModeMovement.aerial name="system.altModeMovement.aerial" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Alt Movement Aquatic --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeMovementAquatic'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.altModeMovement.aquatic" value="{{system.altModeMovement.aquatic}}" />
+      {{numberInput system.altModeMovement.aquatic name="system.altModeMovement.aquatic" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Alt Movement Ground --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeMovementGround'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.altModeMovement.ground" value="{{system.altModeMovement.ground}}" />
+      {{numberInput system.altModeMovement.ground name="system.altModeMovement.ground" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -54,14 +54,14 @@
       {{!-- Alt Mode Crew --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeCrew'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.altModeCrew" value="{{system.altModeCrew}}" />
+      {{numberInput system.altModeCrew name="system.altModeCrew" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Alt Mode Firepoints --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AltModeFirepoints'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.altModeFirepoints" value="{{system.altModeFirepoints}}" />
+      {{numberInput system.altModeFirepoints name="system.altModeFirepoints" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -69,4 +69,3 @@
   </section>
 
 </form>
-

--- a/templates/item/sheets/alteration.hbs
+++ b/templates/item/sheets/alteration.hbs
@@ -85,7 +85,7 @@
         {{!-- Alteration Movement Bonus --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AlterationBonusMovement'}}
         {{#*inline "item-field-inputs"}}
-        {{numberInput system.bonusMovement name="system.bonusMovement" min=0}}
+        {{numberInput system.bonusMovement name="system.bonusMovement" min=0 step=5}}
         <select name="system.bonusMovementType">
           {{#select system.bonusMovementType}}
           {{#each config.movementTypes as |name type|}}
@@ -99,7 +99,7 @@
         {{!-- Alteration Movement Cost --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AlterationCostMovement'}}
         {{#*inline "item-field-inputs"}}
-        {{numberInput system.costMovement name="system.costMovement" min=0}}
+        {{numberInput system.costMovement name="system.costMovement" min=0 step=5}}
         <select name="system.costMovementType">
           {{#select system.costMovementType}}
           {{#each config.movementTypes as |name type|}}

--- a/templates/item/sheets/alteration.hbs
+++ b/templates/item/sheets/alteration.hbs
@@ -85,7 +85,7 @@
         {{!-- Alteration Movement Bonus --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AlterationBonusMovement'}}
         {{#*inline "item-field-inputs"}}
-        <input type="number" name="system.bonusMovement" value="{{system.bonusMovement}}" />
+        {{numberInput system.bonusMovement name="system.bonusMovement" min=0}}
         <select name="system.bonusMovementType">
           {{#select system.bonusMovementType}}
           {{#each config.movementTypes as |name type|}}
@@ -99,7 +99,7 @@
         {{!-- Alteration Movement Cost --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.AlterationCostMovement'}}
         {{#*inline "item-field-inputs"}}
-        <input type="number" name="system.costMovement" value="{{system.costMovement}}" />
+        {{numberInput system.costMovement name="system.costMovement" min=0}}
         <select name="system.costMovementType">
           {{#select system.costMovementType}}
           {{#each config.movementTypes as |name type|}}
@@ -115,14 +115,14 @@
         {{!-- Alteration Non Essence Bonus --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Bonus'}}
         {{#*inline "item-field-inputs"}}
-        <input type="number" name="system.bonus" value="{{system.bonus}}" />
+        {{numberInput system.bonus name="system.bonus" min=0}}
         {{/inline}}
         {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
         {{!-- Alteration Non Essence Bonus --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Cost'}}
         {{#*inline "item-field-inputs"}}
-        <input type="number" name="system.cost" value="{{system.cost}}" />
+        {{numberInput system.cost name="system.cost" min=0}}
         {{/inline}}
         {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
       {{/ifEquals}}

--- a/templates/item/sheets/alteration.hbs
+++ b/templates/item/sheets/alteration.hbs
@@ -115,14 +115,14 @@
         {{!-- Alteration Non Essence Bonus --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Bonus'}}
         {{#*inline "item-field-inputs"}}
-        {{numberInput system.bonus name="system.bonus" min=0}}
+        {{numberInput system.bonus name="system.bonus" min=0 step=1}}
         {{/inline}}
         {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
         {{!-- Alteration Non Essence Bonus --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Cost'}}
         {{#*inline "item-field-inputs"}}
-        {{numberInput system.cost name="system.cost" min=0}}
+        {{numberInput system.cost name="system.cost" min=0 step=1}}
         {{/inline}}
         {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
       {{/ifEquals}}

--- a/templates/item/sheets/armor.hbs
+++ b/templates/item/sheets/armor.hbs
@@ -65,14 +65,14 @@
       {{!-- Toughness --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ArmorBonusToughness'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.bonusToughness name="system.bonusToughness" min=0}}
+      {{numberInput system.bonusToughness name="system.bonusToughness" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Evasion --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ArmorBonusEvasion'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.bonusEvasion name="system.bonusEvasion" min=0}}
+      {{numberInput system.bonusEvasion name="system.bonusEvasion" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/armor.hbs
+++ b/templates/item/sheets/armor.hbs
@@ -65,14 +65,14 @@
       {{!-- Toughness --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ArmorBonusToughness'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.bonusToughness" value="{{system.bonusToughness}}" />
+      {{numberInput system.bonusToughness name="system.bonusToughness" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Evasion --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ArmorBonusEvasion'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.bonusEvasion" value="{{system.bonusEvasion}}" />
+      {{numberInput system.bonusEvasion name="system.bonusEvasion" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/classFeature.hbs
+++ b/templates/item/sheets/classFeature.hbs
@@ -21,9 +21,9 @@
       {{!-- Uses --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ClassFeatureUses'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.uses.value" value="{{system.uses.value}}" />
+      {{numberInput system.uses.value name="system.uses.value" min=0}}
       <div class="min-max-divider">/</div>
-      <input type="number" name="system.uses.max" value="{{system.uses.max}}" />
+      {{numberInput system.uses.max name="system.uses.max" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>

--- a/templates/item/sheets/classFeature.hbs
+++ b/templates/item/sheets/classFeature.hbs
@@ -21,9 +21,9 @@
       {{!-- Uses --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ClassFeatureUses'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.uses.value name="system.uses.value" min=0}}
+      {{numberInput system.uses.value name="system.uses.value" min=0 step=1}}
       <div class="min-max-divider">/</div>
-      {{numberInput system.uses.max name="system.uses.max" min=0}}
+      {{numberInput system.uses.max name="system.uses.max" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>

--- a/templates/item/sheets/contact.hbs
+++ b/templates/item/sheets/contact.hbs
@@ -21,7 +21,7 @@
       {{!-- Allegiance Points --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ContactAllegiancePoints'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.allegiancePoints" value="{{system.allegiancePoints}}" />
+      {{numberInput system.allegiancePoints name="system.allegiancePoints" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/contact.hbs
+++ b/templates/item/sheets/contact.hbs
@@ -21,7 +21,7 @@
       {{!-- Allegiance Points --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ContactAllegiancePoints'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.allegiancePoints name="system.allegiancePoints" min=0}}
+      {{numberInput system.allegiancePoints name="system.allegiancePoints" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/gear.hbs
+++ b/templates/item/sheets/gear.hbs
@@ -33,7 +33,7 @@
 
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.GearQuantity'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.quantity name="system.quantity" min=0}}
+      {{numberInput system.quantity name="system.quantity" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>

--- a/templates/item/sheets/gear.hbs
+++ b/templates/item/sheets/gear.hbs
@@ -33,7 +33,7 @@
 
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.GearQuantity'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.quantity" value="{{system.quantity}}" />
+      {{numberInput system.quantity name="system.quantity" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>

--- a/templates/item/sheets/origin.hbs
+++ b/templates/item/sheets/origin.hbs
@@ -63,21 +63,21 @@
       {{!-- Base Aerial Movement--}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.BaseAerialMovement'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.baseAerialMovement name="system.baseAerialMovement" min=0}}
+      {{numberInput system.baseAerialMovement name="system.baseAerialMovement" min=0 step=5}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Base Aquatic Movement --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.BaseAquaticMovement'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.baseAquaticMovement name="system.baseAquaticMovement" min=0}}
+      {{numberInput system.baseAquaticMovement name="system.baseAquaticMovement" min=0 step=5}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Base Aquatic Movement --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.BaseGroundMovement'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.baseGroundMovement name="system.baseGroundMovement" min=0}}
+      {{numberInput system.baseGroundMovement name="system.baseGroundMovement" min=0 step=5}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/origin.hbs
+++ b/templates/item/sheets/origin.hbs
@@ -63,21 +63,21 @@
       {{!-- Base Aerial Movement--}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.BaseAerialMovement'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.baseAerialMovement" value="{{system.baseAerialMovement}}" />
+      {{numberInput system.baseAerialMovement name="system.baseAerialMovement" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Base Aquatic Movement --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.BaseAquaticMovement'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.baseAquaticMovement" value="{{system.baseAquaticMovement}}" />
+      {{numberInput system.baseAquaticMovement name="system.baseAquaticMovement" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Base Aquatic Movement --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.BaseGroundMovement'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.baseGroundMovement" value="{{system.baseGroundMovement}}" />
+      {{numberInput system.baseGroundMovement name="system.baseGroundMovement" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/origin.hbs
+++ b/templates/item/sheets/origin.hbs
@@ -20,7 +20,7 @@
       {{!-- Starting Health --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.OriginStartingHealth'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" class="flex-group-right" name="system.startingHealth" value="{{system.startingHealth}}" />
+      <input type="number" class="flex-group-right" name="system.startingHealth" value="{{system.startingHealth}}" min="0" step="1"/>
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/perk.hbs
+++ b/templates/item/sheets/perk.hbs
@@ -34,7 +34,7 @@
       {{!-- Selection Limit --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.SelectionLimit'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.selectionLimit name="system.selectionLimit" min=0}}
+      {{numberInput system.selectionLimit name="system.selectionLimit" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/perk.hbs
+++ b/templates/item/sheets/perk.hbs
@@ -34,7 +34,7 @@
       {{!-- Selection Limit --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.SelectionLimit'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.selectionLimit" value="{{system.selectionLimit}}" />
+      {{numberInput system.selectionLimit name="system.selectionLimit" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/power.hbs
+++ b/templates/item/sheets/power.hbs
@@ -35,7 +35,7 @@
       {{!-- Times Selected --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.SelectionLimit'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.selectionLimit" value="{{system.selectionLimit}}" />
+      {{numberInput system.selectionLimit name="system.selectionLimit" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -50,7 +50,7 @@
         {{!-- Power Cost --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerCost'}}
         {{#*inline "item-field-inputs"}}
-        <input type="number" name="system.powerCost" value="{{system.powerCost}}" />
+        {{numberInput system.powerCost name="system.powerCost" min=0}}
         {{/inline}}
         {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -65,7 +65,7 @@
           {{!-- Max Power Cost --}}
           {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerMaxCost'}}
           {{#*inline "item-field-inputs"}}
-          <input type="number" name="system.maxPowerCost" value="{{system.maxPowerCost}}" />
+          {{numberInput system.maxPowerCost name="system.maxPowerCost" min=0}}
           {{/inline}}
           {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
         {{/ifEquals}}
@@ -86,7 +86,7 @@
         {{!-- Uses Per Scene --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerUsesPer'}}
         {{#*inline "item-field-inputs"}}
-        <input type="number" name="system.usesPer" value="{{system.usesPer}}" />
+        {{numberInput system.usesPer name="system.usesPer" min=0}}
         <select name="system.usesInterval">
           {{#select system.usesInterval}}
           {{#each config.usesInterval as |name type|}}

--- a/templates/item/sheets/power.hbs
+++ b/templates/item/sheets/power.hbs
@@ -35,7 +35,7 @@
       {{!-- Times Selected --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.SelectionLimit'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.selectionLimit name="system.selectionLimit" min=0}}
+      {{numberInput system.selectionLimit name="system.selectionLimit" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -50,7 +50,7 @@
         {{!-- Power Cost --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerCost'}}
         {{#*inline "item-field-inputs"}}
-        {{numberInput system.powerCost name="system.powerCost" min=0}}
+        {{numberInput system.powerCost name="system.powerCost" min=0 step=1}}
         {{/inline}}
         {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -65,7 +65,7 @@
           {{!-- Max Power Cost --}}
           {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerMaxCost'}}
           {{#*inline "item-field-inputs"}}
-          {{numberInput system.maxPowerCost name="system.maxPowerCost" min=0}}
+          {{numberInput system.maxPowerCost name="system.maxPowerCost" min=0 step=1}}
           {{/inline}}
           {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
         {{/ifEquals}}
@@ -86,7 +86,7 @@
         {{!-- Uses Per Scene --}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerUsesPer'}}
         {{#*inline "item-field-inputs"}}
-        {{numberInput system.usesPer name="system.usesPer" min=0}}
+        {{numberInput system.usesPer name="system.usesPer" min=0 step=1}}
         <select name="system.usesInterval">
           {{#select system.usesInterval}}
           {{#each config.usesInterval as |name type|}}

--- a/templates/item/sheets/role.hbs
+++ b/templates/item/sheets/role.hbs
@@ -112,14 +112,14 @@
           {{!-- Personal Power Starting Capacity --}}
           {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerPersonalStartingCapacity'}}
           {{#*inline "item-field-inputs"}}
-          <input type="text" name="system.powers.personal.starting" value="{{system.powers.personal.starting}}" />
+          {{numberInput system.powers.personal.starting name="system.powers.personal.starting" min=0 step=1}}
           {{/inline}}
           {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
           {{!-- Personal Power Increase Amount --}}
           {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.PowerPersonalIncrease'}}
           {{#*inline "item-field-inputs"}}
-          <input type="text" name="system.powers.personal.increase" value="{{system.powers.personal.increase}}" />
+          {{numberInput system.powers.personal.increase name="system.powers.personal.increase" min=0 step=1}}
           {{/inline}}
           {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/spell.hbs
+++ b/templates/item/sheets/spell.hbs
@@ -46,7 +46,7 @@
       {{!-- Cost --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Cost'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.cost name="system.cost" min=0}}
+      {{numberInput system.cost name="system.cost" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/spell.hbs
+++ b/templates/item/sheets/spell.hbs
@@ -46,7 +46,7 @@
       {{!-- Cost --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Cost'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.cost" value="{{system.cost}}" />
+      {{numberInput system.cost name="system.cost" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/upgrade.hbs
+++ b/templates/item/sheets/upgrade.hbs
@@ -62,7 +62,7 @@
       {{#ifEquals item.system.type 'armor'}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ArmorBonus'}}
         {{#*inline "item-field-inputs"}}
-          <input type="number" name="system.armorBonus.value" value="{{system.armorBonus.value}}" />
+          {{numberInput system.armorBonus.value name="system.armorBonus.value" min=0}}
           <select name="system.armorBonus.defense">
           {{#select system.armorBonus.defense}}
           {{#each config.defenses as |name defense|}}

--- a/templates/item/sheets/upgrade.hbs
+++ b/templates/item/sheets/upgrade.hbs
@@ -62,7 +62,7 @@
       {{#ifEquals item.system.type 'armor'}}
         {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ArmorBonus'}}
         {{#*inline "item-field-inputs"}}
-          {{numberInput system.armorBonus.value name="system.armorBonus.value" min=0}}
+          {{numberInput system.armorBonus.value name="system.armorBonus.value" min=0 step=1}}
           <select name="system.armorBonus.defense">
           {{#select system.armorBonus.defense}}
           {{#each config.defenses as |name defense|}}

--- a/templates/item/sheets/weapon.hbs
+++ b/templates/item/sheets/weapon.hbs
@@ -63,7 +63,7 @@
       {{!-- Charges --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponUsesPerScene'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.usesPerScene name="system.usesPerScene" min=0}}
+      {{numberInput system.usesPerScene name="system.usesPerScene" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/weapon.hbs
+++ b/templates/item/sheets/weapon.hbs
@@ -63,7 +63,7 @@
       {{!-- Charges --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponUsesPerScene'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.usesPerScene" value="{{system.usesPerScene}}" />
+      {{numberInput system.usesPerScene name="system.usesPerScene" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -46,7 +46,7 @@
       {{!-- Effect Damage --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Damage'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.damageValue name="system.damageValue" min=0}}
+      {{numberInput system.damageValue name="system.damageValue" min=0 step=1}}
       <select name="system.damageType">
         {{#select system.damageType}}
           {{#each config.damageTypes as |name type|}}
@@ -67,7 +67,7 @@
       {{!-- Radius --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponRadius'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.radius name="system.radius" min=0}}
+      {{numberInput system.radius name="system.radius" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -46,7 +46,7 @@
       {{!-- Effect Damage --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.Damage'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.damageValue" value="{{system.damageValue}}" />
+      {{numberInput system.damageValue name="system.damageValue" min=0}}
       <select name="system.damageType">
         {{#select system.damageType}}
           {{#each config.damageTypes as |name type|}}
@@ -67,14 +67,14 @@
       {{!-- Radius --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponRadius'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.radius" value="{{system.radius}}" />
+      {{numberInput system.radius name="system.radius" min=0}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
       {{!-- Shift Down --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.ShiftDown'}}
       {{#*inline "item-field-inputs"}}
-      <input type="number" name="system.shiftDown" value="{{system.shiftDown}}" />
+      {{numberInput system.shiftDown name="system.shiftDown" min=0 step=1}}
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -60,7 +60,7 @@
       {{!-- Targets --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponTargets'}}
       {{#*inline "item-field-inputs"}}
-      <input class="item-field-inputs" type="number" name="system.numTargets" value="{{system.numTargets}}" />
+      <input class="item-field-inputs" type="number" name="system.numTargets" value="{{system.numTargets}}" min="0" step="1" />
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -89,7 +89,7 @@
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponRangeReachMultiplier'}}
       {{#*inline "item-field-inputs"}}
       <input type="number" name="system.range.reachMultiplier" value="{{system.range.reachMultiplier}}"
-        placeholder="{{localize 'E20.WeaponRangeReachMultiplier'}}" />
+        placeholder="{{localize 'E20.WeaponRangeReachMultiplier'}}" min="0" step="1" />
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
 
@@ -97,11 +97,11 @@
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.WeaponRange'}}
       {{#*inline "item-field-inputs"}}
       <input type="number" name="system.range.value" value="{{system.range.value}}"
-        placeholder="{{localize 'E20.WeaponRangeValue'}}" />
+        placeholder="{{localize 'E20.WeaponRangeValue'}}" min="0" step="1" />
       <input type="number" name="system.range.long" value="{{system.range.long}}"
-        placeholder="{{localize 'E20.WeaponRangeLong'}}" />
+        placeholder="{{localize 'E20.WeaponRangeLong'}}" min="0" step="1" />
       <input type="number" name="system.range.min" value="{{system.range.min}}"
-        placeholder="{{localize 'E20.WeaponRangeMin'}}" />
+        placeholder="{{localize 'E20.WeaponRangeMin'}}" min="0" step="1" />
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>


### PR DESCRIPTION
##### In this PR
- Replacing numeric inputs with `numberInput` for items only
- Using `step=1` by default, but 5 for movement
- Using `min=0` everywhere
- Also adding step/min where `numberInput` can't be used (because of classes/placeholders/etc)

##### Testing
- Item sheets should work as expected
- Numeric fields should update correctly
- Steps (via arrow key or scroll) should be 5 for movement and 1 for everything else
- Shouldn't be able to go below 0
- Create a role and drop it on an actor. There shouldn't be any parsing errors still.