### PR TITLE
Adding bonus attack to roll dialog

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -102,7 +102,7 @@ export class Dice {
     let rolePoints = null;
     if (item?.type == 'weapon' && rolePointsList.length) {
       rolePoints = rolePointsList[0]; // There should only be one RolePoints
-      if (rolePoints.system.bonus.type == 'attackUpshift') {
+      if (rolePoints.system.bonus.type == 'attackUpshift' && (rolePoints.system.isActive || !rolePoints.system.isActivatable)) {
         updatedShiftDataset.rolePoints = rolePoints;
       }
     }

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -1,4 +1,5 @@
 import { E20 } from "./helpers/config.mjs";
+import { getItemsOfType } from "./helpers/utils.mjs";
 
 export class Dice {
   /**
@@ -94,6 +95,18 @@ export class Dice {
       edge: actorSkillData.edge,
       snag: actorSkillData.snag,
     };
+
+    updatedShiftDataset.rolePoints = null;
+    const rolePointsList = getItemsOfType('rolePoints', actor.items);
+
+    let rolePoints = null;
+    if (item?.type == 'weapon' && rolePointsList.length) {
+      rolePoints = rolePointsList[0]; // There should only be one RolePoints
+      if (rolePoints.system.bonus.type == 'attackUpshift') {
+        updatedShiftDataset.rolePoints = rolePoints;
+      }
+    }
+
     const skillRollOptions = await this._rollDialog.getSkillRollOptions(updatedShiftDataset, skillDataset, actor);
 
     if (skillRollOptions.cancelled) {
@@ -117,7 +130,7 @@ export class Dice {
       label = this._getSkillRollLabel(dataset, skillRollOptions);
     }
 
-    let finalShift = this._getFinalShift(skillRollOptions, initialShift);
+    let finalShift = this._getFinalShift(skillRollOptions, initialShift, E20.skillShiftList, rolePoints);
 
     if (this._handleAutoFail(finalShift, label, actor)) {
       return;
@@ -259,9 +272,11 @@ export class Dice {
    * @returns {String}   The resultant shift.
    * @private
    */
-  _getFinalShift(skillRollOptions, initialShift, shiftList=E20.skillShiftList) {
+  _getFinalShift(skillRollOptions, initialShift, shiftList=E20.skillShiftList, rolePoints=null) {
     // Apply the skill roll options dialog shifts to the roller's normal shift
-    const optionsShiftTotal = skillRollOptions.shiftUp - skillRollOptions.shiftDown;
+    let optionsShiftTotal = skillRollOptions.shiftUp - skillRollOptions.shiftDown;
+    optionsShiftTotal += rolePoints && skillRollOptions.applyRolePointsUpshift ? rolePoints.system.bonus.value : 0;
+
     const initialShiftIndex = shiftList.findIndex(s => s == initialShift);
     const finalShiftIndex = Math.max(
       0,

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -30,6 +30,7 @@ class Mocki18n {
 }
 
 const mockActor = {
+  items: [],
   system: {
     initiative: {
       formula: "",
@@ -93,6 +94,7 @@ describe("rollSkill", () => {
   const dataset = {
     essence: 'strength',
     isSpecialized: false,
+    rolePoints: null,
     shift: 'd20',
     shiftDown: '0',
     shiftUp: '0',

--- a/module/helpers/roll-dialog.mjs
+++ b/module/helpers/roll-dialog.mjs
@@ -45,6 +45,7 @@ export class RollDialog {
         snag: snag && !edge,
         edge: edge && !snag,
         normal: edge == snag,
+        rolePoints: dataset.rolePoints,
       },
     );
 
@@ -84,6 +85,7 @@ export class RollDialog {
       snag: form.snagEdge.value == 'snag',
       isSpecialized: form.isSpecialized.checked,
       timesToRoll: parseInt(form.timesToRoll.value),
+      applyRolePointsUpshift: form?.applyRolePointsUpshift?.checked,
     };
   }
 }

--- a/templates/dialog/roll-dialog.hbs
+++ b/templates/dialog/roll-dialog.hbs
@@ -3,23 +3,34 @@
     {{localize 'E20.ShiftUp'}}
     <input type="number" name="shiftUp" value={{shiftUp}} min="0" step="1" />
   </div>
+  
   <div>
     {{localize 'E20.ShiftDown'}}
     <input type="number" name="shiftDown" value={{shiftDown}} min="0" step="1" />
   </div>
+
   <div>
     <input type="radio" name="snagEdge" value="snag" data-dtype="String" {{checked snag}} /> {{localize 'E20.RollDialogSnag'}}
     <input type="radio" name="snagEdge" value="normal" data-dtype="String" {{checked normal}} /> {{localize 'E20.RollDialogNormal'}}
     <input type="radio" name="snagEdge" value="edge" data-dtype="String" {{checked edge}} /> {{localize 'E20.RollDialogEdge'}}
   </div>
+
   <div>
     <label>
       <input type="checkbox" name="isSpecialized" {{checked isSpecialized}} />
       <span>{{localize 'E20.RollIsSpecialized'}}</span>
     </label>
   </div>
+
   <div>
     {{localize 'E20.RollDialogTimesToRoll'}}
     <input type="number" name="timesToRoll" value=1 min="1" step="1" />
   </div>
+
+  {{#if rolePoints}}
+  <div class="flexrow" style="align-items: center;">
+    <input type="checkbox" name="applyRolePointsUpshift" {{checked applyRolePointsUpshift}} />
+    Apply {{rolePoints.name}} to gain {{rolePoints.system.bonus.value}}<i class="fas fa-arrow-up" style="flex-grow: 0;"></i>?
+  </div>
+  {{/if}}
 </form>


### PR DESCRIPTION
##### In this PR
- Adding a checkbox to the roll dialog when using a weapon if the actor has a corresponding RP bonus
- Displays the RP name and upshift amount
- Applies bonus upshift to the roll's total

##### Testing
- Start with a default PC. Rolling a WE should not show a RP checkbox in the roll dialog.
- Drop a RP with a bonus attack onto an actor. Rolling a WE should show a RP checkbox in the roll dialog, with correct name and upshift amount.
- The total upshift rolled should corresponding to whether the checkbox is checked or not
- Skill rolls should never show the checkbox
