### PR TITLE
Fixing child item inline editing

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -663,17 +663,27 @@ export class Essence20ActorSheet extends ActorSheet {
    */
   async _onInlineEdit(event) {
     event.preventDefault();
+
+    let item;
     let element = event.currentTarget;
-    let itemId = element.closest(".item").dataset.itemId;
-
-    if (!itemId) {
-      itemId = element.closest(".item").dataset.parentId;
-    }
-
-    const item = this.actor.items.get(itemId);
-    const field = element.dataset.field;
+    const dataset = element.closest(".item").dataset;
+    const itemId = dataset.itemId;
+    const itemUuid = dataset.itemUuid;
+    const parentId = dataset.parentId;
     const newValue = element.type == 'checkbox' ? element.checked : element.value;
 
+    // If a child item is being updated, update the parent's copy too
+    if (!itemId && itemUuid && parentId) {
+      item = await fromUuid(itemUuid);
+
+      const parentItem = this.actor.items.get(parentId);
+      const parentField = dataset.parentField;
+      await parentItem.update({ [parentField]: newValue });
+    } else {
+      item = this.actor.items.get(itemId);
+    }
+
+    const field = element.dataset.field;
     return item.update({ [field]: newValue });
   }
 

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -24,7 +24,7 @@
           <div style="flex-grow: 1.5;">
             {{item.name}}
           </div>
-          <select class="inline-edit" data-field="system.items.{{@key}}.classification.skill" name="item.classification.skill">
+          <select class="inline-edit" data-field="system.classification.skill" data-parent-field="system.items.{{@key}}.classification.skill" name="item.classification.skill">
             {{#select item.classification.skill}}
             {{#each @root.actor.system.skills}}
               {{#if this.displayName}}


### PR DESCRIPTION
##### In this PR
- Fixes bug where the inline weapon skill selector was broken because child items weren't getting updated

##### Testing
- Inline weapon skill selector should work as expected