### PR TITLE
Fixing inline editing for child items

### DIFF
--- a/module/sheet-handlers/listener-item-handler.mjs
+++ b/module/sheet-handlers/listener-item-handler.mjs
@@ -214,7 +214,7 @@ export async function onInlineEdit(event, actor) {
     item = await fromUuid(itemUuid);
 
     const parentItem = actor.items.get(parentId);
-    const parentField = dataset.parentField;
+    const parentField = element.dataset.parentField;
     await parentItem.update({ [parentField]: newValue });
   } else {
     item = actor.items.get(itemId);


### PR DESCRIPTION
##### In this PR
- Fixing inline editing for child items because we were accessing the wrong dataset to access parentField

##### Testing
- Inline editing should work for child items as expected
