### PR TITLE
Creating migration to fix focus essence bug

### DIFF
--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -45,35 +45,21 @@ export const character = () => ({
 
 export function migrateCharacterData(source) {
   if (source.essences) {
-    if (typeof source.essences.strength == 'number') {
-      const strength = source.essences.strength;
-      const speed = source.essences.speed;
-      const smarts = source.essences.smarts;
-      const social = source.essences.social;
-      source.essences.strength = null;
-      source.essences.speed = null;
-      source.essences.smarts = null;
-      source.essences.social = null;
-      source.essences.strength = makeEssenceFields(),
-      source.essences.speed = makeEssenceFields(),
-      source.essences.smarts = makeEssenceFields(),
-      source.essences.social = makeEssenceFields(),
-
-      source.essences.strength.max = strength;
-      source.essences.strength.value = strength;
-      source.essences.speed.max = speed;
-      source.essences.speed.value = speed;
-      source.essences.smarts.max = smarts;
-      source.essences.smarts.value = smarts;
-      source.essences.social.max = social;
-      source.essences.social.value = social;
+    for (const [essence, value] of Object.entries(source.essences)) {
+      if (typeof value == 'number') {
+        source.essences[essence] = null;
+        source.essences[essence] = makeEssenceFields(),
+        source.essences[essence].max = value;
+        source.essences[essence].value = value;
+      }
     }
+
 
     // Fixing Essence bug introduced by Focus update
     for (const [essence, value] of Object.entries(source.essences)) {
-      if (typeof value.max == 'string') {
-        source.essences[essence].max = 0;
-        source.essences[essence].value = 0;
+      if (value?.max?.max) {
+        source.essences[essence].max = value.max.max;
+        source.essences[essence].value = value.max.max;
       }
     }
   }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -69,11 +69,10 @@ export function migrateCharacterData(source) {
       source.essences.social.value = social;
     }
 
-    // Fixing Essence bug introduced by Focus update
     for (const [essence, value] of Object.entries(source.essences)) {
-      if (typeof value.max == 'string') {
-        source.essences[essence].max = 0;
-        source.essences[essence].value = 0;
+      if (value?.max?.max) {
+        source.essences[essence].max = value.max.max;
+        source.essences[essence].value = value.max.max;
       }
     }
   }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -69,10 +69,11 @@ export function migrateCharacterData(source) {
       source.essences.social.value = social;
     }
 
+    // Fixing Essence bug introduced by Focus update
     for (const [essence, value] of Object.entries(source.essences)) {
-      if (value?.max?.max) {
-        source.essences[essence].max = value.max.max;
-        source.essences[essence].value = value.max.max;
+      if (typeof value.max == 'string') {
+        source.essences[essence].max = 0;
+        source.essences[essence].value = 0;
       }
     }
   }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -46,17 +46,14 @@ export const character = () => ({
 export function migrateCharacterData(source) {
   if (source.essences) {
     for (const [essence, value] of Object.entries(source.essences)) {
-      if (typeof value == 'number') {
+      if (typeof value == 'number') { // Standard Essence damage migration
         source.essences[essence] = { max: value, value: value };
-      }
-    }
-
-
-    // Fixing Essence bug introduced by Focus update
-    for (const [essence, value] of Object.entries(source.essences)) {
-      if (value?.max?.max) {
+      } else if (value?.max?.max) { // Possible edge case
         source.essences[essence].max = value.max.max;
         source.essences[essence].value = value.max.max;
+      } else if (value.required) { // Previous migration may have set it to a SchemaField()
+        source.essences[essence].max = value.max || 0;
+        source.essences[essence].value = value.max || 0;
       }
     }
   }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -48,7 +48,7 @@ export function migrateCharacterData(source) {
     for (const [essence, value] of Object.entries(source.essences)) {
       if (typeof value == 'number') {
         source.essences[essence] = null;
-        source.essences[essence] = makeEssenceFields(),
+        // source.essences[essence] = makeEssenceFields(),
         source.essences[essence].max = value;
         source.essences[essence].value = value;
       }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -47,8 +47,6 @@ export function migrateCharacterData(source) {
   if (source.essences) {
     for (const [essence, value] of Object.entries(source.essences)) {
       if (typeof value == 'number') {
-        //source.essences[essence] = null;
-        //source.essences[essence] = makeEssenceFields(),
         source.essences[essence] = { max: value, value: value };
       }
     }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -68,5 +68,12 @@ export function migrateCharacterData(source) {
       source.essences.social.max = social;
       source.essences.social.value = social;
     }
+
+    for (const [essence, value] of Object.entries(source.essences)) {
+      if (value?.max?.max) {
+        source.essences[essence].max = value.max.max;
+        source.essences[essence].value = value.max.max;
+      }
+    }
   }
 }

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -47,7 +47,7 @@ export function migrateCharacterData(source) {
   if (source.essences) {
     for (const [essence, value] of Object.entries(source.essences)) {
       if (typeof value == 'number') {
-        source.essences[essence] = null;
+        //source.essences[essence] = null;
         // source.essences[essence] = makeEssenceFields(),
         source.essences[essence].max = value;
         source.essences[essence].value = value;

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -48,9 +48,8 @@ export function migrateCharacterData(source) {
     for (const [essence, value] of Object.entries(source.essences)) {
       if (typeof value == 'number') {
         //source.essences[essence] = null;
-        // source.essences[essence] = makeEssenceFields(),
-        source.essences[essence].max = value;
-        source.essences[essence].value = value;
+        //source.essences[essence] = makeEssenceFields(),
+        source.essences[essence] = { max: value, value: value };
       }
     }
 

--- a/module/data/item/focus.mjs
+++ b/module/data/item/focus.mjs
@@ -20,7 +20,7 @@ export class FocusItemData extends foundry.abstract.TypeDataModel {
       essences: makeStrArrayWithChoices(Object.keys(E20.essences)),
       essenceLevels: makeStrArrayWithChoices(Object.keys(E20.actorLevels), initEssenceLevels),
       roleId: makeStr(''),
-      skills: makeStrArrayWithChoices(Object.keys(E20.skills)),
+      skills: makeStrArrayWithChoices(Object.keys(E20.originSkills)),
     };
   }
 }

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -368,14 +368,14 @@ export async function onLevelChange(actor, newLevel) {
 
   const roles = getItemsOfType("role", actor.items);
   if (roles.length == 1) {
-    setRoleValues(roles[0], actor, newLevel, previousLevel);
+    await setRoleValues(roles[0], actor, newLevel, previousLevel);
   } else {
     return;
   }
 
   const focus = getItemsOfType("focus", actor.items);
   if (focus.length == 1) {
-    setFocusValues(focus[0], actor, newLevel, previousLevel);
+    await setFocusValues(focus[0], actor, newLevel, previousLevel);
   }
 
   actor.setFlag('essence20', 'previousLevel', newLevel);


### PR DESCRIPTION
##### In this PR
- Reworking Essence migrations to handle:
  1. Standard Essence damage migration
  2. Possible case where essence.max.max existed
  3. Previous migration may have set it to a SchemaField()
- Adding missing awaits to setRoleValues and setFocusValues, which were causing race conditions

##### Testing
- Checkout 63b8d08eff19c8d1de29a57ea536053d9327648b (this is pre-Essence damage)
- Create a character
- Checkout ecbf803cc0d9ddbdd397011513858faa0b3d72b9 (this is post-Essence damage, but the migration throws in a SchemaField)
- No errors/Essences are fine
- Checkout this branch (this fixes remaining migration issues)
- No errors/Essences are fine
- Setting Essence values and leveling for the actor should work as expected (correct values and no flickering)
