### PR TITLE
Fixes for role skill die in WE dropdown

### DIFF
--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -119,6 +119,7 @@ export const common = () => ({
   }),
   size: makeStrWithChoices(Object.keys(E20.actorSizes), 'common'),
   skills: new fields.SchemaField({
+    roleSkillDie: makeSkillFields(),
     acrobatics: makeSkillFields(),
     alertness: makeSkillFields(),
     animalHandling: makeSkillFields(),
@@ -134,7 +135,6 @@ export const common = () => ({
     performance: makeSkillFields(),
     persuasion: makeSkillFields(),
     science: makeSkillFields(),
-    roleSkillDie: makeSkillFields(),
     spellcasting: makeSkillFields(),
     streetwise: makeSkillFields(),
     survival: makeSkillFields(),

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -11,7 +11,7 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
     return {
       ...item(),
       classification: new fields.SchemaField({
-        skill: makeStrWithChoices(Object.keys(E20.skills), 'athletics'),
+        skill: makeStrWithChoices([...Object.keys(E20.skills), 'roleSkillDie'], 'athletics'),
         style: makeStrWithChoices(Object.keys(E20.weaponStyles), 'melee'),
       }),
       damageType: makeStrWithChoices(Object.keys(E20.damageTypes), 'blunt'),

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -119,8 +119,8 @@ export class Dice {
     switch(item?.type) {
     case 'weaponEffect':
       const roleList = getItemsOfType('role', actor.items);
-      const role = roleList.length ? roleList[0] : null;
-      label = this._getWeaponRollLabel(dataset, skillRollOptions, item, role);
+      const roleSkillDieName = roleList.length ? roleList[0].system.skillDie.name : null;
+      label = this._getWeaponRollLabel(dataset, skillRollOptions, item, roleSkillDieName);
       break;
     case 'spell':
       label = this._getSpellRollLabel(skillRollOptions, item);
@@ -214,12 +214,13 @@ export class Dice {
    * @param {Event.currentTarget.element.dataset} dataset   The dataset of the click event.
    * @param {Object} skillRollOptions   The result of getSkillRollOptions().
    * @param {Item} weaponEffect   The weapon effect being used.
+   * @param {String} roleSkillDieName The name of the Role skill die
    * @returns {String}   The resultant roll label.
    * @private
    */
-  _getWeaponRollLabel(dataset, skillRollOptions, weaponEffect, role) {
+  _getWeaponRollLabel(dataset, skillRollOptions, weaponEffect, roleSkillDieName=null) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = this._localize(E20.skills[rolledSkill]) || role.system.skillDie.name;
+    const rolledSkillStr = this._localize(E20.skills[rolledSkill]) || roleSkillDieName;
     const attackRollStr = this._localize('E20.RollTypeAttack');
     const effectStr = this._localize('E20.WeaponEffect');
     const damageType = this._localize(E20.damageTypes[weaponEffect.system.damageType]);

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -115,11 +115,15 @@ export class Dice {
 
     const initialShift = dataset.shift || actorSkillData.shift;
     let label = '';
+    let roleSkillDieName = '';
 
     switch(item?.type) {
     case 'weaponEffect':
-      const roleList = getItemsOfType('role', actor.items);
-      const roleSkillDieName = roleList.length ? roleList[0].system.skillDie.name : null;
+      {
+        const roleList = getItemsOfType('role', actor.items);
+        roleSkillDieName = roleList.length ? roleList[0].system.skillDie.name : null;
+      }
+      
       label = this._getWeaponRollLabel(dataset, skillRollOptions, item, roleSkillDieName);
       break;
     case 'spell':

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -118,7 +118,9 @@ export class Dice {
 
     switch(item?.type) {
     case 'weaponEffect':
-      label = this._getWeaponRollLabel(dataset, skillRollOptions, item);
+      const roleList = getItemsOfType('role', actor.items);
+      const role = roleList.length ? roleList[0] : null;
+      label = this._getWeaponRollLabel(dataset, skillRollOptions, item, role);
       break;
     case 'spell':
       label = this._getSpellRollLabel(skillRollOptions, item);
@@ -215,9 +217,9 @@ export class Dice {
    * @returns {String}   The resultant roll label.
    * @private
    */
-  _getWeaponRollLabel(dataset, skillRollOptions, weaponEffect) {
+  _getWeaponRollLabel(dataset, skillRollOptions, weaponEffect, role) {
     const rolledSkill = dataset.skill;
-    const rolledSkillStr = this._localize(E20.skills[rolledSkill]);
+    const rolledSkillStr = this._localize(E20.skills[rolledSkill]) || role.system.skillDie.name;
     const attackRollStr = this._localize('E20.RollTypeAttack');
     const effectStr = this._localize('E20.WeaponEffect');
     const damageType = this._localize(E20.damageTypes[weaponEffect.system.damageType]);

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -490,6 +490,22 @@ describe("_getWeaponRollLabel", () => {
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
+
+  test("weapon roll with role skill die", () => {
+    const dataset = {
+      skill: 'roleSkillDie',
+    };
+    const skillRollOptions = {
+      edge: false,
+      snag: false,
+    };
+
+    const expected =
+      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (Foo Role Skill)<br>" +
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+
+    expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect, 'Foo Role Skill')).toEqual(expected);
+  });
 });
 
 /* _getSpellRollLabel */

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -26,12 +26,16 @@
           </div>
           <select class="inline-edit" data-field="system.classification.skill" data-parent-field="system.items.{{@key}}.classification.skill" name="item.classification.skill">
             {{#select item.classification.skill}}
-            {{#each @root.actor.system.skills}}
-              {{#if this.displayName}}
-                <option value="{{@key}}">{{this.displayName}}</option>
+            {{#each @root.actor.system.skills as |skill skillType|}}
+              {{#ifEquals skillType "roleSkillDie"}}
+                {{#if @root.role.system.skillDie.isUsed}}
+                  <option value="{{skillType}}">{{@root.role.system.skillDie.name}}</option>
+                {{/if}}
+              {{else if skill.displayName}}
+                <option value="{{skillType}}">{{skill.displayName}}</option>
               {{else}}
-                <option value="{{@key}}">{{localize (lookup @root.config.skills @key)}}</option>
-              {{/if}}
+                <option value="{{skillType}}">{{localize (lookup @root.config.skills skillType)}}</option>
+              {{/ifEquals}}
             {{/each}}
             {{/select}}
           </select>


### PR DESCRIPTION
##### In this PR
- Fixes to allow roleSkillDie to appear correctly in the WE skill dropdown at the top of the list

##### Testing
- Role skills should appear at the top of the WE skill dropdown and roll correctly
- Normal skills roll correctly