### PR TITLE
Transitioning away from Handler classes #2

### DIFF
--- a/module/sheet-handlers/perk-handler.mjs
+++ b/module/sheet-handlers/perk-handler.mjs
@@ -4,60 +4,51 @@ import {
 
 const SORCERY_PERK_ID = "xUBOE1s5pgVyUrwj";
 
-export class PerkHandler {
-  /**
-  * Constructor
-  * @param {Essence20ActorSheet} actorSheet The actor sheet
-  */
-  constructor(actorSheet) {
-    this._actorSheet = actorSheet;
-    this._actor = actorSheet.actor;
-  }
+/**
+ * Handle the dropping of a Perk onto an Actor
+ * @param {Actor} actor The Actor receiving the Perk
+ * @param {Perk} perk The Perk being dropped
+ * @param {Function} dropFunc The function to call to complete the Power drop
+ */
+export async function perkUpdate(actor, perk, dropFunc) {
+  const perkUuid = parseId(perk.uuid);
+  let timesTaken = 0;
 
-  /**
-  * Handle the dropping of a power on to a character
-  * @param {Perk} perk The perk
-  * @param {Function} dropFunc   The function to call to complete the Power drop
-  */
-  async perkUpdate(perk, dropFunc) {
-    const perkUuid = parseId(perk.uuid);
-    let timesTaken = 0;
-
-    if (perkUuid == SORCERY_PERK_ID) {
-      await this._actor.update ({
-        "system.powers.sorcerous.levelTaken": this._actor.system.level,
-      });
-    }
-
-    for (let actorItem of this._actor.items) {
-      if (actorItem.type == 'perk' && actorItem.system.originalId == perkUuid) {
-        timesTaken++;
-        if (perk.system.selectionLimit == timesTaken) {
-          ui.notifications.error(game.i18n.localize('E20.PerkAlreadyTaken'));
-          return;
-        }
-      }
-    }
-
-    const newPerkList = await dropFunc();
-    const newPerk = newPerkList[0];
-
-    await newPerk.update ({
-      "system.originalId": perkUuid,
+  if (perkUuid == SORCERY_PERK_ID) {
+    await actor.update ({
+      "system.powers.sorcerous.levelTaken": actor.system.level,
     });
   }
 
-  /**
-  * Handle the deleting of a perk.
-  * @param {Perk} perk The perk
-  */
-  async onPerkDelete(perk) {
-    const perkUuid = perk.system.originalId;
-
-    if (perkUuid == SORCERY_PERK_ID) {
-      await this._actor.update ({
-        "system.powers.sorcerous.levelTaken": 0,
-      });
+  for (let actorItem of actor.items) {
+    if (actorItem.type == 'perk' && actorItem.system.originalId == perkUuid) {
+      timesTaken++;
+      if (perk.system.selectionLimit == timesTaken) {
+        ui.notifications.error(game.i18n.localize('E20.PerkAlreadyTaken'));
+        return;
+      }
     }
+  }
+
+  const newPerkList = await dropFunc();
+  const newPerk = newPerkList[0];
+
+  await newPerk.update ({
+    "system.originalId": perkUuid,
+  });
+}
+
+/**
+ * Handle the deleting of a Perk on an Actor
+ * @param {Actor} actor The Actor receiving the Perk
+ * @param {Perk} perk The perk
+ */
+export async function onPerkDelete(actor, perk) {
+  const perkUuid = perk.system.originalId;
+
+  if (perkUuid == SORCERY_PERK_ID) {
+    await actor.update ({
+      "system.powers.sorcerous.levelTaken": 0,
+    });
   }
 }

--- a/module/sheet-handlers/power-handler.mjs
+++ b/module/sheet-handlers/power-handler.mjs
@@ -3,112 +3,99 @@ import {
   rememberValues,
 } from "../helpers/utils.mjs";
 
-export class PowerHandler {
-  /**
-  * Constructor
-  * @param {Essence20ActorSheet} actorSheet The actor sheet
-  */
-  constructor(actorSheet) {
-    this._actorSheet = actorSheet;
-    this._actor = actorSheet.actor;
-  }
+/**
+ * Handles dropping a Power on to an Actor
+ * @param {Actor} actor The Actor receiving the Power
+ * @param {Power} power The Power being dropped
+ * @param {Function} dropFunc The function to call to complete the Power drop
+ */
+export async function powerUpdate(actor, power, dropFunc) {
+  const powerUuid = parseId(power.uuid);
+  let timesTaken = 0;
 
-  /**
-  * Handle the dropping of a power on to a character
-  * @param {Power} power The power
-  * @param {Function} dropFunc   The function to call to complete the Power drop
-  */
-  async powerUpdate(power, dropFunc) {
-    const powerUuid = parseId(power.uuid);
-    let timesTaken = 0;
-
-    for (let actorItem of this._actor.items) {
-      if (actorItem.type == 'power' && actorItem.system.originalId == powerUuid) {
-        timesTaken++;
-        if (power.system.selectionLimit == timesTaken) {
-          ui.notifications.error(game.i18n.localize('E20.PowerAlreadyTaken'));
-          return;
-        }
+  for (let actorItem of actor.items) {
+    if (actorItem.type == 'power' && actorItem.system.originalId == powerUuid) {
+      timesTaken++;
+      if (power.system.selectionLimit == timesTaken) {
+        ui.notifications.error(game.i18n.localize('E20.PowerAlreadyTaken'));
+        return;
       }
     }
-
-    const newPowerList = await dropFunc();
-    const newPower = newPowerList[0];
-
-    await newPower.update ({
-      "system.originalId": powerUuid,
-    });
   }
 
-  /**
-  * Handles determining the cost of a power activation
-  * @param {Power} power The power
-  */
-  async powerCost(power) {
-    let maxPower = 0;
-    let powerType = "";
-    if (power.system.type == "grid") {
-      powerType = "personal";
-    } else if (power.system.type == "sorcerous") {
-      powerType = "sorcerous";
+  const newPowerList = await dropFunc();
+  const newPower = newPowerList[0];
+
+  await newPower.update ({
+    "system.originalId": powerUuid,
+  });
+}
+
+/**
+ * Handles determining the cost of a Power activation
+ * @param {Actor} actor The Actor activating the Power
+ * @param {Power} power The Power being activated
+ */
+export async function powerCost(actor, power) {
+  let maxPower = 0;
+  let powerType = "";
+  
+  if (power.system.type == "grid") {
+    powerType = "personal";
+  } else if (power.system.type == "sorcerous") {
+    powerType = "sorcerous";
+  } else {
+    powerType = "threat";
+  }
+
+  if (power.system.hasVariableCost && powerType != "threat") {
+    if (power.system.maxPowerCost) {
+      maxPower = power.system.maxPowerCost;
     } else {
-      powerType = "threat";
+      maxPower = actor.system.powers[powerType].value;
     }
 
-    // for (const actorEffect of this._actor.effects) {
-    //   const parts = actorEffect.origin.split(".");
-    //   if (parts[3] == power._id) {
-    //     actorEffect.update({disabled: false});
-    //   }
-    // }
-
-    if (power.system.hasVariableCost && powerType != "threat") {
-      if (power.system.maxPowerCost) {
-        maxPower = power.system.maxPowerCost;
-      } else {
-        maxPower = this._actor.system.powers[powerType].value;
-      }
-
-      new Dialog(
-        {
-          title: game.i18n.localize('E20.PowerCost'),
-          content: await renderTemplate("systems/essence20/templates/dialog/power-cost.hbs", {
-            power: power,
-            maxPower: maxPower,
-          }),
-          buttons: {
-            save: {
-              label: game.i18n.localize('E20.AcceptButton'),
-              callback: html => this.powerCountUpdate(rememberValues(html), power, powerType),
-            },
+    new Dialog(
+      {
+        title: game.i18n.localize('E20.PowerCost'),
+        content: await renderTemplate("systems/essence20/templates/dialog/power-cost.hbs", {
+          power: power,
+          maxPower: maxPower,
+        }),
+        buttons: {
+          save: {
+            label: game.i18n.localize('E20.AcceptButton'),
+            callback: html => _powerCountUpdate(actor, rememberValues(html), power, powerType),
           },
         },
-      ).render(true);
-    } else if (powerType != "threat" && this._actor.system.powers[powerType].value >= power.system.powerCost) {
-      const updateString = `system.powers.${powerType}.value`;
-      this._actor.update({ [updateString]: Math.max(0, this._actor.system.powers[powerType].value - power.system.powerCost) });
-    } else if (!power.system.powerCost) {
-      console.log("still working on something for here");
-    } else {
-      ui.notifications.error(game.i18n.localize('E20.PowerOverSpent'));
-    }
-  }
-
-  /**
-  * Handle the spending of power for a power activated
-  * @param {Options} options The options selected in power dialog.
-  * @param {Power} power The power
-  * @param {powerType} powerType  The type of power this is.
-  */
-  powerCountUpdate (options, power, powerType) {
-    const powerCost = options[power.name].value;
-    const powerMax = options[power.name].max;
+      },
+    ).render(true);
+  } else if (powerType != "threat" && actor.system.powers[powerType].value >= power.system.powerCost) {
     const updateString = `system.powers.${powerType}.value`;
-    if ((powerCost > powerMax)
-      || (powerType !="threat" && powerCost > this._actor.system.powers[powerType].value)) {
-      ui.notifications.error(game.i18n.localize('E20.PowerOverSpent'));
-    } else if (powerType != "threat") {
-      this._actor.update({ [updateString]: Math.max(0, this._actor.system.powers[powerType].value - powerCost) });
-    }
+    actor.update({ [updateString]: Math.max(0, actor.system.powers[powerType].value - power.system.powerCost) });
+  } else if (!power.system.powerCost) {
+    console.log("still working on something for here");
+  } else {
+    ui.notifications.error(game.i18n.localize('E20.PowerOverSpent'));
+  }
+}
+
+/**
+ * Handles the spending of a Power activation
+ * @param {Actor} actor The Actor activating the Power
+ * @param {Options} options The options selected in Power dialog.
+ * @param {Power} power The Power being activated
+ * @param {String} powerType  The type of Power
+ */
+function _powerCountUpdate(actor, options, power, powerType) {
+  const powerCost = options[power.name].value;
+  const powerMax = options[power.name].max;
+  const updateString = `system.powers.${powerType}.value`;
+
+  if ((powerCost > powerMax)
+    || (powerType !="threat" && powerCost > actor.system.powers[powerType].value)) {
+    ui.notifications.error(game.i18n.localize('E20.PowerOverSpent'));
+  } else if (powerType != "threat") {
+    actor.update({ [updateString]: Math.max(0, actor.system.powers[powerType].value - powerCost) });
   }
 }

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -1,169 +1,166 @@
 import { getItemsOfType, rememberOptions, resizeTokens } from "../helpers/utils.mjs";
 
-export class TransformerHandler {
-  /**
-   * Constructor
-   * @param {Essence20ActorSheet} actorSheet The actor sheet
-   */
-  constructor(actorSheet) {
-    this._actorSheet = actorSheet;
-    this._actor = actorSheet.actor;
+/**
+ * Handles AltModes being deleted
+ * @param {ActorSheet} actorSheet The ActorSheet having an Alt Mode deleted
+ * @param {AltMode} altMode The deleted Alt Mode.
+ */
+export async function onAltModeDelete(actorSheet, altMode) {
+  const altModes = getItemsOfType("altMode", _actor.items);
+  if (altModes.length > 1) {
+    if (altMode._id == actorSheet.actor.system.altModeId) {
+      _transformBotMode(actorSheet);
+    }
+  } else {
+    _transformBotMode(actorSheet);
   }
+}
 
-  /**
-   * Handle AltModes being deleted
-   * @param {AltMode} altMode The deleted AltMode.
-   */
-  async onAltModeDelete(altMode) {
-    const altModes = getItemsOfType("altMode", this._actor.items);
-    if (altModes.length > 1) {
-      if (altMode._id == this._actor.system.altModeId) {
-        this._transformBotMode();
-      }
+/**
+ * Handles clicking the transform button
+ * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ */
+export async function onTransform(actorSheet) {
+  const actor = actorSheet.actor;
+  const altModes = getItemsOfType("altMode", actor.items);
+  const isTransformed = actor.system.isTransformed;
+
+  if (!altModes.length && !isTransformed) {      // No alt-modes to transform into
+    ui.notifications.warn(game.i18n.localize('E20.AltModeNone'));
+  } else if (altModes.length > 1) {              // Select from multiple alt-modes
+    if (!isTransformed) {
+      _showAltModeChoiceDialog(altModes, false); // More than 1 altMode and not transformed
     } else {
-      this._transformBotMode();
+      _showAltModeChoiceDialog(altModes, true);  // More than 1 altMode and transformed
     }
+  } else {                                       // Alt-mode/bot-mode toggle
+    isTransformed
+      ? _transformBotMode(actorSheet)
+      : _transformAltMode(actorSheet, altModes[0]);
+  }
+}
+
+/**
+ * Handle Transforming back into the Bot Mode
+ * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @private
+ */
+async function _transformBotMode(actorSheet) {
+  const actor = actorSheet.actor;
+  const width = CONFIG.E20.tokenSizes[actor.system.size].width;
+  const height = CONFIG.E20.tokenSizes[actor.system.size].height;
+  resizeTokens(actor, width, height);
+
+  await actor.update({
+    "prototypeToken.height": height,
+    "prototypeToken.width": width,
+    "system.movement.aerial.altMode": 0,
+    "system.movement.swim.altMode": 0,
+    "system.movement.ground.altMode": 0,
+    "system.isTransformed": false,
+    "system.altModeId": "",
+    "system.altModeSize": "",
+  }).then(actorSheet.render(false));
+}
+
+/**
+ * Handles Transforming into an Alt Mode
+ * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @param {AltMode} altMode The alt-mode that was selected to transform into
+ * @private
+ */
+async function _transformAltMode(actorSheet, altMode) {
+  const actor = actorSheet.actor;
+  const width = CONFIG.E20.tokenSizes[altMode.system.altModesize].width;
+  const height = CONFIG.E20.tokenSizes[altMode.system.altModesize].height;
+  resizeTokens(actor, width, height);
+
+  await actor.update({
+    "prototypeToken.height": height,
+    "prototypeToken.width": width,
+    "system.movement.aerial.altMode": altMode.system.altModeMovement.aerial,
+    "system.movement.swim.altMode": altMode.system.altModeMovement.aquatic,
+    "system.movement.ground.altMode": altMode.system.altModeMovement.ground,
+    "system.altModeSize": altMode.system.altModesize,
+    "system.altModeId": altMode._id,
+    "system.isTransformed": true,
+  }).then(actorSheet.render(false));
+}
+
+/**
+ * Creates the Alt Mode choice list dialog
+ * @param {Actor} actor The Actor selecting an Alt Mode
+ * @param {AltMode[]} altModes A list of the available Alt Modes
+ * @param {Boolean} isTransformed Whether the Transformer is transformed or not
+ * @private
+ */
+async function _showAltModeChoiceDialog(actor, altModes, isTransformed) {
+  const choices = {};
+  if (isTransformed) {
+    choices["BotMode"] = {
+      chosen: false,
+      label: "BotMode",
+    };
   }
 
-  /**
-   * Handle clicking the transform button
-   */
-  async onTransform() {
-    const altModes = getItemsOfType("altMode", this._actor.items);
-    const isTransformed = this._actor.system.isTransformed;
-
-    if (!altModes.length && !isTransformed) {           // No alt-modes to transform into
-      ui.notifications.warn(game.i18n.localize('E20.AltModeNone'));
-    } else if (altModes.length > 1) {                   // Select from multiple alt-modes
-      if (!isTransformed) {
-        this._showAltModeChoiceDialog(altModes, false); // More than 1 altMode and not transformed
-      } else {
-        this._showAltModeChoiceDialog(altModes, true);  // More than 1 altMode and transformed
-      }
-    } else {                                             // Alt-mode/bot-mode toggle
-      isTransformed
-        ? this._transformBotMode()
-        : this._transformAltMode(altModes[0]);
-    }
-  }
-
-  /**
-   * Handle Transforming back into the Bot Mode
-   * @private
-   */
-  async _transformBotMode() {
-    const width = CONFIG.E20.tokenSizes[this._actor.system.size].width;
-    const height = CONFIG.E20.tokenSizes[this._actor.system.size].height;
-    resizeTokens(this._actor, width, height);
-
-    await this._actor.update({
-      "prototypeToken.height": height,
-      "prototypeToken.width": width,
-      "system.movement.aerial.altMode": 0,
-      "system.movement.swim.altMode": 0,
-      "system.movement.ground.altMode": 0,
-      "system.isTransformed": false,
-      "system.altModeId": "",
-      "system.altModeSize": "",
-    }).then(this._actorSheet.render(false));
-  }
-
-  /**
-   * Handles Transforming into an AltMode
-   * @param {AltMode} altMode The alt-mode that was selected to Transform into
-   * @private
-   */
-  async _transformAltMode(altMode) {
-    const width = CONFIG.E20.tokenSizes[altMode.system.altModesize].width;
-    const height = CONFIG.E20.tokenSizes[altMode.system.altModesize].height;
-    resizeTokens(this._actor, width, height);
-
-    await this._actor.update({
-      "prototypeToken.height": height,
-      "prototypeToken.width": width,
-      "system.movement.aerial.altMode": altMode.system.altModeMovement.aerial,
-      "system.movement.swim.altMode": altMode.system.altModeMovement.aquatic,
-      "system.movement.ground.altMode": altMode.system.altModeMovement.ground,
-      "system.altModeSize": altMode.system.altModesize,
-      "system.altModeId": altMode._id,
-      "system.isTransformed": true,
-    }).then(this._actorSheet.render(false));
-  }
-
-  /**
-   * Creates the Alt Mode Choice List Dialog
-   * @param {AltMode[]} altModes    A list of the available Alt Modes
-   * @param {Boolean} isTransformed Whether the Transformer is transformed or not
-   * @private
-   */
-  async _showAltModeChoiceDialog(altModes, isTransformed) {
-    const choices = {};
-    if (isTransformed) {
-      choices["BotMode"] = {
+  for (const altMode of altModes) {
+    if (actor.system.altModeId != altMode._id) {
+      choices[altMode._id] = {
         chosen: false,
-        label: "BotMode",
+        label: altMode.name,
       };
     }
-
-    for (const altMode of altModes) {
-      if (this._actor.system.altModeId != altMode._id) {
-        choices[altMode._id] = {
-          chosen: false,
-          label: altMode.name,
-        };
-      }
-    }
-
-    new Dialog(
-      {
-        title: game.i18n.localize('E20.AltModeChoice'),
-        content: await renderTemplate("systems/essence20/templates/dialog/option-select.hbs", {
-          choices,
-        }),
-        buttons: {
-          save: {
-            label: game.i18n.localize('E20.AcceptButton'),
-            callback: html => this._altModeSelect(altModes, rememberOptions(html)),
-          },
-        },
-      },
-    ).render(true);
   }
 
-  /**
-   * Handle selecting an alt-mode from the Alt-mode Dialog
-   * @param {AltMode[]} altModes A list of the available Alt Modes
-   * @param {Object} options     The options resulting from _showAltModeDialog()
-   * @private
-   */
-  async _altModeSelect(altModes, options) {
-    let selectedForm = null;
-    let transformation = null;
+  new Dialog(
+    {
+      title: game.i18n.localize('E20.AltModeChoice'),
+      content: await renderTemplate("systems/essence20/templates/dialog/option-select.hbs", {
+        choices,
+      }),
+      buttons: {
+        save: {
+          label: game.i18n.localize('E20.AcceptButton'),
+          callback: html => _altModeSelect(altModes, rememberOptions(html)),
+        },
+      },
+    },
+  ).render(true);
+}
 
-    for (const [altMode, isSelected] of Object.entries(options)) {
-      if (isSelected) {
-        selectedForm = altMode;
+/**
+ * Handles selecting an Alt Mode from the Alt Mode dialog
+ * @param {AltMode[]} altModes A list of the available Alt Modes
+ * @param {Object} options The options resulting from _showAltModeDialog()
+ * @private
+ */
+async function _altModeSelect(altModes, options) {
+  let selectedForm = null;
+  let transformation = null;
+
+  for (const [altMode, isSelected] of Object.entries(options)) {
+    if (isSelected) {
+      selectedForm = altMode;
+      break;
+    }
+  }
+
+  if (!selectedForm) {
+    return;
+  }
+
+  if (selectedForm == "BotMode") {
+    _transformBotMode();
+  } else {
+    for (const mode of altModes) {
+      if (selectedForm == mode._id) {
+        transformation = mode;
         break;
       }
     }
 
-    if (!selectedForm) {
-      return;
-    }
-
-    if (selectedForm == "BotMode") {
-      this._transformBotMode();
-    } else {
-      for (const mode of altModes) {
-        if (selectedForm == mode._id) {
-          transformation = mode;
-          break;
-        }
-      }
-
-      if (transformation) {
-        this._transformAltMode(transformation);
-      }
+    if (transformation) {
+      _transformAltMode(transformation);
     }
   }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -14,7 +14,7 @@ import { influenceUpdate, originUpdate, onOriginDelete } from "../sheet-handlers
 import { showCrossoverOptions } from "../sheet-handlers/crossover-handler.mjs";
 import { prepareZords, onZordDelete, onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
 import { gearDrop, attachItem } from "../sheet-handlers/attachment-handler.mjs";
-import { TransformerHandler } from "../sheet-handlers/transformer-handler.mjs";
+import { onAltModeDelete, onTransform } from "../sheet-handlers/transformer-handler.mjs";
 import { PowerHandler } from "../sheet-handlers/power-handler.mjs";
 import { PerkHandler } from "../sheet-handlers/perk-handler.mjs";
 import { RoleHandler } from "../sheet-handlers/role-handler.mjs";
@@ -24,7 +24,6 @@ export class Essence20ActorSheet extends ActorSheet {
     super(...args);
 
     this._accordionStates = { skills: '' };
-    this._tfHandler = new TransformerHandler(this);
     this._pwHandler = new PowerHandler(this);
     this._pkHandler = new PerkHandler(this);
     this._rlHandler = new RoleHandler(this);
@@ -363,7 +362,7 @@ export class Essence20ActorSheet extends ActorSheet {
     html.find('.morph').click(() => onMorph(this));
 
     // Transform Button
-    html.find('.transform').click(() => this._tfHandler.onTransform(this));
+    html.find('.transform').click(() => onTransform(this));
 
     // Rollable abilities.
     if (this.actor.isOwner) {
@@ -757,7 +756,7 @@ export class Essence20ActorSheet extends ActorSheet {
       } else if (item.type == 'influence') {
         deleteAttachmentsForItem(item, this.actor);
       } else if (item.type == "altMode") {
-        this._tfHandler.onAltModeDelete(item, this);
+        onAltModeDelete(this, item);
       } else if (item.type == "alteration") {
         onAlterationDelete(this.actor, item);
       } else if (item.type == "focus") {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -16,7 +16,7 @@ import { prepareZords, onZordDelete, onMorph } from "../sheet-handlers/power-ran
 import { gearDrop, attachItem } from "../sheet-handlers/attachment-handler.mjs";
 import { onAltModeDelete, onTransform } from "../sheet-handlers/transformer-handler.mjs";
 import { powerUpdate, powerCost } from "../sheet-handlers/power-handler.mjs";
-import { PerkHandler } from "../sheet-handlers/perk-handler.mjs";
+import { perkUpdate, onPerkDelete } from "../sheet-handlers/perk-handler.mjs";
 import { RoleHandler } from "../sheet-handlers/role-handler.mjs";
 
 export class Essence20ActorSheet extends ActorSheet {
@@ -24,7 +24,6 @@ export class Essence20ActorSheet extends ActorSheet {
     super(...args);
 
     this._accordionStates = { skills: '' };
-    this._pkHandler = new PerkHandler(this);
     this._rlHandler = new RoleHandler(this);
   }
 
@@ -763,7 +762,7 @@ export class Essence20ActorSheet extends ActorSheet {
       } else if (item.type == "focus") {
         this._rlHandler.onFocusDelete(item);
       } else if (item.type == "perk") {
-        this._pkHandler.onPerkDelete(item);
+        onPerkDelete(this.actor, item);
       } else if (item.type == "role") {
         this._rlHandler.onRoleDelete(item);
       } else if (item.type == "weapon") {
@@ -868,7 +867,7 @@ export class Essence20ActorSheet extends ActorSheet {
       ui.notifications.error(game.i18n.localize('E20.RolePointsActorDropError'));
       return;
     case 'perk':
-      return await this._pkHandler.perkUpdate(sourceItem, super._onDropItem.bind(this, event, data));
+      return await perkUpdate(this.actor, sourceItem, super._onDropItem.bind(this, event, data));
     case 'power':
       return await powerUpdate(this.actor, sourceItem, super._onDropItem.bind(this, event, data));
     case 'upgrade':

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -15,7 +15,7 @@ import { showCrossoverOptions } from "../sheet-handlers/crossover-handler.mjs";
 import { prepareZords, onZordDelete, onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
 import { gearDrop, attachItem } from "../sheet-handlers/attachment-handler.mjs";
 import { onAltModeDelete, onTransform } from "../sheet-handlers/transformer-handler.mjs";
-import { PowerHandler } from "../sheet-handlers/power-handler.mjs";
+import { powerUpdate, powerCost } from "../sheet-handlers/power-handler.mjs";
 import { PerkHandler } from "../sheet-handlers/perk-handler.mjs";
 import { RoleHandler } from "../sheet-handlers/role-handler.mjs";
 
@@ -24,7 +24,6 @@ export class Essence20ActorSheet extends ActorSheet {
     super(...args);
 
     this._accordionStates = { skills: '' };
-    this._pwHandler = new PowerHandler(this);
     this._pkHandler = new PerkHandler(this);
     this._rlHandler = new RoleHandler(this);
   }
@@ -458,7 +457,9 @@ export class Essence20ActorSheet extends ActorSheet {
     if (this.actor.system.powers.personal.max > 0) {
       powerRestore = Math.min(this.actor.system.powers.personal.max, (this.actor.system.powers.personal.value + this.actor.system.powers.personal.regeneration));
 
-      ui.notifications.info(game.i18n.localize("E20.RestPersonalPowerRegen"));
+      if (powerRestore) {
+        ui.notifications.info(game.i18n.localize("E20.RestPersonalPowerRegen"));
+      }
     }
 
     // Resetting Role Points
@@ -576,7 +577,7 @@ export class Essence20ActorSheet extends ActorSheet {
       }
 
       if (rollType == 'power') {
-        return await this._pwHandler.powerCost(item);
+        return await powerCost(this.actor, item);
       } else if (rollType == 'rolePoints') {
         if (item.system.resource.max != null && item.system.resource.value < 1 && !this.actor.system.useUnlimitedResource) {
           ui.notifications.error(game.i18n.localize('E20.RolePointsOverSpent'));
@@ -869,7 +870,7 @@ export class Essence20ActorSheet extends ActorSheet {
     case 'perk':
       return await this._pkHandler.perkUpdate(sourceItem, super._onDropItem.bind(this, event, data));
     case 'power':
-      return await this._pwHandler.powerUpdate(sourceItem, super._onDropItem.bind(this, event, data));
+      return await powerUpdate(this.actor, sourceItem, super._onDropItem.bind(this, event, data));
     case 'upgrade':
       return await this._onDropUpgrade(sourceItem, event, data);
     case 'weapon':


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/617

##### In this PR
- Un-classes Power, TF, and Perk handlers
- Cleaned up some comment blocks as well
- Tiny tweak to the power restore message so that it only displays if > 0 power is actually being restored

##### Testing
- Power spending and restoring should still work
  - The power restore message should only display when resting if the actor can actually restore power (a default actor wouldn't, for example)
- Adding and deleting perks should work as expected
- Dropping and deleting alt modes and transforming should work as expected
