### PR TITLE
Tweaks for item container layout

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -63,7 +63,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -121,7 +121,7 @@
 }
 
 .essence20 .editor-content {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -188,21 +188,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -224,17 +224,17 @@
 }
 
 .dialog .dialog-buttons button.default {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding-top: 6px;
 }
 
@@ -242,7 +242,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -253,7 +253,7 @@
 }
 
 .dialog input {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .app .window-app dialog {
@@ -264,7 +264,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -275,7 +275,7 @@
 }
 
 #module-management .package-list .package-title {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .item-button-container {
@@ -288,39 +288,39 @@
 
 .rollable:hover,
 .rollable:focus {
-  color: rgb(0, 0, 0);
+  color: black;
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-sender {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-metadata {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -578,7 +578,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -677,7 +677,7 @@
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -693,7 +693,7 @@
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -704,11 +704,11 @@
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .tox .tox-editor-container {
-  background: rgb(255, 255, 255);
+  background: white;
 }
 
 .essence20 .tox .tox-edit-area {
@@ -739,7 +739,7 @@
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -848,7 +848,7 @@
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -953,7 +953,7 @@
   list-style: none;
   padding: 6px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   background: none;
@@ -1039,7 +1039,7 @@
 
 .essence20 .pony {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: #212c5f;
   background-size: cover;
@@ -1081,7 +1081,7 @@
 }
 
 .essence20 .item {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   gap: 5px;
 }
 
@@ -1092,7 +1092,7 @@
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1158,7 +1158,7 @@
   -ms-flex-align: center;
   align-items: center;
   padding: 0 2px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .items-list hr {
@@ -1170,7 +1170,7 @@
   display: none;
 }
 
-.essence20 .collapsible-item-subcontainer .items-list hr {
+.essence20 .collapsible-item-container .items-list hr {
   border: 1px solid #4a4848;
 }
 
@@ -1254,7 +1254,7 @@
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding: 6px;
   min-height: none;
 }
@@ -1271,7 +1271,7 @@
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: rgb(163, 163, 163);
+  color: #a3a3a3;
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1325,11 +1325,11 @@ option {
 
 form .notes,
 form .hint {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .span {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .sheet-body {

--- a/sass/items/_item-styling.scss
+++ b/sass/items/_item-styling.scss
@@ -90,7 +90,7 @@
   display: none;
 }
 
-.essence20 .collapsible-item-subcontainer .items-list hr {
+.essence20 .collapsible-item-container .items-list hr {
   border: 1px solid #4a4848;
 }
 

--- a/templates/actor/parts/misc/collapsible-item-container-header.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container-header.hbs
@@ -1,6 +1,8 @@
 <div class="flexrow">
+  {{#unless parentId}}
   <div></div>
-
+  {{/unless}}
+  
   <div style="flex-grow: 0; white-space: nowrap;">
     {{localize title}}
     {{#ifNotEquals hidePlusButton 'true'}}


### PR DESCRIPTION
##### In this PR
- Changing all HR colors to the darker grey so they don't match the outer container color
- Moving `Item +` headers to the left to distinguish them from the main container headers
![image](https://github.com/user-attachments/assets/9849c79f-bd9a-43ad-b62d-08aaef289027)

##### Testing
- Containers should look as above
