### PR TITLE
Better alteration deletion handling

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -105,7 +105,7 @@
     "AlterationMovementTooBig": "You have decreased a movement more than the maximum.",
     "AlterationMovementText": "Enter the number of 5ft reductions you would like for the available movement types.",
     "AlterationNoMovement": "You have no movement to modify",
-    "AlterationNoOptions": "There are no skills in the Essence that can be decreased.",
+    "AlterationNoOptions": "{name} has a {essence} skill cost, however, there are no skills in {essence} that can be decreased.",
     "AlterationOptions": "Type",
     "AlterationSkillIncrease": "Select a skill to increase.",
     "AlterationSelectNoSkill": "You must select an option to drop.",

--- a/module/sheet-handlers/alteration-handler.mjs
+++ b/module/sheet-handlers/alteration-handler.mjs
@@ -329,7 +329,7 @@ export class AlterationHandler {
     }
 
     if (!Object.keys(choices).length) {
-      ui.notifications.warn(game.i18n.localize('E20.AlterationNoOptions'));
+      ui.notifications.error(game.i18n.format('E20.AlterationNoOptions', {name: alteration.name, essence: CONFIG.E20.essences[costEssence]}));
       return;
     }
 
@@ -404,7 +404,7 @@ export class AlterationHandler {
   * @param {Alteration} alteration The alteration
   */
   async onAlterationDelete(alteration) {
-    if (alteration.system.movementCost) {
+    if (alteration.system.type == 'movement') {
       let totalMovementDecrease = 0;
       for (const movementReductionType in alteration.system.movementCost) {
         const movementReductionValue = alteration.system.movementCost[movementReductionType].value;
@@ -429,7 +429,7 @@ export class AlterationHandler {
         [bonusMovementRemovalString]: newMovement,
       });
 
-    } else {
+    } else if (alteration.system.type == 'essence') {
       const bonusEssence = alteration.system.essenceBonus;
       const bonusEssenceValue = this._actor.system.essences[bonusEssence] - 1;
       const bonusEssenceString = `system.essences.${bonusEssence}`;


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/620

##### In this PR
- Alteration deletion logic now looks at `type` to figure it out what to do, and does no additional steps for "other" types
- Better error message when you don't have a decreasable skill

##### Testing
- Deleting alterations of any type should work as expected
- No console error during deletion
- Drop an essence alteration on a default actor and you should see an improved warning about no decreasable skills
