### PR TITLE
Changing `.data` to `.system` in onItemCreate

### DIFF
--- a/module/sheet-handlers/listener-item-handler.mjs
+++ b/module/sheet-handlers/listener-item-handler.mjs
@@ -29,17 +29,17 @@ export async function onItemCreate(event, actor) {
   const itemData = {
     name: name,
     type: type,
-    data: data,
+    system: data,
   };
 
   // Remove the type from the dataset since it's in the itemData.type prop.
-  delete itemData.data["type"];
+  delete itemData.system["type"];
 
   // Set the parent item type for nested items
   let parentItem = null;
   if (data.parentId) {
     parentItem = actor.items.get(data.parentId);
-    itemData.data.type = parentItem.type;
+    itemData.system.type = parentItem.type;
   }
 
   // Finally, create the item!


### PR DESCRIPTION
##### In this PR
- Fixing a `.data` -> `.system` accessor in onItemCreate, which is no longer supported in v12

##### Testing
- Adding a specialization to an actor should put it on the expected skill, instead of always athletics
