### PR TITLE
Fixing perk type chip in details

### DIFF
--- a/templates/actor/parts/items/perk/details.hbs
+++ b/templates/actor/parts/items/perk/details.hbs
@@ -5,6 +5,6 @@
   <span class="chip" name="chip.perk.prerequisite">{{localize 'E20.PerkPrerequisite'}}: {{item.system.prerequisite}}</span>
   {{/if}}
   {{#if item.system.type}}
-  <span class="chip" name="chip.perk.type">{{localize 'E20.PerkType'}}: {{lookup @root.config.perkTypes item.system.perkType}}</span>
+  <span class="chip" name="chip.perk.type">{{localize 'E20.PerkType'}}: {{lookup @root.config.perkTypes item.system.type}}</span>
   {{/if}}
 </div>


### PR DESCRIPTION
##### In this PR
- Fixing perk type chip in details

##### Testing
- Clicking the info button for a perk should now display `Type: <blah>` instead of just `Type: `
