### PR TITLE
Fixing specialized skill roll label

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -205,10 +205,9 @@ export class Dice {
     } else if (dataset.skill == 'wealth') {
       rolledSkillStr = this._localize('E20.Wealth');
     } else if (dataset.isSpecialized) {
-      rolledSkillStr = dataset.specializationName;
+      rolledSkillStr = dataset.specializationName || E20.skills[dataset.skill];
     } else {
-      const rolledSkill = dataset.skill;
-      rolledSkillStr = this._localize(E20.skills[rolledSkill]);
+      rolledSkillStr = E20.skills[dataset.skill];
     }
 
     const rollingForStr = this._localize('E20.RollRollingFor');

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -243,6 +243,34 @@ describe("rollSkill", () => {
     expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor Foo Specialization", false);
   });
 
+  test("specialized standard skill roll", async () => {
+    const datasetCopy = {
+      ...dataset,
+      isSpecialized: true,
+    };
+    const rollDialog = createMockRollDialog();
+    rollDialog.getSkillRollOptions.mockReturnValue({
+      canCritD2: false,
+      edge: false,
+      snag: false,
+      shiftUp: 0,
+      shiftDown: 0,
+      timesToRoll: 1,
+    });
+    mockActor.getRollData = jest.fn(() => ({
+      skills: {
+        'athletics': {
+          modifier: '0',
+          shift: 'd20',
+        },
+      },
+    }));
+    dice._rollSkillHelper = jest.fn();
+
+    await dice.rollSkill(datasetCopy, mockActor, null);
+    expect(dice._rollSkillHelper).toHaveBeenCalledWith('d20 + 0', mockActor, "E20.RollRollingFor E20.SkillAthletics", false);
+  });
+
   test("specialized skill roll via weapon effect", async () => {
     const datasetCopy = {
       ...dataset,


### PR DESCRIPTION
##### In this PR
- Fixes a bug where rolling a standard skill as specialized would cause undefined to appear in the roll label
- Removing an unnecessary localization

##### Testing
- Do a specialized roll for a standard skill and the chat label should be correct
