### PR TITLE
Moving attachment methods out of utils

### DIFF
--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -28,8 +28,8 @@ export function getItemsOfType(type, items) {
 }
 
 /**
-* Handles creating a unique 5 digit Id for an item
-* @param {Array} items The items keyed by IDs
+* Handles creating a unique 5 digit Id for an Item
+* @param {Item[]} items The Items keyed by IDs
 */
 export function createId(items) {
   let id = "";

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -28,39 +28,31 @@ export function getItemsOfType(type, items) {
 }
 
 /**
- * Creates copies of Items for given IDs
- * @param {Object[]} items The item entries to copy
- * @param {Actor} owner The items' owner
- * @param {String} type The type of items to drop
- * @param {Item} parentItem The items' parent item
- * @param {Number} lastProcessedLevel The flag for the last time the actor changed level
- */
-export async function createItemCopies(items, owner, type, parentItem, lastProcessedLevel=null) {
-  for (const [key, item] of Object.entries(items)) {
-    if (item.type == type) {
-      const createNewItem =
-        !["role", "focus"].includes(parentItem.type)
-        || !item.level || (item.level <= owner.system.level && (!lastProcessedLevel || (item.level > lastProcessedLevel)));
+* Handles creating a unique 5 digit Id for an item
+* @param {Array} items The items keyed by IDs
+*/
+export function createId(items) {
+  let id = "";
+  do {
+    id = _randomId(5);
+  } while (items[id]);
 
-      if (createNewItem) {
-        const itemToCreate = await fromUuid(item.uuid);
-        const newItem = await Item.create(itemToCreate, { parent: owner });
+  return id;
+}
 
-        if (["upgrade", "weaponEffect"].includes(newItem.type) && ["weapon", "armor"].includes(parentItem.type)) {
-          const newKey = await setEntryAndAddItem(newItem, parentItem);
-          newItem.setFlag('essence20', 'collectionId', newKey);
-
-          const deleteString = `system.items.-=${key}`;
-          await parentItem.update({[deleteString]: null});
-        } else {
-          newItem.setFlag('essence20', 'collectionId', key);
-        }
-
-        newItem.setFlag('core', 'sourceId', item.uuid);
-        newItem.setFlag('essence20', 'parentId', parentItem._id);
-      }
-    }
-  }
+/**
+* Generate a random ID
+* Generate random number and convert it to base 36 and remove the '0.' at the beginning
+* As long as the string is not long enough, generate more random data into it
+* Use substring in case we generated a string with a length higher than the requested length
+* @param length    The length of the random ID to generate
+* @return          Return a string containing random letters and numbers
+*/
+export function _randomId(length) {
+  const multiplier = Math.pow(10, length);
+  return Math.floor((1 + Math.random()) * multiplier)
+    .toString(16)
+    .substring(1);
 }
 
 /**
@@ -91,187 +83,4 @@ export function getShiftedSkill(skill, shift, actor) {
   }
 
   return [newShift, skillString];
-}
-
-/**
-* Generate a random ID
-* Generate random number and convert it to base 36 and remove the '0.' at the beginning
-* As long as the string is not long enough, generate more random data into it
-* Use substring in case we generated a string with a length higher than the requested length
-* @param length    The length of the random ID to generate
-* @return          Return a string containing random letters and numbers
-*/
-export function randomId(length) {
-  const multiplier = Math.pow(10, length);
-  return Math.floor((1 + Math.random()) * multiplier)
-    .toString(16)
-    .substring(1);
-}
-
-/**
-* Handles creating a unique 5 digit Id for an item
-* @param {Array} items The items keyed by IDs
-*/
-export function createId(items) {
-  let id = "";
-  do {
-    id = randomId(5);
-  } while (items[id]);
-
-  return id;
-}
-
-/**
-* Handles validating an item being dropped is unique
-* @param {Item} droppedItem The item that was dropped
-* @param {Item} targetItem The item that was dropped on to.
-* @param {Object} entry The entry for the item being added
-* @return {String} The key generated for the dropped item
-*/
-export async function addItemIfUnique(droppedItem, targetItem, entry) {
-  const items = targetItem.system.items;
-  if (items) {
-    for (const [, item] of Object.entries(items)) {
-      if (droppedItem.type == 'rolePoints' && item.type == 'rolePoints') {
-        ui.notifications.error(game.i18n.localize('E20.RolePointsMultipleError'));
-        return;
-      }
-
-      if (item.uuid === droppedItem.uuid) {
-        return;
-      }
-    }
-  }
-
-  const pathPrefix = "system.items";
-  const key = createId(items);
-
-  await targetItem.update({
-    [`${pathPrefix}.${key}`]: entry,
-  });
-
-  return key;
-}
-
-/**
-* Handles setting the value of the Entry variable and calling the creating function.
-* @param {Item} droppedItem The item that is being attached on the item
-* @param {Item} atttachedItem The item that we are attaching to.
-* @return {String} The key generated for the dropped item
-*/
-export async function setEntryAndAddItem(droppedItem, targetItem) {
-  const entry = {
-    uuid: droppedItem.uuid,
-    img: droppedItem.img,
-    name: droppedItem.name,
-    type: droppedItem.type,
-  };
-
-  switch (targetItem.type) {
-  case "armor":
-    if (droppedItem.type == "upgrade" && droppedItem.system.type == "armor") {
-      entry['armorBonus'] = droppedItem.system.armorBonus;
-      entry['availability'] = droppedItem.system.availability;
-      entry['benefit'] = droppedItem.system.benefit;
-      entry['description'] = droppedItem.system.description;
-      entry['prerequisite'] = droppedItem.system.prerequisite;
-      entry['source'] = droppedItem.system.source;
-      entry['subtype'] = droppedItem.system.type;
-      entry['traits'] = droppedItem.system.traits;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    }
-
-    break;
-  case "focus":
-    if (droppedItem.type == "perk") {
-      entry ['subtype'] = droppedItem.system.type;
-      entry ['level'] = 1;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    } else if (droppedItem.type == "role") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    }
-
-    break;
-  case "influence":
-    if (droppedItem.type == "perk") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    } else if (droppedItem.type == "hangUp") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    }
-
-    break;
-  case "origin":
-    if (droppedItem.type == "perk") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    }
-
-    break;
-  case "role":
-    if (droppedItem.type == "perk") {
-      entry ['subtype'] = droppedItem.system.type;
-      entry ['level'] = 1;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    } else if (droppedItem.type == "rolePoints") {
-      entry['bonus'] = droppedItem.system.bonus;
-      entry['isActivatable'] = droppedItem.system.isActivatable;
-      entry['isActive'] = droppedItem.system.isActive;
-      entry['powerCost'] = droppedItem.system.powerCost;
-      entry['resource'] = droppedItem.system.resource;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    }
-
-    break;
-  case "weapon":
-    if (droppedItem.type == "upgrade" && droppedItem.system.type == "weapon") {
-      entry['availability'] = droppedItem.system.availability;
-      entry['benefit'] = droppedItem.system.benefit;
-      entry['description'] = droppedItem.system.description;
-      entry['prerequisite'] = droppedItem.system.prerequisite;
-      entry['source'] = droppedItem.system.source;
-      entry['subtype'] = droppedItem.system.type;
-      entry['traits'] = droppedItem.system.traits;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    } else if (droppedItem.type == "weaponEffect") {
-      entry['classification'] = droppedItem.system.classification;
-      entry['damageValue'] = droppedItem.system.damageValue;
-      entry['damageType'] = droppedItem.system.damageType;
-      entry['numHands'] = droppedItem.system.numHands;
-      entry['numTargets'] = droppedItem.system.numTargets;
-      entry['radius'] = droppedItem.system.radius;
-      entry['range'] = droppedItem.system.range;
-      entry['shiftDown'] = droppedItem.system.shiftDown;
-      entry['traits'] = droppedItem.system.traits;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
-    }
-
-    break;
-  default:
-    break;
-  }
-}
-
-/**
-* Handles deleting items attached to other items
-* @param {Item} item The item that was deleted
-* @param {Actor} actor The actor the parent item is on
-* @param {Value} previousLevel (optional) The value of the last time you leveled up.
-*/
-export function deleteAttachmentsForItem(item, actor, previousLevel=null) {
-  for (const actorItem of actor.items) {
-    const itemSourceId = actor.items.get(actorItem._id).getFlag('core', 'sourceId');
-    const parentId = actor.items.get(actorItem._id).getFlag('essence20', 'parentId');
-    const collectionId = actor.items.get(actorItem._id).getFlag('essence20', 'collectionId');
-
-    for (const [key, attachment] of Object.entries(item.system.items)) {
-      if (itemSourceId) {
-        if (itemSourceId == attachment.uuid && item._id == parentId) {
-          if (!previousLevel || (attachment.level > actor.system.level && attachment.level <= previousLevel)) {
-            actorItem.delete();
-          }
-        }
-      } else if (item._id == parentId && key == collectionId) {
-        actorItem.delete();
-      }
-    }
-  }
 }

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -2,9 +2,9 @@ import { rememberOptions } from "../helpers/dialog.mjs";
 import { createId, getItemsOfType } from "../helpers/utils.mjs";
 
 /**
- * Handles dropping items that have attachments onto an Actor
- * @param {Actor} actor The Actor receiving the item
- * @param {Item} droppedItem The item being dropped
+ * Handles dropping Items that have attachments onto an Actor
+ * @param {Actor} actor The Actor receiving the Item
+ * @param {Item} droppedItem The Item being dropped
  * @param {Function} dropFunc The function to call to complete the drop
  */
 export async function gearDrop(actor, droppedItem, dropFunc) {
@@ -19,11 +19,11 @@ export async function gearDrop(actor, droppedItem, dropFunc) {
 
 /**
  * Creates copies of Items for given IDs
- * @param {Object[]} items The item entries to copy
- * @param {Actor} owner The items' owner
- * @param {String} type The type of items to drop
- * @param {Item} parentItem The items' parent item
- * @param {Number} lastProcessedLevel The flag for the last time the actor changed level
+ * @param {Object[]} items The Item entries to copy
+ * @param {Actor} owner The Items' owner
+ * @param {String} type The type of Items to drop
+ * @param {Item} parentItem The Items' parent Item
+ * @param {Number} lastProcessedLevel The flag for the last time the Actor changed level
  */
 export async function createItemCopies(items, owner, type, parentItem, lastProcessedLevel=null) {
   for (const [key, item] of Object.entries(items)) {
@@ -54,7 +54,7 @@ export async function createItemCopies(items, owner, type, parentItem, lastProce
 }
 
 /**
- * Initiates the process to apply an attachment item to an item on the actor sheet
+ * Initiates the process to apply an attachment Item to an Item on the Actor sheet
  * @param {Actor} actor The Actor receiving the attachment
  * @param {Item} droppedItem The attachment being dropped
  * @param {Function} dropFunc The function to call to complete the drop
@@ -120,7 +120,7 @@ async function _attachSelectedItemOptionHandler(actor, options, dropFunc) {
 }
 
 /**
- * Creates the attachment for the actor and attaches it to the given item
+ * Creates the attachment for the Actor and attaches it to the given Item
  * @param {Item} targetItem The item to attach to
  * @param {Function} dropFunc The function to call to complete the drop
  * @private
@@ -136,9 +136,9 @@ async function _attachItem(targetItem, dropFunc) {
 }
 
 /**
-* Handles setting the value of the Entry variable and calling the creating function.
-* @param {Item} droppedItem The item that is being attached on the item
-* @param {Item} atttachedItem The item that we are attaching to.
+* Handles setting the value of the entry variable and calling the creating function
+* @param {Item} droppedItem The Item that is being attached to the other Item
+* @param {Item} atttachedItem The Item receiving the dropped Item
 * @return {String} The key generated for the dropped item
 */
 export async function setEntryAndAddItem(droppedItem, targetItem) {
@@ -233,11 +233,11 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
 }
 
 /**
-* Handles validating an item being dropped is unique
-* @param {Item} droppedItem The item that was dropped
-* @param {Item} targetItem The item that was dropped on to.
-* @param {Object} entry The entry for the item being added
-* @return {String} The key generated for the dropped item
+* Handles validating an Item being dropped is unique
+* @param {Item} droppedItem The Item that was dropped
+* @param {Item} targetItem The Item that was dropped onto
+* @param {Object} entry The entry for the Item being added
+* @return {String} The key generated for the dropped Item
 */
 export async function addItemIfUnique(droppedItem, targetItem, entry) {
   const items = targetItem.system.items;
@@ -265,10 +265,10 @@ export async function addItemIfUnique(droppedItem, targetItem, entry) {
 }
 
 /**
-* Handles deleting items attached to other items
-* @param {Item} item The item that was deleted
-* @param {Actor} actor The actor the parent item is on
-* @param {Value} previousLevel (optional) The value of the last time you leveled up.
+* Handles deleting Items attached to other items
+* @param {Item} item The Item that was deleted
+* @param {Actor} actor The Actor that owns the parent Item
+* @param {Number} previousLevel (optional) The value of the last time the Actor leveled up
 */
 export function deleteAttachmentsForItem(item, actor, previousLevel=null) {
   for (const actorItem of actor.items) {

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -1,9 +1,5 @@
 import { rememberOptions } from "../helpers/dialog.mjs";
-import {
-  createItemCopies,
-  getItemsOfType,
-  setEntryAndAddItem,
-} from "../helpers/utils.mjs";
+import { createId, getItemsOfType } from "../helpers/utils.mjs";
 
 /**
  * Handles dropping items that have attachments onto an Actor
@@ -17,6 +13,42 @@ export async function gearDrop(actor, droppedItem, dropFunc) {
     await createItemCopies(droppedItem.system.items, actor, "upgrade", newGearList[0]);
     if (droppedItem.type == 'weapon') {
       await createItemCopies(droppedItem.system.items, actor, "weaponEffect", newGearList[0]);
+    }
+  }
+}
+
+/**
+ * Creates copies of Items for given IDs
+ * @param {Object[]} items The item entries to copy
+ * @param {Actor} owner The items' owner
+ * @param {String} type The type of items to drop
+ * @param {Item} parentItem The items' parent item
+ * @param {Number} lastProcessedLevel The flag for the last time the actor changed level
+ */
+export async function createItemCopies(items, owner, type, parentItem, lastProcessedLevel=null) {
+  for (const [key, item] of Object.entries(items)) {
+    if (item.type == type) {
+      const createNewItem =
+        !["role", "focus"].includes(parentItem.type)
+        || !item.level || (item.level <= owner.system.level && (!lastProcessedLevel || (item.level > lastProcessedLevel)));
+
+      if (createNewItem) {
+        const itemToCreate = await fromUuid(item.uuid);
+        const newItem = await Item.create(itemToCreate, { parent: owner });
+
+        if (["upgrade", "weaponEffect"].includes(newItem.type) && ["weapon", "armor"].includes(parentItem.type)) {
+          const newKey = await setEntryAndAddItem(newItem, parentItem);
+          newItem.setFlag('essence20', 'collectionId', newKey);
+
+          const deleteString = `system.items.-=${key}`;
+          await parentItem.update({[deleteString]: null});
+        } else {
+          newItem.setFlag('essence20', 'collectionId', key);
+        }
+
+        newItem.setFlag('core', 'sourceId', item.uuid);
+        newItem.setFlag('essence20', 'parentId', parentItem._id);
+      }
     }
   }
 }
@@ -100,5 +132,160 @@ async function _attachItem(targetItem, dropFunc) {
   if (targetItem) {
     const key = await setEntryAndAddItem(newattachedItem, targetItem);
     newattachedItem.setFlag('essence20', 'collectionId', key);
+  }
+}
+
+/**
+* Handles setting the value of the Entry variable and calling the creating function.
+* @param {Item} droppedItem The item that is being attached on the item
+* @param {Item} atttachedItem The item that we are attaching to.
+* @return {String} The key generated for the dropped item
+*/
+export async function setEntryAndAddItem(droppedItem, targetItem) {
+  const entry = {
+    uuid: droppedItem.uuid,
+    img: droppedItem.img,
+    name: droppedItem.name,
+    type: droppedItem.type,
+  };
+
+  switch (targetItem.type) {
+  case "armor":
+    if (droppedItem.type == "upgrade" && droppedItem.system.type == "armor") {
+      entry['armorBonus'] = droppedItem.system.armorBonus;
+      entry['availability'] = droppedItem.system.availability;
+      entry['benefit'] = droppedItem.system.benefit;
+      entry['description'] = droppedItem.system.description;
+      entry['prerequisite'] = droppedItem.system.prerequisite;
+      entry['source'] = droppedItem.system.source;
+      entry['subtype'] = droppedItem.system.type;
+      entry['traits'] = droppedItem.system.traits;
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    }
+
+    break;
+  case "focus":
+    if (droppedItem.type == "perk") {
+      entry ['subtype'] = droppedItem.system.type;
+      entry ['level'] = 1;
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    } else if (droppedItem.type == "role") {
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    }
+
+    break;
+  case "influence":
+    if (droppedItem.type == "perk") {
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    } else if (droppedItem.type == "hangUp") {
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    }
+
+    break;
+  case "origin":
+    if (droppedItem.type == "perk") {
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    }
+
+    break;
+  case "role":
+    if (droppedItem.type == "perk") {
+      entry ['subtype'] = droppedItem.system.type;
+      entry ['level'] = 1;
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    } else if (droppedItem.type == "rolePoints") {
+      entry['bonus'] = droppedItem.system.bonus;
+      entry['isActivatable'] = droppedItem.system.isActivatable;
+      entry['isActive'] = droppedItem.system.isActive;
+      entry['powerCost'] = droppedItem.system.powerCost;
+      entry['resource'] = droppedItem.system.resource;
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    }
+
+    break;
+  case "weapon":
+    if (droppedItem.type == "upgrade" && droppedItem.system.type == "weapon") {
+      entry['availability'] = droppedItem.system.availability;
+      entry['benefit'] = droppedItem.system.benefit;
+      entry['description'] = droppedItem.system.description;
+      entry['prerequisite'] = droppedItem.system.prerequisite;
+      entry['source'] = droppedItem.system.source;
+      entry['subtype'] = droppedItem.system.type;
+      entry['traits'] = droppedItem.system.traits;
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    } else if (droppedItem.type == "weaponEffect") {
+      entry['classification'] = droppedItem.system.classification;
+      entry['damageValue'] = droppedItem.system.damageValue;
+      entry['damageType'] = droppedItem.system.damageType;
+      entry['numHands'] = droppedItem.system.numHands;
+      entry['numTargets'] = droppedItem.system.numTargets;
+      entry['radius'] = droppedItem.system.radius;
+      entry['range'] = droppedItem.system.range;
+      entry['shiftDown'] = droppedItem.system.shiftDown;
+      entry['traits'] = droppedItem.system.traits;
+      return await addItemIfUnique(droppedItem, targetItem, entry);
+    }
+
+    break;
+  default:
+    break;
+  }
+}
+
+/**
+* Handles validating an item being dropped is unique
+* @param {Item} droppedItem The item that was dropped
+* @param {Item} targetItem The item that was dropped on to.
+* @param {Object} entry The entry for the item being added
+* @return {String} The key generated for the dropped item
+*/
+export async function addItemIfUnique(droppedItem, targetItem, entry) {
+  const items = targetItem.system.items;
+  if (items) {
+    for (const [, item] of Object.entries(items)) {
+      if (droppedItem.type == 'rolePoints' && item.type == 'rolePoints') {
+        ui.notifications.error(game.i18n.localize('E20.RolePointsMultipleError'));
+        return;
+      }
+
+      if (item.uuid === droppedItem.uuid) {
+        return;
+      }
+    }
+  }
+
+  const pathPrefix = "system.items";
+  const key = createId(items);
+
+  await targetItem.update({
+    [`${pathPrefix}.${key}`]: entry,
+  });
+
+  return key;
+}
+
+/**
+* Handles deleting items attached to other items
+* @param {Item} item The item that was deleted
+* @param {Actor} actor The actor the parent item is on
+* @param {Value} previousLevel (optional) The value of the last time you leveled up.
+*/
+export function deleteAttachmentsForItem(item, actor, previousLevel=null) {
+  for (const actorItem of actor.items) {
+    const itemSourceId = actor.items.get(actorItem._id).getFlag('core', 'sourceId');
+    const parentId = actor.items.get(actorItem._id).getFlag('essence20', 'parentId');
+    const collectionId = actor.items.get(actorItem._id).getFlag('essence20', 'collectionId');
+
+    for (const [key, attachment] of Object.entries(item.system.items)) {
+      if (itemSourceId) {
+        if (itemSourceId == attachment.uuid && item._id == parentId) {
+          if (!previousLevel || (attachment.level > actor.system.level && attachment.level <= previousLevel)) {
+            actorItem.delete();
+          }
+        }
+      } else if (item._id == parentId && key == collectionId) {
+        actorItem.delete();
+      }
+    }
   }
 }

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -160,7 +160,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
       entry['source'] = droppedItem.system.source;
       entry['subtype'] = droppedItem.system.type;
       entry['traits'] = droppedItem.system.traits;
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -168,23 +168,23 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
     if (droppedItem.type == "perk") {
       entry ['subtype'] = droppedItem.system.type;
       entry ['level'] = 1;
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "role") {
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
   case "influence":
     if (droppedItem.type == "perk") {
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "hangUp") {
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
   case "origin":
     if (droppedItem.type == "perk") {
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -192,14 +192,14 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
     if (droppedItem.type == "perk") {
       entry ['subtype'] = droppedItem.system.type;
       entry ['level'] = 1;
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "rolePoints") {
       entry['bonus'] = droppedItem.system.bonus;
       entry['isActivatable'] = droppedItem.system.isActivatable;
       entry['isActive'] = droppedItem.system.isActive;
       entry['powerCost'] = droppedItem.system.powerCost;
       entry['resource'] = droppedItem.system.resource;
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -212,7 +212,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
       entry['source'] = droppedItem.system.source;
       entry['subtype'] = droppedItem.system.type;
       entry['traits'] = droppedItem.system.traits;
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "weaponEffect") {
       entry['classification'] = droppedItem.system.classification;
       entry['damageValue'] = droppedItem.system.damageValue;
@@ -223,7 +223,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
       entry['range'] = droppedItem.system.range;
       entry['shiftDown'] = droppedItem.system.shiftDown;
       entry['traits'] = droppedItem.system.traits;
-      return addItemIfUnique(droppedItem, targetItem, entry);
+      return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -239,7 +239,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
 * @param {Object} entry The entry for the Item being added
 * @return {String} The key generated for the dropped Item
 */
-export async function addItemIfUnique(droppedItem, targetItem, entry) {
+export async function _addItemIfUnique(droppedItem, targetItem, entry) {
   const items = targetItem.system.items;
   if (items) {
     for (const [, item] of Object.entries(items)) {

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -37,7 +37,7 @@ export async function createItemCopies(items, owner, type, parentItem, lastProce
         const newItem = await Item.create(itemToCreate, { parent: owner });
 
         if (["upgrade", "weaponEffect"].includes(newItem.type) && ["weapon", "armor"].includes(parentItem.type)) {
-          const newKey = await setEntryAndAddItem(newItem, parentItem);
+          const newKey = setEntryAndAddItem(newItem, parentItem);
           newItem.setFlag('essence20', 'collectionId', newKey);
 
           const deleteString = `system.items.-=${key}`;
@@ -130,7 +130,7 @@ async function _attachItem(targetItem, dropFunc) {
   const newattachedItem = newattachedItemList[0];
   newattachedItem.setFlag('essence20', 'parentId', targetItem._id);
   if (targetItem) {
-    const key = await setEntryAndAddItem(newattachedItem, targetItem);
+    const key = setEntryAndAddItem(newattachedItem, targetItem);
     newattachedItem.setFlag('essence20', 'collectionId', key);
   }
 }
@@ -160,7 +160,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
       entry['source'] = droppedItem.system.source;
       entry['subtype'] = droppedItem.system.type;
       entry['traits'] = droppedItem.system.traits;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -168,23 +168,23 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
     if (droppedItem.type == "perk") {
       entry ['subtype'] = droppedItem.system.type;
       entry ['level'] = 1;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "role") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
   case "influence":
     if (droppedItem.type == "perk") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "hangUp") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
   case "origin":
     if (droppedItem.type == "perk") {
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -192,14 +192,14 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
     if (droppedItem.type == "perk") {
       entry ['subtype'] = droppedItem.system.type;
       entry ['level'] = 1;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "rolePoints") {
       entry['bonus'] = droppedItem.system.bonus;
       entry['isActivatable'] = droppedItem.system.isActivatable;
       entry['isActive'] = droppedItem.system.isActive;
       entry['powerCost'] = droppedItem.system.powerCost;
       entry['resource'] = droppedItem.system.resource;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;
@@ -212,7 +212,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
       entry['source'] = droppedItem.system.source;
       entry['subtype'] = droppedItem.system.type;
       entry['traits'] = droppedItem.system.traits;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     } else if (droppedItem.type == "weaponEffect") {
       entry['classification'] = droppedItem.system.classification;
       entry['damageValue'] = droppedItem.system.damageValue;
@@ -223,7 +223,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
       entry['range'] = droppedItem.system.range;
       entry['shiftDown'] = droppedItem.system.shiftDown;
       entry['traits'] = droppedItem.system.traits;
-      return await addItemIfUnique(droppedItem, targetItem, entry);
+      return addItemIfUnique(droppedItem, targetItem, entry);
     }
 
     break;

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -1,10 +1,6 @@
 import { rememberOptions } from "../helpers/dialog.mjs";
-import {
-  deleteAttachmentsForItem,
-  createItemCopies,
-  getItemsOfType,
-  getShiftedSkill,
-} from "../helpers/utils.mjs";
+import { getItemsOfType, getShiftedSkill } from "../helpers/utils.mjs";
+import { createItemCopies, deleteAttachmentsForItem } from "./attachment-handler.mjs";
 
 /**
  * Handle the dropping of an influence on to a character

--- a/module/sheet-handlers/listener-item-handler.mjs
+++ b/module/sheet-handlers/listener-item-handler.mjs
@@ -1,13 +1,10 @@
 import { checkIsLocked } from "../helpers/actor.mjs";
-import {
-  deleteAttachmentsForItem,
-  setEntryAndAddItem,
-} from "../helpers/utils.mjs";
 import { onAlterationDelete } from "./alteration-handler.mjs";
+import { deleteAttachmentsForItem, setEntryAndAddItem } from "./attachment-handler.mjs";
 import { onOriginDelete } from "./background-handler.mjs";
+import { onPerkDelete } from "./perk-handler.mjs";
 import { onFocusDelete, onRoleDelete } from "./role-handler.mjs";
 import { onAltModeDelete } from "./transformer-handler.mjs";
-import { onPerkDelete } from "./perk-handler.mjs";
 
 /**
  * Handle creating a new Owned Item for the actor using initial data defined in the HTML dataset

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -1,9 +1,6 @@
 import { rememberOptions, rememberSelect } from "../helpers/dialog.mjs";
-import {
-  createItemCopies,
-  deleteAttachmentsForItem,
-  getItemsOfType,
-} from "../helpers/utils.mjs";
+import { getItemsOfType } from "../helpers/utils.mjs";
+import { createItemCopies, deleteAttachmentsForItem } from "./attachment-handler.mjs";
 
 /**
  * Handles setting the values and Items for an Actor's Role

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -8,7 +8,7 @@ import { getItemsOfType } from "../helpers/utils.mjs";
  * @param {AltMode} altMode The deleted Alt Mode.
  */
 export async function onAltModeDelete(actorSheet, altMode) {
-  const altModes = getItemsOfType("altMode", _actor.items);
+  const altModes = getItemsOfType("altMode", actorSheet.actor.items);
   if (altModes.length > 1) {
     if (altMode._id == actorSheet.actor.system.altModeId) {
       _transformBotMode(actorSheet);

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -1,6 +1,6 @@
 import { onManageActiveEffect, prepareActiveEffectCategories } from "../helpers/effects.mjs";
 import { onManageSelectTrait } from "../helpers/traits.mjs";
-import { setEntryAndAddItem } from "../helpers/utils.mjs";
+import { setEntryAndAddItem } from "../sheet-handlers/attachment-handler.mjs";
 
 /**
  * Extend the basic ItemSheet with some very simple modifications


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/617

##### In this PR
- Moving attachment-related methods out of utils and into attachment-handler
- Includes createItemCopies, setEntryAndAddItem, addItemIfUnique, deleteAttachmentsForItem
- Cleaning up comments
- Removing awaits not needed for setEntryAndAddItem and addItemIfUnique since they don't return promises
- Fixing actor access in onAltModeDelete

##### Testing
- No import errors
- Creating, deleting, and dropping attachments onto actors works as normal
- Delete an alt-mode on a transformer