### PR TITLE
Using checkbox for RP unlimited resource; spend notification

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -409,6 +409,7 @@
     "RolePointsOverSpent": "You don't have enough points to use this Role Feature.",
     "RolePointsPersonalPowerCost": "Personal Power Cost",
     "RolePointsResource": "Resource",
+    "RolePointsResourceUnlimited": "Unlimited",
     "RolePointsRoll": "Use Roll Points",
     "RolePointsSecondaryPointIncrease": "Has Secondary Advancement",
     "RolePointsStartingMax": "Starting Max",

--- a/lang/en.json
+++ b/lang/en.json
@@ -411,6 +411,7 @@
     "RolePointsResource": "Resource",
     "RolePointsResourceUnlimited": "Unlimited",
     "RolePointsRoll": "Use Roll Points",
+    "RolePointsSpent": "Spent {spentString} for {name}!",
     "RolePointsSecondaryPointIncrease": "Has Secondary Advancement",
     "RolePointsStartingMax": "Starting Max",
     "RolePointsStartingValue": "Starting Value",

--- a/lang/en.json
+++ b/lang/en.json
@@ -404,7 +404,7 @@
     "RolePointsIncrease": "Increase",
     "RolePointsIncreaseLevels": "Points Increase Levels",
     "RolePointsLevel20Value": "Level 20 Value",
-    "RolePointsLevel20ValueUnlimited": "Level 20 Value (99 is unlimited)",
+    "RolePointsLevel20ValueUnlimited": "Level 20 Value",
     "RolePointsMultipleError": "Roles can only have one instance of Role Points.",
     "RolePointsOverSpent": "You don't have enough points to use this Role Feature.",
     "RolePointsPersonalPowerCost": "Personal Power Cost",

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -76,6 +76,7 @@ export class Essence20Actor extends Actor {
       this._prepareHealth();
       this._prepareMovement();
       this._prepareSorcerousPower();
+      this._prepareResource();
     }
   }
 
