### PR TITLE
Changing resource.startingValue to resource.startingMax

### DIFF
--- a/module/data/item/role-points.mjs
+++ b/module/data/item/role-points.mjs
@@ -40,7 +40,7 @@ export class RolePointsItemData extends foundry.abstract.TypeDataModel {
         level20ValueIsUnlimited: makeBool(false),
         increaseLevels: makeStrArrayWithChoices(Object.keys(E20.actorLevels), []),
         max: makeInt(null),
-        startingValue: makeInt(null),
+        startingMax: makeInt(null),
         value : makeInt(0),
       }),
     };


### PR DESCRIPTION
##### In this PR
- Changing resource.startingValue to resource.startingMax

##### Testing
- Role resources should now have the correct max values
