### PR TITLE
Add AltMode to Origin

### DIFF
--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -106,6 +106,8 @@ export const common = () => ({
   }),
   movementIsReadOnly: makeBool(false),
   movementNotSet: makeBool(false),
+  originEssencesIncrease: makeStr(),
+  originSkillsIncrease: makeStr(),
   powers: new fields.SchemaField({
     personal: new fields.SchemaField({
       regeneration: makeInt(0),

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -67,6 +67,7 @@ export function getShiftedSkill(skill, shift, actor) {
   let skillString = "";
   let currentShift = "";
   let newShift = "";
+
   if (skill == "initiative") {
     skillString = `system.${skill}.shift`;
     currentShift = actor.system[skill].shift;

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -67,7 +67,6 @@ export function getShiftedSkill(skill, shift, actor) {
   let skillString = "";
   let currentShift = "";
   let newShift = "";
-
   if (skill == "initiative") {
     skillString = `system.${skill}.shift`;
     currentShift = actor.system[skill].shift;

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -188,9 +188,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
 
     break;
   case "origin":
-    if (droppedItem.type =="altMode") {
-      return _addItemIfUnique(droppedItem, targetItem, entry);
-    } else if (droppedItem.type == "perk") {
+    if (["altMode", "perk"].includes(droppedItem.type)) {
       return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -35,6 +35,11 @@ export async function createItemCopies(items, owner, type, parentItem, lastProce
       if (createNewItem) {
         const itemToCreate = await fromUuid(item.uuid);
         const newItem = await Item.create(itemToCreate, { parent: owner });
+        if (newItem.type == "altMode") {
+          await owner.update({
+            "system.canTransform": true,
+          });
+        }
 
         if (["upgrade", "weaponEffect"].includes(newItem.type) && ["weapon", "armor"].includes(parentItem.type)) {
           const newKey = await setEntryAndAddItem(newItem, parentItem);
@@ -183,7 +188,10 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
 
     break;
   case "origin":
-    if (droppedItem.type == "perk") {
+    if (droppedItem.type =="altMode") {
+      return _addItemIfUnique(droppedItem, targetItem, entry);
+    }
+    else if (droppedItem.type == "perk") {
       return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -190,8 +190,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
   case "origin":
     if (droppedItem.type =="altMode") {
       return _addItemIfUnique(droppedItem, targetItem, entry);
-    }
-    else if (droppedItem.type == "perk") {
+    } else if (droppedItem.type == "perk") {
       return _addItemIfUnique(droppedItem, targetItem, entry);
     }
 

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -290,13 +290,7 @@ export async function onOriginDelete(actor, origin) {
   const [newShift, skillString] = getShiftedSkill(selectedSkill, -1, actor);
   await deleteAttachmentsForItem(origin, actor);
 
-  let hasAltMode = false;
-  for (const [, item] of Object.entries(actor.items)) {
-    if (item.type == "altMode") {
-      hasAltMode = true;
-      break;
-    }
-  }
+  const hasAltMode = !!getItemsOfType("altMode", actor.items).length;
 
   const essenceString = `system.essences.${essence}`;
 

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -297,6 +297,7 @@ export async function onOriginDelete(actor, origin) {
       break;
     }
   }
+
   const essenceString = `system.essences.${essence}`;
 
   await actor.update({

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -198,6 +198,7 @@ export async function setOriginValues(actor, origin, essence, options, dropFunc)
 
   const newOriginList = await dropFunc();
   await createItemCopies(origin.system.items, actor, "perk", newOriginList[0]);
+  await createItemCopies(origin.system.items, actor, "altMode", newOriginList[0]);
 
   await actor.update({
     [essenceString]: essenceValue,
@@ -289,11 +290,19 @@ export async function onOriginDelete(actor, origin) {
   const [newShift, skillString] = getShiftedSkill(selectedSkill, -1, actor);
   await deleteAttachmentsForItem(origin, actor);
 
+  let hasAltMode = false;
+  for (const [, item] of Object.entries(actor.items)) {
+    if (item.type == "altMode") {
+      hasAltMode = true;
+      break;
+    }
+  }
   const essenceString = `system.essences.${essence}`;
 
   await actor.update({
     [essenceString]: essenceValue,
     [skillString]: newShift,
+    "system.canTransform": hasAltMode,
     "system.health.max": 0,
     "system.health.value": 0,
     "system.movement.aerial.base": 0,

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -98,6 +98,9 @@ export class Essence20ItemSheet extends ItemSheet {
 
     // Delete Role Points from Role
     html.find('.rolePoints-delete').click(this._onObjectDelete.bind(this, ".rolePoints"));
+
+    //Delete AltMode From Origin
+    html.find('.altMode-delete').click(this._onObjectDelete.bind(this, ".altMode"));
   }
 
   /**

--- a/templates/item/sheets/origin.hbs
+++ b/templates/item/sheets/origin.hbs
@@ -90,6 +90,9 @@
 
       {{!-- Origin Perk --}}
       {{> "systems/essence20/templates/item/parts/id-drop.hbs" className="originPerk" label='E20.OriginPerk' items=@root.system.items type='perk'}}
+
+      {{!-- Alt Mode --}}
+      {{> "systems/essence20/templates/item/parts/id-drop.hbs" className="altMode" label='E20.AltMode' items=@root.system.items type='altMode'}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- Created Option to add AltMode to Origin
- When and Origin with an AltMode is added to an actor canTransform is set to true
- deleting the Origin removes the altMode and if no remaining altModes sets canTransform to false
- fixes dataModel issue with Origin Skills and Essences

##### Testing
- Create Origin with and without altMode and drop on various actors 
