### PR TITLE
Adding language section for NPCs

### DIFF
--- a/template.json
+++ b/template.json
@@ -487,7 +487,7 @@
         "notes": ""
       },
       "creature": {
-        "languages": []
+        "languages": ""
       },
       "machine": {
         "canHover": false,

--- a/templates/actor/parts/headers/npc.hbs
+++ b/templates/actor/parts/headers/npc.hbs
@@ -4,14 +4,22 @@
   <label for="threatLevel" class="resource-label">{{localize 'E20.NpcThreatLevel'}}</label>
   {{numberInput system.threatLevel name="system.threatLevel" min=0 step=1}}
 </div>
+
 <div>
   <label for="conditioning" class="resource-label">{{ localize 'E20.ActorConditioning' }}</label>
   {{numberInput system.conditioning name="system.conditioning" min=0 step=1}}
 </div>
+
+<div>
+  <label for="system.languages" class="resource-label">{{localize 'E20.ActorLanguages'}}</label>
+  <input type="text" name="system.languages" value="{{system.languages}}" />
+</div>
+
 <div class="pr-header-color flex-group-center">
   <label for="system.color" class="resource-label">{{localize 'E20.ActorColor'}}</label>
   <input type="color" class="picker" name="system.color" value="{{system.color}}" />
 </div>
+
 {{> "systems/essence20/templates/actor/parts/misc/initiative.hbs"}}
 {{/inline}}
 {{/"systems/essence20/templates/actor/parts/headers/common.hbs"}}


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/618

##### In this PR
- Adding language section for NPCs. They already have `languages` in their template from `creature`. 
- Speaking of which, we defaulted that to `[]`, which we definitely don't use as an array, so I've changed it to `""`. As soon as you enter a string on an actor sheet it's no longer an array anyway, so no migration needed.

##### Testing
- NPC sheets should have a `languages` field that works as expected