@@ -233,6 +234,17 @@ export class Essence20Actor extends Actor {
     const levelMultiplier = system.level - system.powers.sorcerous.levelTaken;
 
     system.powers.sorcerous.max = (levelMultiplier * 2) + 4;
+  }
+
+  /**
+   * Prepare Resource (from Role Points) type specific data.
+   */
+  _prepareResource() {
+    const rolePointsList = getItemsOfType('rolePoints', this.items);
+    if (rolePointsList.length) {
+      const rolePoints = rolePointsList[0]; // There should only be one RolePoints
+      this.system.useUnlimitedResource = rolePoints.system.resource.level20ValueIsUnlimited && this.system.level == 20;
+    }
   }
 
   /**

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -115,19 +115,23 @@ export class Essence20Item extends Item {
     const actorLevel = this.actor.system.level;
     const resourceLevelIncreases = getLevelIncreases(this.system.resource.increaseLevels, actorLevel);
 
-    if (actorLevel == 20 && this.system.resource.level20Value) {
-      this.system.resource.max = this.system.resource.level20Value;
-    } else {
-      this.system.resource.max = this.system.resource.startingMax + (this.system.resource.increase * resourceLevelIncreases);
+    if (this.system.resource.startingMax != null) {
+      if (actorLevel == 20 && this.system.resource.level20Value) {
+        this.system.resource.max = this.system.resource.level20Value;
+      } else {
+        this.system.resource.max = this.system.resource.startingMax + (this.system.resource.increase * resourceLevelIncreases);
+      }
     }
 
-    if (this.system.bonus.type != CONFIG.E20.bonusTypes.none) {
-      const bonusLevelIncreases = getLevelIncreases(this.system.bonus.increaseLevels, actorLevel);
+    if (this.system.bonus.startingValue != null) {
+      if (this.system.bonus.type != CONFIG.E20.bonusTypes.none) {
+        const bonusLevelIncreases = getLevelIncreases(this.system.bonus.increaseLevels, actorLevel);
 
-      if (actorLevel == 20 && this.system.bonus.level20Value) {
-        this.system.bonus.value = this.system.bonus.level20Value;
-      } else {
-        this.system.bonus.value = this.system.bonus.startingValue + (this.system.bonus.increase * bonusLevelIncreases);
+        if (actorLevel == 20 && this.system.bonus.level20Value) {
+          this.system.bonus.value = this.system.bonus.level20Value;
+        } else {
+          this.system.bonus.value = this.system.bonus.startingValue + (this.system.bonus.increase * bonusLevelIncreases);
+        }
       }
     }
   }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -605,18 +605,18 @@ export class Essence20ActorSheet extends ActorSheet {
                   this.actor.system.powers.personal.value - item.system.powerCost,
               });
 
-              spentStrings.push(`${item.system.powerCost} Power`)
+              spentStrings.push(`${item.system.powerCost} Power`);
             }
           }
 
           // If Role Points are being used and not unlimited, decrement uses
           if (!this.actor.system.useUnlimitedResource) {
             await item.update({ 'system.resource.value': item.system.resource.value - 1 });
-            spentStrings.push('1 point')
+            spentStrings.push('1 point');
           }
 
           if (spentStrings.length) {
-            const spentString = spentStrings.join(', ')
+            const spentString = spentStrings.join(', ');
             ui.notifications.info(game.i18n.format('E20.RolePointsSpent', { spentString, name: item.name }));
           }
         }

--- a/template.json
+++ b/template.json
@@ -926,7 +926,7 @@
         "increase": 0,
         "level20Value": null,
         "increaseLevels": [],
-        "startingValue": 0,
+        "startingValue": null,
         "type": "none",
         "value" : 0
       },
@@ -937,8 +937,8 @@
         "increase": 0,
         "level20Value": null,
         "increaseLevels": [],
-        "max": 0,
-        "startingMax": 0,
+        "max": null,
+        "startingMax": null,
         "value" : 0
       }
     },

--- a/template.json
+++ b/template.json
@@ -936,6 +936,7 @@
       "resource": {
         "increase": 0,
         "level20Value": null,
+        "level20ValueIsUnlimited": false,
         "increaseLevels": [],
         "max": null,
         "startingMax": null,

--- a/templates/actor/parts/items/rolePoints/container.hbs
+++ b/templates/actor/parts/items/rolePoints/container.hbs
@@ -46,7 +46,7 @@
         </div>
 
         {{!-- Resource --}}
-        {{#ifEquals rolePoints.system.resource.max 99}}
+        {{#if @root.system.useUnlimitedResource}}
           <div>{{localize 'E20.RolePointsResourceUnlimited'}}</div>
         {{else ifNotEquals rolePoints.system.resource.max null}}
           <input class="inline-edit centered-input no-lock" data-field="system.resource.value" type="number"
@@ -56,7 +56,7 @@
           <input class="centered-input no-unlock" data-field="rolePoints.system.resource.max" type="number"
             name="rolePoints.system.resource.max" value="{{rolePoints.system.resource.max}}" min="0"
             step="1" readonly />
-        {{/ifEquals}}
+        {{/if}}
       </div>
     {{/with}}
   {{else if @root.role.system.skillDie.isUsed}}

--- a/templates/actor/parts/items/rolePoints/container.hbs
+++ b/templates/actor/parts/items/rolePoints/container.hbs
@@ -46,7 +46,9 @@
         </div>
 
         {{!-- Resource --}}
-        {{#if rolePoints.system.resource.max}}
+        {{#ifEquals rolePoints.system.resource.max 99}}
+          <div>{{localize 'E20.RolePointsResourceUnlimited'}}</div>
+        {{else ifNotEquals rolePoints.system.resource.max null}}
           <input class="inline-edit centered-input no-lock" data-field="system.resource.value" type="number"
             name="system.resource.value" value="{{system.resource.value}}" min="0"
             step="1" />
@@ -54,7 +56,7 @@
           <input class="centered-input no-unlock" data-field="rolePoints.system.resource.max" type="number"
             name="rolePoints.system.resource.max" value="{{rolePoints.system.resource.max}}" min="0"
             step="1" readonly />
-        {{/if}}
+        {{/ifEquals}}
       </div>
     {{/with}}
   {{else if @root.role.system.skillDie.isUsed}}

--- a/templates/item/parts/sheet-field.hbs
+++ b/templates/item/parts/sheet-field.hbs
@@ -6,7 +6,7 @@
     {{/item-field-edit}}
   </div>
 
-  <div class="flexrow item-field-inputs">
+  <div class="flexrow item-field-inputs" style="align-items: center;">
     {{#> item-field-inputs}}
     {{!-- Custom item inputs go here --}}
     {{/item-field-inputs}}

--- a/templates/item/sheets/rolePoints.hbs
+++ b/templates/item/sheets/rolePoints.hbs
@@ -154,7 +154,9 @@
       {{!-- Level 20 Value --}}
       {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.RolePointsLevel20ValueUnlimited'}}
       {{#*inline "item-field-inputs"}}
-      {{numberInput system.resource.level20Value name="system.resource.level20Value"}}
+      {{numberInput system.resource.level20Value name="system.resource.level20Value" disabled=system.resource.level20ValueIsUnlimited }}
+      <input type="checkbox" name="system.resource.level20ValueIsUnlimited" {{checked system.resource.level20ValueIsUnlimited}}/>
+      <div style="flex-grow: 0;">{{localize "E20.RolePointsResourceUnlimited"}}</div>
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>


### PR DESCRIPTION
##### In this PR
- Unlimited is now specified for a RP via checkbox instead of supplying 99
- 0 is now a valid value for starting values
- Having unlimited points no longer tries to decrement
- Fixed a bug where it would decrement a point before realizing you didn't have enough power
- Displaying a notification for spending

##### Testing
- Unlimited checkbox will disable the normal input
- Dropping a resource/bonus with a 0 starting value will show up, but not ones that are null
- If the RP box is checked and the actor is level 20, then the resource should appear as `Unlimited`
- Notifications should appear if the RP uses a resource or power
- Error messages should still work