### PR TITLE
Readding NPC weapon icons

### DIFF
--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -22,7 +22,7 @@
       {{/inline}}
 
       {{#*inline "item-label" item}}
-        <div class="flexrow" style="align-items: center;">
+        <div class="flexrow" style="align-items: center; gap: 2px;">
           <div style="flex-grow: 1.5;">
             {{item.name}}
           </div>
@@ -34,9 +34,7 @@
             {{/select}}
           </select>
 
-          {{#ifEquals "npc" @root.actor.type}}
-            {{!-- NPCs don't have enough room for weapon effect icons --}}
-          {{else}}
+          <div class="flexrow" style="flex-wrap: nowrap; gap: 2px;">
             <div style="text-align: center;" title="{{item.numTargets}} {{localize "E20.WeaponTargets"}}">
               {{item.numTargets}} <i class="fas fa-bullseye"></i>
             </div>
@@ -62,7 +60,7 @@
                 <i class="fas fa-person-harassing"></i>
               {{/ifEquals}}
             </div>
-          {{/ifEquals}}
+          </div>
         </div>
       {{/inline}}
 


### PR DESCRIPTION
##### In this PR
- Adding weapon icons back to NPCs that handles the small space better

##### Testing
- Weapon icons should be the same on PC sheets
- They should always be grouped together on NPC sheets
