### PR TITLE
Moving actor-related methods out of utils

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,6 +1,7 @@
 import { Dice } from "../dice.mjs";
 import { RollDialog } from "../helpers/roll-dialog.mjs";
-import { resizeTokens, getItemsOfType, roleValueChange } from "../helpers/utils.mjs";
+import { resizeTokens } from "../helpers/actor.mjs";
+import { getItemsOfType, roleValueChange } from "../helpers/utils.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -10,7 +10,7 @@ import { Essence20ItemSheet } from "./sheets/item-sheet.mjs";
 import { highlightCriticalSuccessFailure } from "./chat.mjs";
 import { E20 } from "./helpers/config.mjs";
 import { preloadHandlebarsTemplates } from "./helpers/templates.mjs";
-import { getNumActions } from "./helpers/utils.mjs";
+import { getNumActions } from "./helpers/actor.mjs";
 import { performPreLocalization } from "./helpers/localize.mjs";
 import { migrateWorld } from "./migration.mjs";
 

--- a/module/helpers/actor.mjs
+++ b/module/helpers/actor.mjs
@@ -1,0 +1,43 @@
+/**
+ * Handle looking up tokens associated with actor and changing size
+ * @param {Actor} actor  The actor
+ * @param {Number} width The actor's new width
+ * @param {Number} height The actor's new width
+ */
+export function resizeTokens(actor, width, height) {
+  const tokens = actor.getActiveTokens();
+  for (const token of tokens) {
+    token.document.update({
+      "height": height,
+      "width": width,
+    });
+  }
+}
+
+/**
+ * Displays an error message if the sheet is locked
+ * @returns {boolean} True if the sheet is locked, and false otherwise
+ */
+export function checkIsLocked(actor) {
+  if (actor.system.isLocked) {
+    ui.notifications.error(game.i18n.localize('E20.ActorLockError'));
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Prepare the number of actions available for the given actor
+ * @param {Actor} actor The actor to get actions for
+ * @return {Object} Action types mapped to an action count
+ */
+export function getNumActions(actor) {
+  const speed = actor.system.essences.speed;
+
+  return {
+    free: Math.max(0, speed - 2),
+    movement: speed > 0 ? 1 : 0,
+    standard: speed > 1 ? 1 : 0,
+  };
+}

--- a/module/helpers/effects.mjs
+++ b/module/helpers/effects.mjs
@@ -1,4 +1,4 @@
-import { checkIsLocked } from "../helpers/utils.mjs";
+import { checkIsLocked } from "../helpers/actor.mjs";
 
 /**
  * Manage Active Effect instances through the Actor Sheet via effect control buttons.

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -64,22 +64,6 @@ export async function createItemCopies(items, owner, type, parentItem, lastProce
 }
 
 /**
- * Handle looking up tokens associated with actor and changing size
- * @param {Actor} actor  The actor
- * @param {Number} width The actor's new width
- * @param {Number} height The actor's new width
- */
-export function resizeTokens(actor, width, height) {
-  const tokens = actor.getActiveTokens();
-  for (const token of tokens) {
-    token.document.update({
-      "height": height,
-      "width": width,
-    });
-  }
-}
-
-/**
  * Handle Shifting skills
  * @param {String} skill The skill shifting
  * @param {Number} shift The quantity of the shift
@@ -107,19 +91,6 @@ export function getShiftedSkill(skill, shift, actor) {
   }
 
   return [newShift, skillString];
-}
-
-/**
- * Displays an error message if the sheet is locked
- * @returns {boolean} True if the sheet is locked, and false otherwise
- */
-export function checkIsLocked(actor) {
-  if (actor.system.isLocked) {
-    ui.notifications.error(game.i18n.localize('E20.ActorLockError'));
-    return true;
-  }
-
-  return false;
 }
 
 /**
@@ -452,19 +423,4 @@ export async function setFocusValues(focus, actor, newLevel=null, previousLevel=
     // Level down
     await deleteAttachmentsForItem(focus, actor, previousLevel);
   }
-}
-
-/**
- * Prepare the number of actions available for the given actor
- * @param {Actor} actor The actor to get actions for
- * @return {Object} Action types mapped to an action count
- */
-export function getNumActions(actor) {
-  const speed = actor.system.essences.speed;
-
-  return {
-    free: Math.max(0, speed - 2),
-    movement: speed > 0 ? 1 : 0,
-    standard: speed > 1 ? 1 : 0,
-  };
 }

--- a/module/sheet-handlers/drop-handler.mjs
+++ b/module/sheet-handlers/drop-handler.mjs
@@ -1,7 +1,5 @@
-import {
-  checkIsLocked,
-  parseId,
-} from "../helpers/utils.mjs";
+import { checkIsLocked } from "../helpers/actor.mjs";
+import { parseId } from "../helpers/utils.mjs";
 import { alterationUpdate } from "./alteration-handler.mjs";
 import { attachItem, gearDrop } from "./attachment-handler.mjs";
 import { influenceUpdate, originUpdate } from "./background-handler.mjs";

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -1,5 +1,6 @@
 import { rememberOptions } from "../helpers/dialog.mjs";
-import { getItemsOfType, resizeTokens } from "../helpers/utils.mjs";
+import { resizeTokens } from "../helpers/actor.mjs";
+import { getItemsOfType } from "../helpers/utils.mjs";
 
 /**
  * Handles AltModes being deleted

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -1,10 +1,6 @@
 import { onManageActiveEffect, prepareActiveEffectCategories } from "../helpers/effects.mjs";
-import {
-  deleteAttachmentsForItem,
-  checkIsLocked,
-  getNumActions,
-  setEntryAndAddItem,
-} from "../helpers/utils.mjs";
+import { checkIsLocked, getNumActions } from "../helpers/actor.mjs";
+import { deleteAttachmentsForItem, setEntryAndAddItem } from "../helpers/utils.mjs";
 import { onLevelChange } from "../sheet-handlers/advancement-handler.mjs";
 import { onAlterationDelete } from "../sheet-handlers/alteration-handler.mjs";
 import { onOriginDelete } from "../sheet-handlers/background-handler.mjs";


### PR DESCRIPTION
Addresses https://github.com/WookieeMatt/Essence20/issues/617

##### In this PR
- Moving actor-related methods out of `utils.mjs`
- These relate to the actor sheet lock, num action calculation, and token resizing

##### Testing
- No logic has changed, so seeing no import errors in the console should be sufficient