### PR TITLE
Adding totalBonuses to armor model

### DIFF
--- a/module/data/item/armor.mjs
+++ b/module/data/item/armor.mjs
@@ -23,6 +23,8 @@ export class ArmorItemData extends foundry.abstract.TypeDataModel {
       classification: makeStrWithChoices(Object.keys(E20.armorClassifications), 'light'),
       equipped: makeBool(false),
       traits: makeStrArrayWithChoices(Object.keys(E20.armorTraits)),
+      totalBonusEvasion: makeInt(0),
+      totalBonusToughness: makeInt(0),
       upgradeTraits: makeStrArrayWithChoices(Object.keys(E20.armorTraits)),
     };
   }


### PR DESCRIPTION
##### In this PR
- Adding totalBonusEvasion and totalBonusToughness to armor model to fix errors

##### Testing
- No more errors when opening an actor sheet that has armor
