### PR TITLE
Moving files out of utils that are only used in one location

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,6 +1,5 @@
 import { Dice } from "../dice.mjs";
 import { RollDialog } from "../helpers/roll-dialog.mjs";
-import { getLevelIncreases } from "../helpers/utils.mjs";
 
 /**
  * Extend the basic Item with some very simple modifications.
@@ -108,7 +107,7 @@ export class Essence20Item extends Item {
     if (!this.actor) return null;
 
     const actorLevel = this.actor.system.level;
-    const resourceLevelIncreases = getLevelIncreases(this.system.resource.increaseLevels, actorLevel);
+    const resourceLevelIncreases = this._getLevelIncreases(this.system.resource.increaseLevels, actorLevel);
 
     if (this.system.resource.startingMax != null) {
       if (actorLevel == 20 && this.system.resource.level20Value) {
@@ -120,7 +119,7 @@ export class Essence20Item extends Item {
 
     if (this.system.bonus.startingValue != null) {
       if (this.system.bonus.type != CONFIG.E20.bonusTypes.none) {
-        const bonusLevelIncreases = getLevelIncreases(this.system.bonus.increaseLevels, actorLevel);
+        const bonusLevelIncreases = this._getLevelIncreases(this.system.bonus.increaseLevels, actorLevel);
 
         if (actorLevel == 20 && this.system.bonus.level20Value) {
           this.system.bonus.value = this.system.bonus.level20Value;
@@ -129,6 +128,25 @@ export class Essence20Item extends Item {
         }
       }
     }
+  }
+
+  /**
+   * Determines the number of increases that have occured based on the level of the actor
+   * @param {String[]} levels The array of levels that you advance at
+   * @param {Number} currentLevel The current level of the actor
+   * @returns {Number} The number of increases for the level of the actor
+   */
+  _getLevelIncreases(levels, currentLevel) {
+    let levelIncreases = 0;
+    for (const arrayLevel of levels) {
+
+      const level = arrayLevel.replace(/[^0-9]/g, '');
+      if (level <= currentLevel) {
+        levelIncreases += 1;
+      }
+    }
+
+    return levelIncreases;
   }
 
   /**

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -10,7 +10,7 @@ import { Essence20ItemSheet } from "./sheets/item-sheet.mjs";
 import { highlightCriticalSuccessFailure } from "./chat.mjs";
 import { E20 } from "./helpers/config.mjs";
 import { preloadHandlebarsTemplates } from "./helpers/templates.mjs";
-import { getNumActions, performPreLocalization, setOptGroup } from "./helpers/utils.mjs";
+import { getNumActions, performPreLocalization } from "./helpers/utils.mjs";
 import { migrateWorld } from "./migration.mjs";
 
 function registerSystemSettings() {
@@ -276,4 +276,24 @@ async function rollItemMacro(itemId, itemName) {
 
   // Trigger the item roll
   return item.roll();
+}
+
+/*
+ * Handle organizing selects by adding optGroups
+ * @param {Select} select The select that you are organizing
+ * @param {Category} category The category that we are adding to the options
+ * @param {Items} items The types that you are putting in the category
+ */
+export function setOptGroup(select, category, items) {
+  const options = select.querySelectorAll(":scope > option");
+  const optGroup = document.createElement("optgroup");
+  optGroup.label = category;
+
+  for (const option of options) {
+    if (items[option.value]) {
+      optGroup.appendChild(option);
+    }
+  }
+
+  return optGroup;
 }

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -245,26 +245,6 @@ export function compareShift(shift1, shift2, operator) {
   }
 }
 
