### PR TITLE
Fixes for upgrade chips

### DIFF
--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -188,6 +188,13 @@ E20.armorTypes = {
 };
 preLocalize("armorTypes");
 
+// Options for Upgrade traits
+E20.upgradeTraits = {
+  ...E20.armorTraits,
+  ...E20.weaponTraits,
+}
+preLocalize("upgradeTraits");
+
 /************************************************
  * Essences and Skills                          *
  ***********************************************/

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -192,7 +192,7 @@ preLocalize("armorTypes");
 E20.upgradeTraits = {
   ...E20.armorTraits,
   ...E20.weaponTraits,
-}
+};
 preLocalize("upgradeTraits");
 
 /************************************************

--- a/templates/actor/parts/items/upgrade/details.hbs
+++ b/templates/actor/parts/items/upgrade/details.hbs
@@ -1,19 +1,5 @@
-{{#ifEquals system.type "drone"}}
-  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
-  <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.system.prerequisite}}}</div>
-  <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.system.benefit}}}</div>
-  <div class="chip-section">
-    <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.system.type}}</span>
-    <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.system.availability}}</span>
-    {{#if item.system.armorBonus.value}}
-    <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.system.armorBonus.defense}}: {{item.system.armorBonus.value}}</span>
-    {{/if}}
-    {{#each item.system.traits as |trait|}}
-    <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.armorTraits trait}}</span>
-    {{/each}}
-  </div>
-{{else}}
-  {{#if @root.actor.system.canTransform}}
+{{#if item.system }}
+  {{#ifEquals system.type "drone"}}
     <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
     <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.system.prerequisite}}}</div>
     <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.system.benefit}}}</div>
@@ -24,22 +10,84 @@
       <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.system.armorBonus.defense}}: {{item.system.armorBonus.value}}</span>
       {{/if}}
       {{#each item.system.traits as |trait|}}
-      <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.armorTraits trait}}</span>
+      <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.upgradeTraits trait}}</span>
       {{/each}}
     </div>
   {{else}}
+    {{#if @root.actor.system.canTransform}}
+      <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+      <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.system.prerequisite}}}</div>
+      <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.system.benefit}}}</div>
+      <div class="chip-section">
+        <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.system.type}}</span>
+        <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.system.availability}}</span>
+        {{#if item.system.armorBonus.value}}
+        <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.system.armorBonus.defense}}: {{item.system.armorBonus.value}}</span>
+        {{/if}}
+        {{#each item.system.traits as |trait|}}
+        <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.upgradeTraits trait}}</span>
+        {{/each}}
+      </div>
+    {{else}}
+      <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
+      <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.system.prerequisite}}}</div>
+      <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.system.benefit}}}</div>
+      <div class="chip-section">
+        <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.system.type}}</span>
+        <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.system.availability}}</span>
+        {{#if item.system.armorBonus.value}}
+        <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.system.armorBonus.defense}}: {{item.system.armorBonus.value}}</span>
+        {{/if}}
+        {{#each item.system.traits as |trait|}}
+        <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.upgradeTraits trait}}</span>
+        {{/each}}
+      </div>
+    {{/if}}
+  {{/ifEquals}}
+{{else}}
+  {{#ifEquals system.type "drone"}}
     <div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
     <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.prerequisite}}}</div>
     <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.benefit}}}</div>
     <div class="chip-section">
-      <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.subtype}}</span>
+      <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.type}}</span>
       <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.availability}}</span>
       {{#if item.armorBonus.value}}
       <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.armorBonus.defense}}: {{item.armorBonus.value}}</span>
       {{/if}}
       {{#each item.traits as |trait|}}
-      <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.armorTraits trait}}</span>
+      <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.upgradeTraits trait}}</span>
       {{/each}}
     </div>
-  {{/if}}
-{{/ifEquals}}
+  {{else}}
+    {{#if @root.actor.system.canTransform}}
+      <div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
+      <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.prerequisite}}}</div>
+      <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.benefit}}}</div>
+      <div class="chip-section">
+        <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.type}}</span>
+        <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.availability}}</span>
+        {{#if item.armorBonus.value}}
+        <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.armorBonus.defense}}: {{item.armorBonus.value}}</span>
+        {{/if}}
+        {{#each item.traits as |trait|}}
+        <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.upgradeTraits trait}}</span>
+        {{/each}}
+      </div>
+    {{else}}
+      <div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
+      <div>{{localize 'E20.UpgradePrerequisite'}}: {{{item.prerequisite}}}</div>
+      <div>{{localize 'E20.UpgradeBenefit'}}: {{{item.benefit}}}</div>
+      <div class="chip-section">
+        <span class="chip" name="chip.upgrade.type">{{localize 'E20.UpgradeType'}}: {{lookup @root.config.upgradeTypes item.subtype}}</span>
+        <span class="chip" name="chip.upgrade.availability">{{localize 'E20.UpgradeAvailability'}}: {{lookup @root.config.availabilities item.availability}}</span>
+        {{#if item.armorBonus.value}}
+        <span class="chip" name="chip.upgrade.armorBonus">{{lookup @root.config.defenses item.armorBonus.defense}}: {{item.armorBonus.value}}</span>
+        {{/if}}
+        {{#each item.traits as |trait|}}
+        <span class="chip" name="chip.upgrade.trait.{{trait}}">{{lookup @root.config.upgradeTraits trait}}</span>
+        {{/each}}
+      </div>
+    {{/if}}
+  {{/ifEquals}}
+{{/if}}

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -1,6 +1,11 @@
+{{#if item.system }}
 <div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
 <div class="chip-section">
-   <span class="chip" name="chip.weapon.classification">{{lookup @root.config.skills item.system.classification.skill}} {{lookup @root.config.weaponSizes parentItem.system.classification.size}} {{lookup @root.config.weaponStyles item.system.classification.style}}</span>
+  <span class="chip" name="chip.weapon.classification">
+    {{lookup @root.config.skills item.system.classification.skill}}
+    {{lookup @root.config.weaponSizes parentItem.system.classification.size}}
+    {{lookup @root.config.weaponStyles item.system.classification.style}}
+  </span>
   <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.system.numHands}}</span>
   <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.system.numTargets}}</span>
   {{#if item.system.damageValue}}
@@ -11,3 +16,22 @@
   <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.system.shiftDown}}</span>
   {{/if}}
 </div>
+{{else}}
+<div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
+<div class="chip-section">
+  <span class="chip" name="chip.weapon.classification">
+    {{lookup @root.config.skills item.classification.skill}}
+    {{lookup @root.config.weaponSizes parentItem.system.classification.size}}
+    {{lookup @root.config.weaponStyles item.classification.style}}
+  </span>
+  <span class="chip" name="chip.weapon.numHands">{{localize 'E20.WeaponHands'}}: {{item.numHands}}</span>
+  <span class="chip" name="chip.weapon.numTargets">{{localize 'E20.WeaponTargets'}}: {{item.numTargets}}</span>
+  {{#if item.damageValue}}
+  <span class="chip" name="chip.weapon.damageValue">{{localize 'E20.Damage'}}: {{item.damageValue}}</span>
+  {{/if}}
+  <span class="chip" name="chip.weapon.damageType">{{localize 'E20.DamageType'}}: {{localize (lookup @root.config.damageTypes item.damageType)}}</span>
+  {{#if item.shiftDown}}
+  <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.shiftDown}}</span>
+  {{/if}}
+</div>
+{{/if}}


### PR DESCRIPTION
##### In this PR
- Fixes for upgrade chips in both actor sheet and chat
- The context for the actor sheet is the weapon or armor child item, while the chat logic has the full item, so the templates checks for `{{item.system}}` to determine if `item.blah` or `item.system.blah` should be used
- Creating a combined `E20.upgradeTraits` that contains armor + upgrade traits. Previously only armor traits worked.

##### Testing
- Weapon, armor, drone, and transformer upgrades should have correctly populated chips on actor sheets and in chat
