### PR TITLE
Removing Origin container plus button

### DIFF
--- a/templates/actor/parts/items/origin/container.hbs
+++ b/templates/actor/parts/items/origin/container.hbs
@@ -1,4 +1,4 @@
-{{#> "systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.origins title='E20.Origin' dataType='origin'}}
+{{#> "systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.origins title='E20.Origin' dataType='origin' hidePlusButton='true' defaultText='Drop an Origin here'}}
   {{#*inline "expand-details" item}}
     {{> "systems/essence20/templates/actor/parts/items/origin/details.hbs"}}
   {{/inline}}

--- a/templates/actor/parts/misc/collapsible-item-container-header.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container-header.hbs
@@ -3,9 +3,11 @@
 
   <div style="flex-grow: 0; white-space: nowrap;">
     {{localize title}}
+    {{#ifNotEquals hidePlusButton 'true'}}
     <a class="item-create" data-type={{dataType}} data-parent-id="{{parentId}}" title="{{ localize 'E20.ItemControlAdd' }}">
       <i class="fas fa-plus"></i>
     </a>
+    {{/ifNotEquals}}
   </div>
 
   <span class="header-accordion-wrapper">

--- a/templates/actor/parts/misc/collapsible-item-container.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container.hbs
@@ -1,23 +1,29 @@
 <div class="collapsible-item-container" style="border-color: {{system.color}};">
   {{!-- Header with + and v buttons --}}
-  {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-header.hbs" items=items title=title dataType=dataType}}
+  {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-header.hbs" items=items title=title dataType=dataType hidePlusButton=hidePlusButton}}
 
   <ol class="items-list" style="border-color: {{system.color}};">
-    {{#each items as |item|}}
-    <li class="item accordion-wrapper flexcol" data-item-id="{{item._id}}" data-parent-id="{{../parentId}}">
-      {{!-- Item label and buttons --}}
-      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
+    {{#if items.length}}
+      {{#each items as |item|}}
+      <li class="item accordion-wrapper flexcol" data-item-id="{{item._id}}" data-parent-id="{{../parentId}}">
+        {{!-- Item label and buttons --}}
+        {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item}}
 
-      {{!-- Item content --}}
-      {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item}}
+        {{!-- Item content --}}
+        {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item}}
 
-      {{#> subcontainers parentItem=item }}
-      {{!-- Subcontainers here --}}
-      {{/subcontainers}}
-    </li>
+        {{#> subcontainers parentItem=item }}
+        {{!-- Subcontainers here --}}
+        {{/subcontainers}}
+      </li>
 
-    <hr>
+      <hr>
 
-    {{/each}}
+      {{/each}}
+    {{else}}
+      {{#if defaultText}}
+      <li style="text-align: center">{{defaultText}}</li>
+      {{/if}}
+    {{/if}}
   </ol>
 </div>


### PR DESCRIPTION
##### In this PR
- Removing Origin container plus button. When Origins are added this way, the drop logic doesn't trigger and it causes confusion
- Also adding default text to the container when no Origin is present. I'd like to use localized text, but it won't let me add `{{ localize ... }}` within the template thing 🤷 

##### Testing
- Origin container should no longer have a plus button
- A sheet with no Origin should show the help text
- A sheet with an Origin should behave as normal