### PR TITLE
WEs can now be specialized

### DIFF
--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -1,6 +1,6 @@
 import { E20 } from "../../helpers/config.mjs";
 
-import { makeInt, makeStrWithChoices } from "../generic-makers.mjs";
+import { makeBool, makeInt, makeStrWithChoices } from "../generic-makers.mjs";
 
 import { item } from './templates/item.mjs';
 import { itemDescription } from './templates/item-description.mjs';
@@ -18,7 +18,7 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
       }),
       damageType: makeStrWithChoices(Object.keys(E20.damageTypes), 'blunt'),
       damageValue: makeInt(1),
-      shiftDown: makeInt(0),
+      isSpecialized: makeBool(false),
       numHands: makeInt(1),
       numTargets: makeInt(1),
       radius: makeInt(0),
@@ -28,6 +28,7 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
         long: makeInt(null),
         value: makeInt(null),
       }),
+      shiftDown: makeInt(0),
     };
   }
 }

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -65,12 +65,12 @@ export class Dice {
    * @param {Actor} actor   The actor performing the roll.
    * @param {Item} item   The item being used, if any.
    */
-  async rollSkill(rawDataset, actor, item) {
+  async rollSkill(rawDataset, actor, item=None) {
     const dataset = { // Converting strings to usable types
       ...rawDataset,
       shiftDown: parseInt(rawDataset.shiftDown),
       shiftUp: parseInt(rawDataset.shiftUp),
-      isSpecialized: rawDataset.isSpecialized && rawDataset.isSpecialized != 'false' || item.system?.isSpecialized,
+      isSpecialized: rawDataset.isSpecialized && rawDataset.isSpecialized != 'false' || item?.system?.isSpecialized,
       canCritD2: rawDataset.canCritD2 && rawDataset.canCritD2 != 'false',
     };
     const rolledSkill = dataset.skill;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -70,7 +70,7 @@ export class Dice {
       ...rawDataset,
       shiftDown: parseInt(rawDataset.shiftDown),
       shiftUp: parseInt(rawDataset.shiftUp),
-      isSpecialized: rawDataset.isSpecialized && rawDataset.isSpecialized != 'false',
+      isSpecialized: rawDataset.isSpecialized && rawDataset.isSpecialized != 'false' || item.system?.isSpecialized,
       canCritD2: rawDataset.canCritD2 && rawDataset.canCritD2 != 'false',
     };
     const rolledSkill = dataset.skill;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -65,12 +65,14 @@ export class Dice {
    * @param {Actor} actor   The actor performing the roll.
    * @param {Item} item   The item being used, if any.
    */
-  async rollSkill(rawDataset, actor, item=None) {
+  async rollSkill(rawDataset, actor, item=null) {
     const dataset = { // Converting strings to usable types
       ...rawDataset,
       shiftDown: parseInt(rawDataset.shiftDown),
       shiftUp: parseInt(rawDataset.shiftUp),
-      isSpecialized: rawDataset.isSpecialized && rawDataset.isSpecialized != 'false' || item?.system?.isSpecialized,
+      isSpecialized: rawDataset.isSpecialized
+        && rawDataset.isSpecialized != 'false'
+        || !!item?.system?.isSpecialized,
       canCritD2: rawDataset.canCritD2 && rawDataset.canCritD2 != 'false',
     };
     const rolledSkill = dataset.skill;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -97,8 +97,8 @@ export class Dice {
     const initialShift = dataset.shift || actorSkillData.shift;
     const skillDataset = {
       shift: initialShift,
-      edge: actorSkillData.edge || essenceShifts[rolledEssence]?.edge,
-      snag: actorSkillData.snag || essenceShifts[rolledEssence]?.snag,
+      edge: actorSkillData.edge || !!essenceShifts[rolledEssence]?.edge,
+      snag: actorSkillData.snag || !!essenceShifts[rolledEssence]?.snag,
     };
 
     updatedShiftDataset.rolePoints = null;

--- a/templates/item/sheets/weaponEffect.hbs
+++ b/templates/item/sheets/weaponEffect.hbs
@@ -92,6 +92,13 @@
         placeholder="{{localize 'E20.WeaponRangeMin'}}" min="0" step="1" />
       {{/inline}}
       {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
+
+      {{!-- Specialized --}}
+      {{#> "systems/essence20/templates/item/parts/sheet-field.hbs" label='E20.RollIsSpecialized'}}
+      {{#*inline "item-field-inputs"}}
+      <input type="checkbox" name="system.isSpecialized" {{checked system.isSpecialized}} />
+      {{/inline}}
+      {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}
     </div>
   </section>
 </form>


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/743

##### In this PR
- WEs can now be specialized
- Unit test, and fixing another one

##### Testing
- Create a weapon and enable the specialized checkbox
- The specialized checkbox should be enabled in the dialog when you roll it