-/*
- * Handle organizing selects by adding optGroups
- * @param {Select} select The select that you are organizing
- * @param {Category} category The category that we are adding to the options
- * @param {Items} items The types that you are putting in the category
- */
-export function setOptGroup(select, category, items) {
-  const options = select.querySelectorAll(":scope > option");
-  const optGroup = document.createElement("optgroup");
-  optGroup.label = category;
-
-  for (const option of options) {
-    if (items[option.value]) {
-      optGroup.appendChild(option);
-    }
-  }
-
-  return optGroup;
-}
-
 /**
  * Displays an error message if the sheet is locked
  * @returns {boolean} True if the sheet is locked, and false otherwise

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -611,25 +611,6 @@ export async function setFocusValues(focus, actor, newLevel=null, previousLevel=
 }
 
 /**
- * Determines the number of increases that have occured based on the level of the actor
- * @param {String[]} levels The array of levels that you advance at
- * @param {Number} currentLevel The current level of the actor
- * @returns {Number} level Increase The number of increases for the level of the actor
- */
-export function getLevelIncreases(levels, currentLevel) {
-  let levelIncreases = 0;
-  for (const arrayLevel of levels) {
-
-    const level = arrayLevel.replace(/[^0-9]/g, '');
-    if (level <= currentLevel) {
-      levelIncreases += 1;
-    }
-  }
-
-  return levelIncreases;
-}
-
-/**
  * Prepare the number of actions available for the given actor
  * @param {Actor} actor The actor to get actions for
  * @return {Object} Action types mapped to an action count

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -227,24 +227,6 @@ export function getShiftedSkill(skill, shift, actor) {
   return [newShift, skillString];
 }
 
-/** Handle comparing skill rank
- * @param {String} shift1 The first skill
- * @param {String} shift2 The second skill
- * @param {String} operator The type of comparison
- * @return {Boolean} The result of the comparison
- */
-export function compareShift(shift1, shift2, operator) {
-  if (operator == 'greater') {
-    return CONFIG.E20.skillShiftList.indexOf(shift1) < CONFIG.E20.skillShiftList.indexOf(shift2);
-  } else if (operator == 'lesser') {
-    return CONFIG.E20.skillShiftList.indexOf(shift1) > CONFIG.E20.skillShiftList.indexOf(shift2);
-  } else if (operator == 'equal') {
-    return CONFIG.E20.skillShiftList.indexOf(shift1) == CONFIG.E20.skillShiftList.indexOf(shift2);
-  } else {
-    throw new Error(`Operator ${operator} not expected`);
-  }
-}
-
 /**
  * Displays an error message if the sheet is locked
  * @returns {boolean} True if the sheet is locked, and false otherwise

--- a/module/sheet-handlers/alteration-handler.mjs
+++ b/module/sheet-handlers/alteration-handler.mjs
@@ -1,5 +1,4 @@
 import {
-  compareShift,
   getShiftedSkill,
   parseId,
   rememberOptions,
@@ -279,7 +278,7 @@ async function _showAlterationCostSkillDialog(actor, alteration, bonusSkill, alt
       for (const essence of essences) {
         if (options[essence]) {
           if (actor.system.skills[skill].essences[essence]) {
-            if (compareShift(actor.system.skills[skill].shift, "d20", "greater")) {
+            if (_compareShift(actor.system.skills[skill].shift, "d20", "greater")) {
               choices[skill] = {
                 chosen: false,
                 label: CONFIG.E20.originSkills[skill],
@@ -293,7 +292,7 @@ async function _showAlterationCostSkillDialog(actor, alteration, bonusSkill, alt
     const essence = alteration.system.essenceCost;
     for (const skill in actor.system.skills) {
       if (actor.system.skills[skill].essences[essence]) {
-        if (compareShift(actor.system.skills[skill].shift, "d20", "greater")) {
+        if (_compareShift(actor.system.skills[skill].shift, "d20", "greater")) {
           choices[skill] = {
             chosen: false,
             label: CONFIG.E20.originSkills[skill],
@@ -348,6 +347,24 @@ async function _showAlterationCostSkillDialog(actor, alteration, bonusSkill, alt
       },
     },
   ).render(true);
+}
+
+/** Handle comparing skill rank
+ * @param {String} shift1 The first skill
+ * @param {String} shift2 The second skill
+ * @param {String} operator The type of comparison
+ * @return {Boolean} The result of the comparison
+ */
+function _compareShift(shift1, shift2, operator) {
+  if (operator == 'greater') {
+    return CONFIG.E20.skillShiftList.indexOf(shift1) < CONFIG.E20.skillShiftList.indexOf(shift2);
+  } else if (operator == 'lesser') {
+    return CONFIG.E20.skillShiftList.indexOf(shift1) > CONFIG.E20.skillShiftList.indexOf(shift2);
+  } else if (operator == 'equal') {
+    return CONFIG.E20.skillShiftList.indexOf(shift1) == CONFIG.E20.skillShiftList.indexOf(shift2);
+  } else {
+    throw new Error(`Operator ${operator} not expected`);
+  }
 }
 
 /**


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/617

##### In this PR
- Moving files out of utils that are only used in one location

##### Testing
- `getLevelIncreases` - Role Points should still calculate correctly when leveling
- `setOptGroup` - Item groups work as normal when creating an item
- `compareShift` - Dropping an Alteration still shows the dialog and works as normal