### PR TITLE
Fixes for wealth and initiative container widths

### DIFF
--- a/templates/actor/parts/misc/common.hbs
+++ b/templates/actor/parts/misc/common.hbs
@@ -3,7 +3,7 @@
   {{> "systems/essence20/templates/actor/parts/misc/morph-transform.hbs"}}
 
   {{!-- Initiative --}}
-  <div class="stats-container flexrow flex-group-center" style="border-color: {{system.color}};">
+  <div class="stats-container flexrow flex-group-center" style="min-width: fit-content; border-color: {{system.color}};">
     {{> "systems/essence20/templates/actor/parts/misc/initiative.hbs"}}
   </div>
 

--- a/templates/actor/parts/misc/wealth-die.hbs
+++ b/templates/actor/parts/misc/wealth-die.hbs
@@ -1,4 +1,4 @@
-<div class="stats-container flexrow flex-group-center" style="border-color: {{system.color}};">
+<div class="stats-container flexrow flex-group-center" style="min-width: fit-content; border-color: {{system.color}};">
   <div class="flexcol flex-group-center">
     <label>{{localize 'E20.ActorWealth'}}</label>
     <div class="initiative-dropdown flex-group-center">


### PR DESCRIPTION
##### In this PR
- Fixing wealth and initiative container widths so they don't get horiz scroll bars. This happened on transformer sheets because of the long "Transform" button string.

##### Testing
- Open a transformer sheet. Wealth and initiative containers should no longer have horiz scroll bars.
- Other sheets should still look as normal
