### PR TITLE
Correcting default value for SPT title

### DIFF
--- a/module/settings.js
+++ b/module/settings.js
@@ -73,7 +73,7 @@ export const registerSettings = function () {
     name: game.i18n.localize("E20.SptOptionPointsName"),
     scope: "world",
     config: true,
-    default: POINTS_NAME_OPTIONS.story,
+    default: "story",
     type: String,
     choices: POINTS_NAME_OPTIONS,
     onChange: debouncedReload,


### PR DESCRIPTION
##### In this PR
- Correcting default value for SPT title so it doesn't show "undefined"

##### Testing
- Create a new world. The SPT title should say "Story" instead of "undefined"
