### PR TITLE
Fixing default text for item drop fields

### DIFF
--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -145,8 +145,8 @@ Handlebars.registerHelper('ifNotEquals', function (arg1, arg2, options) {
 });
 
 Handlebars.registerHelper('itemsContainType', function (items, type, options) {
-  for (item in items) {
-    if (item.type == type) {
+  for (const key in items) {
+    if (items[key].type == type) {
       return options.fn(this);
     }
   }

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -144,6 +144,16 @@ Handlebars.registerHelper('ifNotEquals', function (arg1, arg2, options) {
   return (arg1 != arg2) ? options.fn(this) : options.inverse(this);
 });
 
+Handlebars.registerHelper('itemsContainType', function (items, type, options) {
+  for (item in items) {
+    if (item.type == type) {
+      return options.fn(this)
+    }
+  }
+
+  return options.inverse(this);
+});
+
 /* -------------------------------------------- */
 /*  Misc Hooks                                  */
 /* -------------------------------------------- */

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -147,7 +147,7 @@ Handlebars.registerHelper('ifNotEquals', function (arg1, arg2, options) {
 Handlebars.registerHelper('itemsContainType', function (items, type, options) {
   for (item in items) {
     if (item.type == type) {
-      return options.fn(this)
+      return options.fn(this);
     }
   }
 

--- a/templates/item/parts/id-drop.hbs
+++ b/templates/item/parts/id-drop.hbs
@@ -1,6 +1,6 @@
 {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" className=className label=label items=items type=type}}
 {{#*inline "item-field-inputs"}}
-{{#if items}}
+{{#itemsContainType items type}}
   <div class="flexcol">
     {{#each items as |item|}}
       {{#ifEquals item.type ../type}}
@@ -23,6 +23,6 @@
   </div>
 {{else}}
   <label>{{localize 'E20.ItemDrop'}}</label>
-{{/if}}
+{{/itemsContainType}}
 {{/inline}}
 {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}

--- a/templates/item/parts/role-perk-drop.hbs
+++ b/templates/item/parts/role-perk-drop.hbs
@@ -1,6 +1,6 @@
 {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" className=className label=label items=items type=type}}
 {{#*inline "item-field-inputs"}}
-{{#if items}}
+{{#itemsContainType items type}}
   <div class="flexcol" id="rolePerkList">
     {{#each items as |item|}}
       {{#ifEquals item.type ../type}}
@@ -24,6 +24,6 @@
   </div>
 {{else}}
   <label>{{localize 'E20.ItemDrop'}}</label>
-{{/if}}
+{{/itemsContainType}}
 {{/inline}}
 {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}


### PR DESCRIPTION
##### In this PR
- Fixing default text for item drop fields
- Creating `itemsContainType` handlebars helper that returns true if the items given contains at least one item of the type specified

##### Testing
- Create a new item that has an item drop field. Those fields should now show the default text.
- Dropping an item onto it should work as expected
- Do the same for a Focus, since it uses `role-perk-drop.hbs`