### PR TITLE
Creating skill rank allocation tooltip

### DIFF
--- a/module/data/actor/templates/character.mjs
+++ b/module/data/actor/templates/character.mjs
@@ -17,6 +17,13 @@ function makeDefensesFields(name, essence) {
   });
 }
 
+function makeSkillRankAllocation() {
+  return new fields.SchemaField({
+    value: makeInt(0),
+    string: makeStr(''),
+  });
+}
+
 export function makeEssenceFields() {
   return new fields.SchemaField({
     max: makeInt(3),
@@ -75,10 +82,10 @@ export const character = () => ({
   }),
   notes: new fields.HTMLField(),
   skillRankAllocation: new fields.SchemaField({
-    strength: makeInt(0),
-    speed: makeInt(0),
-    smarts: makeInt(0),
-    social: makeInt(0),
+    strength: makeSkillRankAllocation(),
+    speed: makeSkillRankAllocation(),
+    smarts: makeSkillRankAllocation(),
+    social: makeSkillRankAllocation(),
   }),
 });
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -158,23 +158,43 @@ export class Essence20ActorSheet extends ActorSheet {
     const unrankedIndex = CONFIG.E20.skillShiftList.indexOf('d20');
 
     for (const essence in CONFIG.E20.originEssences) {
-      let numUpshifts = 0;
+      let essenceUpshifts = 0;
       let numSpecializations = 0;
+      let essenceStrings = [];
 
       for (const skill of CONFIG.E20.skillsByEssence[essence]) {
         const skillData = context.system.skills[skill];
         const skillIndex = Math.max(0, CONFIG.E20.skillShiftList.indexOf(skillData.shift));
-        numUpshifts += Math.max(0, unrankedIndex - skillIndex);
-        numSpecializations += context.specializations[skill] ? context.specializations[skill].length : 0;
+
+        const skillUpshifts = Math.max(0, unrankedIndex - skillIndex);
+        if (skillUpshifts) {
+          essenceStrings.push(`${skillUpshifts} ${CONFIG.E20.skills[skill]}`);
+          essenceUpshifts += skillUpshifts;
+        }
+
+        for (const specialization of context.specializations[skill] || []) {
+          numSpecializations += 1;
+          essenceStrings.push(`1 ${specialization.name}`);
+        }
       }
 
-      context.system.skillRankAllocation[essence] = numUpshifts + numSpecializations;
+      context.system.skillRankAllocation[essence].string = essenceStrings.join(' + ');
+      context.system.skillRankAllocation[essence].value = essenceUpshifts + numSpecializations;
     }
 
-    context.system.skillRankAllocation['strength'] += context.system.conditioning;
+    context.system.skillRankAllocation['strength'].string = [
+        context.system.skillRankAllocation['strength'].string,
+        `${context.system.conditioning} ${game.i18n.localize('E20.ActorConditioning')}`,
+      ].filter(Boolean).join(' + ');
+    context.system.skillRankAllocation['strength'].value += context.system.conditioning;
 
     const initiativeIndex = Math.max(0, CONFIG.E20.skillShiftList.indexOf(context.system.initiative.shift));
-    context.system.skillRankAllocation['speed'] += Math.max(0, unrankedIndex - initiativeIndex);
+    const initiativeUpshifts = Math.max(0, unrankedIndex - initiativeIndex);
+    context.system.skillRankAllocation['speed'].string = [
+      context.system.skillRankAllocation['speed'].string,
+      `${initiativeUpshifts} ${game.i18n.localize('E20.ActorInitiative')}`,
+    ].filter(Boolean).join(' + ');
+    context.system.skillRankAllocation['speed'].value += initiativeUpshifts
   }
 
   /**

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -183,9 +183,9 @@ export class Essence20ActorSheet extends ActorSheet {
     }
 
     context.system.skillRankAllocation['strength'].string = [
-        context.system.skillRankAllocation['strength'].string,
-        `${context.system.conditioning} ${game.i18n.localize('E20.ActorConditioning')}`,
-      ].filter(Boolean).join(' + ');
+      context.system.skillRankAllocation['strength'].string,
+      `${context.system.conditioning} ${game.i18n.localize('E20.ActorConditioning')}`,
+    ].filter(Boolean).join(' + ');
     context.system.skillRankAllocation['strength'].value += context.system.conditioning;
 
     const initiativeIndex = Math.max(0, CONFIG.E20.skillShiftList.indexOf(context.system.initiative.shift));
@@ -194,7 +194,7 @@ export class Essence20ActorSheet extends ActorSheet {
       context.system.skillRankAllocation['speed'].string,
       `${initiativeUpshifts} ${game.i18n.localize('E20.ActorInitiative')}`,
     ].filter(Boolean).join(' + ');
-    context.system.skillRankAllocation['speed'].value += initiativeUpshifts
+    context.system.skillRankAllocation['speed'].value += initiativeUpshifts;
   }
 
   /**

--- a/templates/actor/parts/misc/pc-skills.hbs
+++ b/templates/actor/parts/misc/pc-skills.hbs
@@ -8,7 +8,7 @@
       <input class="two-digit-input" type="number" name="system.essences.strength.max" value="{{system.essences.strength.max}}" min="0" step="1" />
     </div>
     <div class="essence-header">
-      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.strength.max skillRankAllocation=system.skillRankAllocation.strength}}
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" skillRankAllocation=system.skillRankAllocation.strength.value skillRankString=system.skillRankAllocation.strength.string}}
       <span>{{localize 'E20.ActorConditioning'}}</span>
       <input class="one-digit-input" type="number" name="system.conditioning" value="{{system.conditioning}}" min="0" step="1" />
     </div>
@@ -26,7 +26,7 @@
       <input class="two-digit-input" type="number" name="system.essences.speed.max" value="{{system.essences.speed.max}}" min="0" step="1" />
     </div>
     <div class="essence-header">
-      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.speed.max skillRankAllocation=system.skillRankAllocation.speed}}
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" skillRankAllocation=system.skillRankAllocation.speed.value skillRankString=system.skillRankAllocation.speed.string}}
       <span>Actions: {{numActions.movement}}M, {{numActions.standard}}S, {{numActions.free}}F</span>
     </div>
     {{#each @root.config.skillsByEssence.speed as |skill|}}
@@ -43,7 +43,7 @@
       <input class="two-digit-input" type="number" name="system.essences.smarts.max" value="{{system.essences.smarts.max}}" min="0" step="1" />
     </div>
     <div class="essence-header">
-      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.smarts.max skillRankAllocation=system.skillRankAllocation.smarts}}
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" skillRankAllocation=system.skillRankAllocation.smarts.value skillRankString=system.skillRankAllocation.smarts.string}}
     </div>
    {{#each @root.config.skillsByEssence.smarts as |skill|}}
       {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='smarts' skill=skill fields=(lookup @root.system.skills skill)}}
@@ -59,7 +59,7 @@
       <input class="two-digit-input" type="number" name="system.essences.social.max" value="{{system.essences.social.max}}" min="0" step="1" />
     </div>
     <div class="essence-header">
-      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" essenceMax=system.essences.social.max skillRankAllocation=system.skillRankAllocation.social}}
+      {{> "systems/essence20/templates/actor/parts/misc/skill-rank-allocation.hbs" skillRankAllocation=system.skillRankAllocation.social.value skillRankString=system.skillRankAllocation.social.string}}
     </div>
     {{#each @root.config.skillsByEssence.social as |skill|}}
       {{> "systems/essence20/templates/actor/parts/misc/essence-skills.hbs" essence='social' skill=skill fields=(lookup @root.system.skills skill)}}

--- a/templates/actor/parts/misc/skill-rank-allocation.hbs
+++ b/templates/actor/parts/misc/skill-rank-allocation.hbs
@@ -1,4 +1,4 @@
-<div>
+<div title="{{skillRankString}}">
   <span>{{localize 'E20.SkillRanksAllocated'}}: </span>
-  <span title="{{skillRankString}}">{{skillRankAllocation}}</span>
+  <span>{{skillRankAllocation}}</span>
 </div>

--- a/templates/actor/parts/misc/skill-rank-allocation.hbs
+++ b/templates/actor/parts/misc/skill-rank-allocation.hbs
@@ -1,8 +1,4 @@
 <div>
   <span>{{localize 'E20.SkillRanksAllocated'}}: </span>
-  {{#ifEquals skillRankAllocation essenceMax}}
-  <span>{{skillRankAllocation}}/{{essenceMax}}</span>
-  {{else}}
-  <span style="color: orange;">{{skillRankAllocation}}/{{essenceMax}}</span>
-  {{/ifEquals}}
+  <span title="{{skillRankString}}">{{skillRankAllocation}}</span>
 </div>


### PR DESCRIPTION
##### In this PR
- Adding a tooltip to the skill rank allocation value that shows the math being done
- To facilitate this, I'm changing the data model to contain a string and value for each essence
- Simplifying what's displayed to just a number, since it's difficult to tell if it's actually correct or not

##### Testing
- Mess with skill ranks, conditioning, and initiative. The value displayed and tooltip should be correct.
