### PR TITLE
Showing skill rank allocations on PC sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -484,6 +484,7 @@
     "SkillMight": "Might",
     "SkillPerformance": "Performance",
     "SkillPersuasion": "Persuasion",
+    "SkillRanksAllocated": "Skill ranks allocated",
     "SkillScience": "Science",
     "SkillSpellcasting": "Spellcasting",
     "SkillStreetwise": "Streetwise",

--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -74,6 +74,12 @@ export const character = () => ({
     }),
   }),
   notes: new fields.HTMLField(),
+  skillRankAllocation: new fields.SchemaField({
+    strength: makeInt(0),
+    speed: makeInt(0),
+    smarts: makeInt(0),
+    social: makeInt(0),
+  }),
 });
 
 export function migrateCharacterData(source) {

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -151,7 +151,6 @@ describe("rollSkill", () => {
 
   test("repeated normal skill roll", async () => {
     rollDialog.getSkillRollOptions.mockReturnValue({
-      canCritD2: false,
       edge: false,
       snag: false,
       shiftUp: 0,

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -151,6 +151,7 @@ describe("rollSkill", () => {
 
   test("repeated normal skill roll", async () => {
     rollDialog.getSkillRollOptions.mockReturnValue({
+      canCritD2: false,
       edge: false,
       snag: false,
       shiftUp: 0,

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -41,6 +41,7 @@ export const preloadHandlebarsTemplates = async function () {
     "systems/essence20/templates/actor/parts/misc/pc-skills.hbs",
     "systems/essence20/templates/actor/parts/misc/pc-tabs.hbs",
     "systems/essence20/templates/actor/parts/misc/power-points.hbs",
+    "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs",
     "systems/essence20/templates/actor/parts/misc/spells.hbs",
     "systems/essence20/templates/actor/parts/misc/stun.hbs",
     "systems/essence20/templates/actor/parts/misc/vehicle-crew.hbs",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -152,6 +152,7 @@ export class Essence20ActorSheet extends ActorSheet {
   /**
    * Prepare skill rank allocation calculations for PCs by adding the number of shifts
    * and Specializations present for each Essence.
+   * @param {Object} context The actor data to prepare.
    */
   _prepareSkillRankAllocation(context) {
     for (const essence in CONFIG.E20.originEssences) {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -163,7 +163,7 @@ export class Essence20ActorSheet extends ActorSheet {
         const skillData = context.system.skills[skill];
         const skillIndex = Math.max(0, CONFIG.E20.skillShiftList.indexOf(skillData.shift));
         const unrankedIndex = CONFIG.E20.skillShiftList.indexOf('d20');
-        numUpshifts += unrankedIndex - skillIndex;
+        numUpshifts += Math.max(0, unrankedIndex - skillIndex);
         numSpecializations += context.specializations[skill] ? context.specializations[skill].length : 0;
       }
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -86,6 +86,11 @@ export class Essence20ActorSheet extends ActorSheet {
     context.accordionStates = this.accordionStates;
     context.canMorphOrTransform = context.actor.system.canMorph || context.actor.system.canTransform;
 
+    // Prepare PC skill rank allocation
+    if (["giJoe", "pony", "powerRanger", "transformer"].includes(this.actor.type)) {
+      this._prepareSkillRankAllocation(context);
+    }
+
     return context;
   }
 
@@ -143,6 +148,28 @@ export class Essence20ActorSheet extends ActorSheet {
 
     context.displayedNpcSkills = displayedNpcSkills;
   }
+
+  /**
+   * Prepare skill rank allocation calculations for PCs by adding the number of shifts
+   * and Specializations present for each Essence.
+   */
+  _prepareSkillRankAllocation(context) {
+    for (const essence in CONFIG.E20.originEssences) {
+      let numUpshifts = 0;
+      let numSpecializations = 0;
+
+      for (const skill of CONFIG.E20.skillsByEssence[essence]) {
+        const skillData = context.system.skills[skill];
+        const skillIndex = Math.max(0, CONFIG.E20.skillShiftList.indexOf(skillData.shift));
+        const unrankedIndex = CONFIG.E20.skillShiftList.indexOf('d20');
+        numUpshifts += unrankedIndex - skillIndex;
+        numSpecializations += context.specializations[skill] ? context.specializations[skill].length : 0;
+      }
+
+      context.system.skillRankAllocation[essence] = numUpshifts + numSpecializations;
+    }
+  }
+
   /**
    * Prepare skill list to be used or weaponEffects on an actor
    * @param {Object} actorData The acor data converted to an object

--- a/templates/actor/parts/misc/pc-skills.hbs
+++ b/templates/actor/parts/misc/pc-skills.hbs
@@ -8,6 +8,7 @@
       <input class="two-digit-input" type="number" name="system.essences.strength.max" value="{{system.essences.strength.max}}" min="0" step="1" />
     </div>
     <div class="essence-header">
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.strength.max skillRankAllocation=system.skillRankAllocation.strength}}
       <span>{{localize 'E20.ActorConditioning'}}</span>
       <input class="one-digit-input" type="number" name="system.conditioning" value="{{system.conditioning}}" min="0" step="1" />
     </div>
@@ -25,6 +26,7 @@
       <input class="two-digit-input" type="number" name="system.essences.speed.max" value="{{system.essences.speed.max}}" min="0" step="1" />
     </div>
     <div class="essence-header">
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.speed.max skillRankAllocation=system.skillRankAllocation.speed}}
       <span>Actions: {{numActions.movement}}M, {{numActions.standard}}S, {{numActions.free}}F</span>
     </div>
     {{#each @root.config.skillsByEssence.speed as |skill|}}
@@ -40,6 +42,9 @@
       /
       <input class="two-digit-input" type="number" name="system.essences.smarts.max" value="{{system.essences.smarts.max}}" min="0" step="1" />
     </div>
+    <div class="essence-header">
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.smarts.max skillRankAllocation=system.skillRankAllocation.smarts}}
+    </div>
    {{#each @root.config.skillsByEssence.smarts as |skill|}}
       {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='smarts' skill=skill fields=(lookup @root.system.skills skill)}}
     {{/each}}
@@ -52,6 +57,9 @@
       <input class="two-digit-input" type="number" name="system.essences.social.value" value="{{system.essences.social.value}}" min="0" step="1" />
       /
       <input class="two-digit-input" type="number" name="system.essences.social.max" value="{{system.essences.social.max}}" min="0" step="1" />
+    </div>
+    <div class="essence-header">
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.social.max skillRankAllocation=system.skillRankAllocation.social}}
     </div>
     {{#each @root.config.skillsByEssence.social as |skill|}}
       {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='social' skill=skill fields=(lookup @root.system.skills skill)}}

--- a/templates/actor/parts/misc/skill-rank-allocation.hbs
+++ b/templates/actor/parts/misc/skill-rank-allocation.hbs
@@ -1,0 +1,8 @@
+<div>
+  <span>{{localize 'E20.SkillRanksAllocated'}}: </span>
+  {{#ifEquals skillRankAllocation essenceMax}}
+  <span>{{skillRankAllocation}}/{{essenceMax}}</span>
+  {{else}}
+  <span style="color: orange;">{{skillRankAllocation}}/{{essenceMax}}</span>
+  {{/ifEquals}}
+</div>


### PR DESCRIPTION
##### In this PR
- Showing skill rank allocations on PC sheets

![image](https://github.com/user-attachments/assets/7d890c15-9646-4b9d-b567-023c1677faae)

##### Testing
- Allocate skill ranks on a PC sheet by selecting upshifts and creating Specializations
- The text should appear orange when the amount allocated != the Essence max
- Make sure the math with multiple upshifts on the same skill is right, and selecting stuff below d20 doesn't detract from the count
