### PR TITLE
Fixing isSpecialized field for skill rolls

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -69,6 +69,7 @@ export class Dice {
       ...rawDataset,
       shiftDown: parseInt(rawDataset.shiftDown),
       shiftUp: parseInt(rawDataset.shiftUp),
+      isSpecialized: rawDataset.isSpecialized && rawDataset.isSpecialized != 'false',
     };
     const rolledSkill = dataset.skill;
     const rolledEssence = dataset.essence || E20.skillToEssence[rolledSkill];

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -121,6 +121,32 @@ describe("rollSkill", () => {
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor E20.SkillAthletics");
   });
 
+  test("normal skill roll works with isSpecialized as false string", async () => {
+    const datasetCopy = {
+      ...dataset,
+      isSpecialized: 'false',
+    };
+    rollDialog.getSkillRollOptions.mockReturnValue({
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    });
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'athletics': {
+          modifier: '0',
+          shift: 'd20',
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn();
+
+    await dice.rollSkill(dataset, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor E20.SkillAthletics");
+  });
+
   test("repeated normal skill roll", async () => {
     rollDialog.getSkillRollOptions.mockReturnValue({
       edge: false,
@@ -174,6 +200,33 @@ describe("rollSkill", () => {
     const datasetCopy = {
       ...dataset,
       isSpecialized: true,
+      specializationName: 'Foo Specialization',
+    };
+    rollDialog.getSkillRollOptions.mockReturnValue({
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    });
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'athletics': {
+          modifier: '0',
+          shift: 'd20',
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn();
+
+    await dice.rollSkill(datasetCopy, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor Foo Specialization");
+  });
+
+  test("specialized skill roll works with isSpecialized as true string", async () => {
+    const datasetCopy = {
+      ...dataset,
+      isSpecialized: 'true',
       specializationName: 'Foo Specialization',
     };
     rollDialog.getSkillRollOptions.mockReturnValue({


### PR DESCRIPTION
##### In this PR
- Fixing isSpecialized field for skill rolls, which is passed in from the hbs as a string 'true' or 'false'
- Some tests for that

##### Testing
- Specialized rolls should work as expected and have their name appear in the chat message
