### PR TITLE
Fixes for weapon effect rolls

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -100,7 +100,7 @@ export class Dice {
     const rolePointsList = getItemsOfType('rolePoints', actor.items);
 
     let rolePoints = null;
-    if (item?.type == 'weapon' && rolePointsList.length) {
+    if (item?.type == 'weaponEffect' && rolePointsList.length) {
       rolePoints = rolePointsList[0]; // There should only be one RolePoints
       if (rolePoints.system.bonus.type == 'attackUpshift' && (rolePoints.system.isActive || !rolePoints.system.isActivatable)) {
         updatedShiftDataset.rolePoints = rolePoints;
@@ -117,7 +117,7 @@ export class Dice {
     let label = '';
 
     switch(item?.type) {
-    case 'weapon':
+    case 'weaponEffect':
       label = this._getWeaponRollLabel(dataset, skillRollOptions, actor, item);
       break;
     case 'spell':

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -118,7 +118,7 @@ export class Dice {
 
     switch(item?.type) {
     case 'weaponEffect':
-      label = this._getWeaponRollLabel(dataset, skillRollOptions, actor, item);
+      label = this._getWeaponRollLabel(dataset, skillRollOptions, item);
       break;
     case 'spell':
       label = this._getSpellRollLabel(skillRollOptions, item);
@@ -211,12 +211,11 @@ export class Dice {
    * Create weapon roll label.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().
-   * @param {Actor} actor   The actor performing the roll.
    * @param {Item} weaponEffect   The weapon effect being used.
    * @returns {String}   The resultant roll label.
    * @private
    */
-  _getWeaponRollLabel(dataset, skillRollOptions, actor, weaponEffect) {
+  _getWeaponRollLabel(dataset, skillRollOptions, weaponEffect) {
     const rolledSkill = dataset.skill;
     const rolledSkillStr = this._localize(E20.skills[rolledSkill]);
     const attackRollStr = this._localize('E20.RollTypeAttack');

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -252,7 +252,7 @@ describe("rollSkill", () => {
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor Foo Specialization");
   });
 
-  test("normal weapon skill roll", async () => {
+  test("normal weapon effect skill roll", async () => {
     rollDialog.getSkillRollOptions.mockReturnValue({
       edge: false,
       snag: false,
@@ -260,15 +260,15 @@ describe("rollSkill", () => {
       shiftDown: 0,
       timesToRoll: 1,
     });
-    const weapon = {
-      name: 'Zeo Power Clubs',
-      type: 'weapon',
+    const weaponEffect = {
+      name: 'Zeo Power Clubs Effect',
+      type: 'weaponEffect',
       system: {
-        alternateEffects: "Some alternate effects",
         classification: {
           skill: "athletics",
         },
-        effect: "Some effect",
+        damageType: "blunt",
+        damageValue: 1,
       },
     };
     mockActor.getRollData = jest.fn(() => ({
@@ -281,8 +281,12 @@ describe("rollSkill", () => {
     }));
     dice._rollSkillHelper = jest.fn();
 
-    await dice.rollSkill(dataset, mockActor, weapon);
-    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "<b>E20.RollTypeAttack</b> - Zeo Power Clubs (E20.SkillAthletics)<br><b>E20.WeaponEffect</b> - Some effect<br><b>E20.WeaponAlternateEffects</b> - Some alternate effects<br><b>ITEM.TypeClassfeature</b> - E20.None");
+    await dice.rollSkill(dataset, mockActor, weaponEffect);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith(
+      'd20 + 0',
+      mockActor,
+      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics)<br><b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>",
+    );
   });
 
   test("normal spell skill roll", async () => {
@@ -321,7 +325,7 @@ describe("rollSkill", () => {
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "<b>E20.RollTypeSpell</b> - Barreling Beam (E20.SkillSpellcasting)<br><b>E20.ItemDescription</b> - Some description<br>");
   });
 
-  test.only("essence-shifted skill roll", async () => {
+  test("essence-shifted skill roll", async () => {
     rollDialog.getSkillRollOptions.mockReturnValue({
       edge: false,
       snag: false,
@@ -427,6 +431,18 @@ describe("_getSkillRollLabel", () => {
 
 /* _getWeaponRollLabel */
 describe("_getWeaponRollLabel", () => {
+  const weaponEffect = {
+    name: 'Zeo Power Clubs Effect',
+    type: 'weaponEffect',
+    system: {
+      classification: {
+        skill: "athletics",
+      },
+      damageType: "blunt",
+      damageValue: 1,
+    },
+  };
+
   test("weapon roll", () => {
     const dataset = {
       skill: 'athletics',
@@ -435,21 +451,12 @@ describe("_getWeaponRollLabel", () => {
       edge: false,
       snag: false,
     };
-    const weapon = {
-      name: 'Zeo Power Clubs',
-      type: 'weapon',
-      system: {
-        effect: "Some effect",
-        alternateEffects: "Some alternate effects",
-      },
-    };
-    const expected =
-      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs (E20.SkillAthletics)<br>" +
-      "<b>E20.WeaponEffect</b> - Some effect<br>" +
-      "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
-      "<b>ITEM.TypeClassfeature</b> - E20.None";
 
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weapon)).toEqual(expected);
+    const expected =
+      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics)<br>" +
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weaponEffect)).toEqual(expected);
   });
 
   test("weapon roll with Edge", () => {
@@ -460,21 +467,12 @@ describe("_getWeaponRollLabel", () => {
       edge: true,
       snag: false,
     };
-    const weapon = {
-      name: 'Zeo Power Clubs',
-      type: 'weapon',
-      system: {
-        effect: "Some effect",
-        alternateEffects: "Some alternate effects",
-      },
-    };
-    const expected =
-      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs (E20.SkillAthletics) E20.RollWithAnEdge<br>" +
-      "<b>E20.WeaponEffect</b> - Some effect<br>" +
-      "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
-      "<b>ITEM.TypeClassfeature</b> - E20.None";
 
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weapon)).toEqual(expected);
+    const expected =
+      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics) E20.RollWithAnEdge<br>" +
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weaponEffect)).toEqual(expected);
   });
 
   test("weapon roll with Snag", () => {
@@ -485,46 +483,12 @@ describe("_getWeaponRollLabel", () => {
       edge: false,
       snag: true,
     };
-    const weapon = {
-      name: 'Zeo Power Clubs',
-      type: 'weapon',
-      system: {
-        effect: "Some effect",
-        alternateEffects: "Some alternate effects",
-      },
-    };
+
     const expected =
-      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs (E20.SkillAthletics) E20.RollWithASnag<br>" +
-      "<b>E20.WeaponEffect</b> - Some effect<br>" +
-      "<b>E20.WeaponAlternateEffects</b> - Some alternate effects<br>" +
-      "<b>ITEM.TypeClassfeature</b> - E20.None";
+      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics) E20.RollWithASnag<br>" +
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
 
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weapon)).toEqual(expected);
-  });
-
-  test("no effects", () => {
-    const dataset = {
-      skill: 'athletics',
-    };
-    const skillRollOptions = {
-      edge: false,
-      snag: false,
-    };
-    const weapon = {
-      name: 'Zeo Power Clubs',
-      type: 'weapon',
-      system: {
-        effect: "",
-        alternateEffects: "",
-      },
-    };
-    const expected =
-      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs (E20.SkillAthletics)<br>" +
-      "<b>E20.WeaponEffect</b> - E20.None<br>" +
-      "<b>E20.WeaponAlternateEffects</b> - E20.None<br>" +
-      "<b>ITEM.TypeClassfeature</b> - E20.None";
-
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weapon)).toEqual(expected);
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weaponEffect)).toEqual(expected);
   });
 });
 

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -456,7 +456,7 @@ describe("_getWeaponRollLabel", () => {
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics)<br>" +
       "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
 
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weaponEffect)).toEqual(expected);
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
 
   test("weapon roll with Edge", () => {
@@ -472,7 +472,7 @@ describe("_getWeaponRollLabel", () => {
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics) E20.RollWithAnEdge<br>" +
       "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
 
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weaponEffect)).toEqual(expected);
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
 
   test("weapon roll with Snag", () => {
@@ -488,7 +488,7 @@ describe("_getWeaponRollLabel", () => {
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics) E20.RollWithASnag<br>" +
       "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
 
-    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, null, weaponEffect)).toEqual(expected);
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
 });
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -147,10 +147,9 @@ export class Essence20Item extends Item {
   /**
    * Handle clickable rolls.
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
-   * @param {String} childKey The key of the item attached to another item
    * @private
    */
-  async roll(dataset, childKey) {
+  async roll(dataset) {
     if (dataset.rollType == 'info') {
       // Initialize chat data.
       const speaker = ChatMessage.getSpeaker({ actor: this.actor });

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -217,11 +217,11 @@ export class Essence20Item extends Item {
         flavor: label,
         content: content,
       });
-    } else if (this.type == 'weapon') {
-      const skill = this.system.items[childKey].classification.skill;
+    } else if (this.type == 'weaponEffect') {
+      const skill = this.system.classification.skill;
       const shift = this.actor.system.skills[skill].shift;
       const shiftUp = this.actor.system.skills[skill].shiftUp;
-      const shiftDown = this.actor.system.skills[skill].shiftDown + this.system.items[childKey].shiftDown;
+      const shiftDown = this.actor.system.skills[skill].shiftDown + this.system.shiftDown;
       const isSpecialized = this.actor.system.skills[skill].isSpecialized;
       const weaponDataset = {
         ...dataset,

--- a/module/helpers/roll-dialog.mjs
+++ b/module/helpers/roll-dialog.mjs
@@ -59,7 +59,7 @@ export class RollDialog {
             callback: html => resolve(this._processSkillRollOptions(html[0].querySelector("form"))),
           },
           cancel: {
-            label: this._localize('E20.RollDialogCancelButton'),
+            label: this._localize('E20.DialogCancelButton'),
             /* eslint-disable no-unused-vars */
             callback: html => resolve({ cancelled: true }),
           },

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -560,14 +560,8 @@ export class Essence20ActorSheet extends ActorSheet {
 
       const childKey = element.closest('.item').dataset.itemKey || null;
       if (childKey) {
-        if (rollType == 'weapon') {
-          // Special case for weapon effect attacks where we want the parent weapon as the item
-          const parentId = element.closest('.item').dataset.parentId;
-          item = this.actor.items.get(parentId);
-        } else {
-          const childUuid = element.closest('.item').dataset.itemUuid;
-          item = await fromUuid(childUuid);
-        }
+        const childUuid = element.closest('.item').dataset.itemUuid;
+        item = await fromUuid(childUuid);
       } else {
         const itemId = element.closest('.item').dataset.itemId;
         item = this.actor.items.get(itemId);

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -16,7 +16,7 @@
     {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.system.items title="E20.ItemTypeWeaponEffectPlural" dataType="weaponEffect" parentItem=parentItem}}
 
       {{#*inline "roll-button"}}
-        <a class="rollable" data-roll-type="weapon" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
+        <a class="rollable" data-roll-type="weaponEffect" title="{{localize 'E20.WeaponRollTitle'}}"><i class="fas fa-dice-d20"></i></a>
       {{/inline}}
 
       {{#*inline "item-label" item}}

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -1,13 +1,13 @@
 <div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
 <div class="chip-section">
-   <span class="chip" name="chip.weapon.classification">{{lookup @root.config.skills item.classification.skill}} {{lookup @root.config.weaponSizes parentItem.system.classification.size}} {{lookup @root.config.weaponStyles item.classification.style}}</span>
-  <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.numHands}}</span>
-  <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.numTargets}}</span>
-  {{#if item.damageValue}}
-  <span class="chip" name="chip.weapon.damageValue">{{localize 'E20.Damage'}}: {{item.damageValue}}</span>
+   <span class="chip" name="chip.weapon.classification">{{lookup @root.config.skills item.system.classification.skill}} {{lookup @root.config.weaponSizes parentItem.system.classification.size}} {{lookup @root.config.weaponStyles item.system.classification.style}}</span>
+  <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
+  <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
+  {{#if item.system.damageValue}}
+  <span class="chip" name="chip.weapon.damageValue">{{localize 'E20.Damage'}}: {{item.system.damageValue}}</span>
   {{/if}}
-  <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{localize (lookup @root.config.damageTypes item.damageType)}}</span>
-  {{#if item.shiftDown}}
-  <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.shiftDown}}</span>
+  <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{localize (lookup @root.config.damageTypes item.system.damageType)}}</span>
+  {{#if item.system.shiftDown}}
+  <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.system.shiftDown}}</span>
   {{/if}}
 </div>


### PR DESCRIPTION
##### In this PR
- While weapon effect skill rolls were working, the info button was not, and TAH was broken as well. This is because we were working off of the item/roll type being "weapon" instead of "weaponEffect", which TAH can't really handle.
- We were also mixing up in the logic whether `item` was a weapon or a weapon effect, leading to some values being undefined in the info message
- A while ago I accidentally committed a `test.only` for the dice tests, meaning most of them haven't been running. I removed that and fixed other tests as needed.
- Fixed the roll dialog cancel button text

##### Testing
- Weapon and weapon effect info buttons should work. Probably use a compendium weapon to see all the fields get filled in
- Weapon effect rolls should still work as expected
- Roll dialog cancel button should say "Cancel" again