### PR TITLE
Adding RP bonus to actor health

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -399,7 +399,7 @@
     "RolePointsActorDropError": "Role Points can only be dropped onto Roles.",
     "RolePointsBonus": "Bonus",
     "RolePointsBonusType": "Bonus Type",
-    "RolePointsCanBeActivated": "Can Be Activated?",
+    "RolePointsCanBeActivated": "Is Activatable?",
     "RolePointsGeneral": "General",
     "RolePointsIncrease": "Increase",
     "RolePointsIncreaseLevels": "Points Increase Levels",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -106,6 +106,7 @@ export class Essence20Actor extends Actor {
     const conditionName = game.i18n.localize('E20.SkillConditioning');
     const bonusName = game.i18n.localize('E20.Bonus');
 
+    // Health from Origin
     const origins = getItemsOfType('origin', this.items);
     if (origins.length > 0) {
       const origin = origins[0];
@@ -113,8 +114,10 @@ export class Essence20Actor extends Actor {
       originName = origin.name;
     }
 
+    // Health from Role Points
     const rolePointsList = getItemsOfType('rolePoints', this.items);
-    if (rolePointsList.length > 0 && rolePointsList[0].system.bonus.type == 'healthBonus') {
+    if (rolePointsList.length > 0 && rolePointsList[0].system.bonus.type == 'healthBonus'
+      && (!rolePointsList[0].system.isActivatable || rolePointsList[0].system.isActive)) {
       const rolePoints = rolePointsList[0];
       rolePointsName = rolePoints.name;
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,6 +1,6 @@
 import { Dice } from "../dice.mjs";
 import { RollDialog } from "../helpers/roll-dialog.mjs";
-import { resizeTokens, getItemsOfType } from "../helpers/utils.mjs";
+import { resizeTokens, getItemsOfType, roleValueChange } from "../helpers/utils.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -97,21 +97,38 @@ export class Essence20Actor extends Actor {
     const system = this.system;
     system.healthIsReadOnly = true;
     const health = system.health;
-    let startingHealth = 0;
+    let originStartingHealth = 0;
+    let rolePointsBonusHealth = 0;
     const conditioning = system.conditioning;
     const bonus = system.health.bonus;
-    const originName = game.i18n.localize('E20.Origin');
+    let originName = game.i18n.localize('E20.Origin');
+    let rolePointsName = game.i18n.localize('E20.RolePoints');
     const conditionName = game.i18n.localize('E20.SkillConditioning');
     const bonusName = game.i18n.localize('E20.Bonus');
 
     const origins = getItemsOfType('origin', this.items);
     if (origins.length > 0) {
-      startingHealth = origins[0].system.startingHealth;
+      const origin = origins[0];
+      originStartingHealth = origin.system.startingHealth;
+      originName = origin.name;
     }
 
-    health.max = startingHealth + conditioning + bonus;
-    health.string = `${startingHealth} ${originName} + ${conditioning} ${conditionName} + ${bonus} ${bonusName}`;
+    const rolePointsList = getItemsOfType('rolePoints', this.items);
+    if (rolePointsList.length > 0 && rolePointsList[0].system.bonus.type == 'healthBonus') {
+      const rolePoints = rolePointsList[0];
+      rolePointsName = rolePoints.name;
+
+      if (this.system.level == 20) {
+        rolePointsBonusHealth = rolePoints.system.bonus.level20Value;
+      } else {
+        rolePointsBonusHealth = rolePoints.system.bonus.startingValue + roleValueChange(this.system.level, rolePoints.system.bonus.increaseLevels);
+      }
+    }
+
+    health.max = originStartingHealth + rolePointsBonusHealth + conditioning + bonus;
+    health.string = `${originStartingHealth} (${originName}) + ${rolePointsBonusHealth} (${rolePointsName}) + ${conditioning} (${conditionName}) + ${bonus} (${bonusName})`;
   }
+
   /**
   * Prepare Defenses specific data.
   */

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -467,7 +467,7 @@ export function deleteAttachmentsForItem(item, actor, previousLevel=null) {
  * @param {Number} lastProcessedLevel The value of actor.system.level the last time a level change was processed
  * @returns {Number} totalChange The number of level changes.
  */
-export async function roleValueChange(currentLevel, arrayLevels, lastProcessedLevel=null) {
+export function roleValueChange(currentLevel, arrayLevels, lastProcessedLevel=null) {
   const levelDiff = currentLevel - lastProcessedLevel;
   if (!levelDiff) {
     return 0;
@@ -502,7 +502,7 @@ export async function roleValueChange(currentLevel, arrayLevels, lastProcessedLe
  */
 export async function setRoleValues(role, actor, newLevel=null, previousLevel=null) {
   for (const essence in role.system.essenceLevels) {
-    const totalChange = await roleValueChange(actor.system.level, role.system.essenceLevels[essence], previousLevel);
+    const totalChange = roleValueChange(actor.system.level, role.system.essenceLevels[essence], previousLevel);
     const essenceValue = actor.system.essences[essence] + totalChange;
     const essenceString = `system.essences.${essence}`;
 
@@ -512,7 +512,7 @@ export async function setRoleValues(role, actor, newLevel=null, previousLevel=nu
   }
 
   if (role.system.powers.personal.starting) {
-    const totalChange = await roleValueChange(actor.system.level, role.system.powers.personal.levels, previousLevel);
+    const totalChange = roleValueChange(actor.system.level, role.system.powers.personal.levels, previousLevel);
     const newPersonalPowerMax =
         actor.system.powers.personal.max
       + newLevel ? 0 : role.system.powers.personal.starting
@@ -524,7 +524,7 @@ export async function setRoleValues(role, actor, newLevel=null, previousLevel=nu
   }
 
   if (role.system.adjustments.health.length) {
-    const totalChange = await roleValueChange(actor.system.level, role.system.adjustments.health, previousLevel);
+    const totalChange = roleValueChange(actor.system.level, role.system.adjustments.health, previousLevel);
     const newHealthBonus = actor.system.health.bonus + totalChange;
 
     await actor.update({
@@ -535,7 +535,7 @@ export async function setRoleValues(role, actor, newLevel=null, previousLevel=nu
   if (role.system.skillDie.isUsed) {
     const skillName = "roleSkillDie";
     const shiftList = CONFIG.E20.skillShiftList;
-    const totalChange = await roleValueChange(actor.system.level, role.system.skillDie.levels, previousLevel);
+    const totalChange = roleValueChange(actor.system.level, role.system.skillDie.levels, previousLevel);
     let initialShiftIndex = shiftList.findIndex(s => s == "d2");
     if (actor.system.skills[skillName].shift) {
       initialShiftIndex = shiftList.findIndex(s => s == actor.system.skills[skillName].shift);
@@ -590,7 +590,7 @@ export async function setRoleValues(role, actor, newLevel=null, previousLevel=nu
  * @param {Number} previousLevel (Optional) The last level processed for the actor
  */
 export async function setFocusValues(focus, actor, newLevel=null, previousLevel=null) {
-  const totalChange = await roleValueChange(actor.system.level, focus.system.essenceLevels, previousLevel);
+  const totalChange = roleValueChange(actor.system.level, focus.system.essenceLevels, previousLevel);
   const essenceValue = actor.system.essences[actor.system.focusEssence] + totalChange;
   const essenceString = `system.essences.${actor.system.focusEssence}`;
 

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -124,7 +124,7 @@ export class RoleHandler {
    */
   async onFocusDelete(focus) {
     const previousLevel = this._actor.getFlag('essence20', 'previousLevel');
-    const totalDecrease = await roleValueChange(0, focus.system.essenceLevels, previousLevel);
+    const totalDecrease = roleValueChange(0, focus.system.essenceLevels, previousLevel);
     const essenceValue = Math.max(0, this._actor.system.essences[this._actor.system.focusEssence] + totalDecrease);
     const essenceString = `system.essences.${this._actor.system.focusEssence}`;
 
@@ -207,7 +207,7 @@ export class RoleHandler {
     const focus = getItemsOfType("focus", this._actor.items);
 
     for (const essence in role.system.essenceLevels) {
-      const totalDecrease = await roleValueChange(0, role.system.essenceLevels[essence], previousLevel);
+      const totalDecrease = roleValueChange(0, role.system.essenceLevels[essence], previousLevel);
       const essenceValue = Math.max(0, this._actor.system.essences[essence] + totalDecrease);
       const essenceString = `system.essences.${essence}`;
 
@@ -217,7 +217,7 @@ export class RoleHandler {
     }
 
     if (role.system.powers.personal.starting) {
-      const totalDecrease = await roleValueChange(0, role.system.powers.personal.levels, previousLevel);
+      const totalDecrease = roleValueChange(0, role.system.powers.personal.levels, previousLevel);
       const newPersonalPowerMax = Math.max(0, parseInt(this._actor.system.powers.personal.max) - role.system.powers.personal.starting + (role.system.powers.personal.increase * totalDecrease));
 
       await this._actor.update({
@@ -233,7 +233,7 @@ export class RoleHandler {
     }
 
     if (role.system.adjustments.health.length) {
-      const totalDecrease = await roleValueChange(0, role.system.adjustments.health, previousLevel);
+      const totalDecrease = roleValueChange(0, role.system.adjustments.health, previousLevel);
       const newHealthBonus = Math.max(0, this._actor.system.health.bonus + totalDecrease);
 
       await this._actor.update({


### PR DESCRIPTION
##### In this PR
- Adding RP bonus to actor health when the bonus type is 'healthBonus'
- Takes RP activation into account
- `roleValueChange` doesn't need to be async, so cleaning that up
- Health tooltip will show origin/RP names when they exist

##### Testing
- On a new actor, the health tooltip should be `0 (Origin) + 0 (Role Points) + 0 (Conditioning) + 0 (Bonus)`
- After dropping an origin, health max should update and the origin name should be in the tooltip
- After dropping a role with an HP RP, health max should update and the RP name should be in the tooltip
- Max HP on the actor sheet should be correct, and increase correctly when leveling and hitting level 20
- HP only increases when the RP is active if it's activatable