### PR TITLE
Moving dialog helper methods from `utils.mjs` to `dialog.mjs`

### DIFF
--- a/module/helpers/dialog.mjs
+++ b/module/helpers/dialog.mjs
@@ -1,0 +1,45 @@
+/**
+ * Returns values of inputs upon dialog submission. Used for passing data between sequential dialogs.
+ * @param {HTML} html   The html of the dialog upon submission
+ * @returns {Object>}  The dialog inputs and their submitted values
+ */
+export function rememberOptions(html) {
+  const options = {};
+  html.find("input").each((i, el) => {
+    options[el.id] = el.checked;
+  });
+
+  return options;
+}
+
+/**
+ * Returns values of inputs upon dialog submission.
+ * @param {HTML} html   The html of the dialog upon submission
+ * @returns {Object}  The dialog inputs and their submitted values
+ */
+export function rememberSelect(html) {
+  const options = {};
+  html.find("select").each((i, el) => {
+    options[el.id] = el.value;
+  });
+
+  return options;
+}
+
+/**
+ * Returns values of inputs upon dialog submission. Used for passing data between sequential dialogs.
+ * (This one does values instead of checked)
+ * @param {HTML} html   The html of the dialog upon submission
+ * @returns {Object}  The dialog inputs and their entered values
+ */
+export function rememberValues(html) {
+  const options = {};
+  html.find("input").each((i, el) => {
+    options[el.id] = {
+      max: el.max,
+      value: el.value,
+    };
+  });
+
+  return options;
+}

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -28,52 +28,6 @@ export function getItemsOfType(type, items) {
 }
 
 /**
- * Returns values of inputs upon dialog submission. Used for passing data between sequential dialogs.
- * @param {HTML} html   The html of the dialog upon submission
- * @returns {Object>}  The dialog inputs and their submitted values
- */
-export function rememberOptions(html) {
-  const options = {};
-  html.find("input").each((i, el) => {
-    options[el.id] = el.checked;
-  });
-
-  return options;
-}
-
-/**
- * Returns values of inputs upon dialog submission.
- * @param {HTML} html   The html of the dialog upon submission
- * @returns {Object}  The dialog inputs and their submitted values
- */
-export function rememberSelect(html) {
-  const options = {};
-  html.find("select").each((i, el) => {
-    options[el.id] = el.value;
-  });
-
-  return options;
-}
-
-/**
- * Returns values of inputs upon dialog submission. Used for passing data between sequential dialogs.
- * (This one does values instead of checked)
- * @param {HTML} html   The html of the dialog upon submission
- * @returns {Object}  The dialog inputs and their entered values
- */
-export function rememberValues(html) {
-  const options = {};
-  html.find("input").each((i, el) => {
-    options[el.id] = {
-      max: el.max,
-      value: el.value,
-    };
-  });
-
-  return options;
-}
-
-/**
  * Creates copies of Items for given IDs
  * @param {Object[]} items The item entries to copy
  * @param {Actor} owner The items' owner

--- a/module/sheet-handlers/alteration-handler.mjs
+++ b/module/sheet-handlers/alteration-handler.mjs
@@ -1,8 +1,11 @@
+
+import {
+  rememberOptions,
+  rememberValues,
+} from "../helpers/dialog.mjs";
 import {
   getShiftedSkill,
   parseId,
-  rememberOptions,
-  rememberValues,
 } from "../helpers/utils.mjs";
 
 /**

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -1,7 +1,7 @@
+import { rememberOptions } from "../helpers/dialog.mjs";
 import {
   createItemCopies,
   getItemsOfType,
-  rememberOptions,
   setEntryAndAddItem,
 } from "../helpers/utils.mjs";
 

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -1,9 +1,11 @@
 import {
+  rememberOptions,
+} from "../helpers/dialog.mjs";
+import {
   deleteAttachmentsForItem,
   createItemCopies,
   getItemsOfType,
   getShiftedSkill,
-  rememberOptions,
 } from "../helpers/utils.mjs";
 
 /**

--- a/module/sheet-handlers/crossover-handler.mjs
+++ b/module/sheet-handlers/crossover-handler.mjs
@@ -1,4 +1,4 @@
-import { rememberOptions } from "../helpers/utils.mjs";
+import { rememberOptions } from "../helpers/dialog.mjs";
 
 /**
  * Creates dialog window for crossover options

--- a/module/sheet-handlers/power-handler.mjs
+++ b/module/sheet-handlers/power-handler.mjs
@@ -1,7 +1,5 @@
-import {
-  parseId,
-  rememberValues,
-} from "../helpers/utils.mjs";
+import { rememberValues} from "../helpers/dialog.mjs";
+import { parseId } from "../helpers/utils.mjs";
 
 /**
  * Handles dropping a Power on to an Actor
@@ -39,7 +37,7 @@ export async function powerUpdate(actor, power, dropFunc) {
 export async function powerCost(actor, power) {
   let maxPower = 0;
   let powerType = "";
-  
+
   if (power.system.type == "grid") {
     powerType = "personal";
   } else if (power.system.type == "sorcerous") {

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -1,8 +1,7 @@
+import { rememberOptions, rememberSelect } from "../helpers/dialog.mjs";
 import {
   deleteAttachmentsForItem,
   getItemsOfType,
-  rememberOptions,
-  rememberSelect,
   roleValueChange,
   setFocusValues,
   setRoleValues,

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -1,4 +1,5 @@
-import { getItemsOfType, rememberOptions, resizeTokens } from "../helpers/utils.mjs";
+import { rememberOptions } from "../helpers/dialog.mjs";
+import { getItemsOfType, resizeTokens } from "../helpers/utils.mjs";
 
 /**
  * Handles AltModes being deleted


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/617

##### In this PR
- Moving dialog-related helper methods into `dialog.mjs`

##### Testing
- Dialogs should work as expected
- These are just import changes, so just checking for errors in the console is probably sufficient