### PR TITLE
Fix for spendable RP button

### DIFF
--- a/templates/actor/parts/items/rolePoints/container.hbs
+++ b/templates/actor/parts/items/rolePoints/container.hbs
@@ -13,10 +13,10 @@
           <i class="fas fa-message-lines"></i>
         </a>
 
-        {{#if rolePoints.system.isSpendable}}
+        {{#ifNotEquals rolePoints.system.resource.max null}}
         <a class="rollable" style="flex-grow: 0;" data-roll-type="rolePoints" title="{{localize 'E20.RolePointsRoll'}}"><i
           class="fas fa-hand-fist"></i></a>
-        {{/if}}
+        {{/ifNotEquals}}
 
         {{#if rolePoints.system.isActivatable}}
           <input class="inline-edit item-label-checkbox" type="checkbox" data-field="system.isActive" name="rolePoints.system.isActive"


### PR DESCRIPTION
##### In this PR
- The spend button for RP resources ended up never displaying after the previous refactor, so this is a fix

##### Testing
- The RP spend/fist button should only appear for RPs that are a resource
