### PR TITLE
Fixes for adding a Weapon Effect on a shield and setting parentId on a selectable hangup

### DIFF
--- a/module/apps/choices-prompt.mjs
+++ b/module/apps/choices-prompt.mjs
@@ -73,7 +73,7 @@ export default class ChoicesPrompt extends HandlebarsApplicationMixin(Applicatio
   }
 
   static influence(event, selection) {
-    _hangUpSelect(this._actor, selection.value);
+    _hangUpSelect(this._actor, selection.value, this._dropFunc);
     this.close();
   }
 

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -30,7 +30,7 @@ export async function influenceUpdate(actor, influence, dropFunc) {
     }
 
     if (hangUpIds.length > 1) {
-      _chooseHangUp(actor, influence);
+      _chooseHangUp(actor, influence, newInfluenceList[0]);
     } else {
       await createItemCopies(influence.system.items, actor, "hangUp", newInfluenceList[0]);
     }
@@ -248,9 +248,10 @@ export async function setOriginValues(actor, origin, essence, skill, dropFunc, s
  * Displays a dialog for selecting a Hang Up from an Influence
  * @param {Actor} actor The Actor receiving the Influence
  * @param {Influence} influence The Influence being dropped
+ * @param {Object} newInfluence The new Influence created as part of the drop
  * @private
  */
-async function _chooseHangUp(actor, influence) {
+async function _chooseHangUp(actor, influence, newInfluence) {
   const choices = {};
   let itemArray = [];
   for (const [, item] of Object.entries(influence.system.items)) {
@@ -268,19 +269,21 @@ async function _chooseHangUp(actor, influence) {
 
   const prompt = "E20.SelectHangUp";
   const title = "E20.SelectInfluenceHangUp";
-  new ChoicesPrompt (choices, influence, actor, prompt, title).render(true);
+  new ChoicesPrompt (choices, influence, actor, prompt, title, newInfluence).render(true);
 }
 
 /**
  * Adds the chosen HangUp to the character
  * @param {Actor} actor The Actor receiving the HangUp
  * @param {String} uuid The uuid of the item selected from the choice-prompt application
+ * @param {Object} parentItem The new Influence created as part of the drop
  */
-export async function _hangUpSelect(actor, uuid) {
+export async function _hangUpSelect(actor, uuid, parentItem) {
 
   const itemToCreate = await fromUuid(uuid);
   const newItem = await Item.create(itemToCreate, { parent: actor });
   newItem.setFlag('core', 'sourceId', uuid);
+  newItem.setFlag('essence20', 'parentId', parentItem._id);
 }
 
 /**

--- a/module/sheet-handlers/listener-item-handler.mjs
+++ b/module/sheet-handlers/listener-item-handler.mjs
@@ -55,7 +55,7 @@ export async function onItemCreate(event, actor) {
     // Update parent item's ID list for upgrades and weapon effects
     if (newItem.type == 'upgrade' && ['armor', 'weapon'].includes(parentItem.type)) {
       key = await setEntryAndAddItem(newItem, parentItem);
-    } else if (newItem.type == 'weaponEffect' && parentItem.type == 'weapon') {
+    } else if (newItem.type == 'weaponEffect' && (parentItem.type == 'weapon' || parentItem.type == 'shield')) {
       key = await setEntryAndAddItem(newItem, parentItem);
     }
 

--- a/templates/actor/parts/items/shield/container.hbs
+++ b/templates/actor/parts/items/shield/container.hbs
@@ -1,4 +1,4 @@
-{{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.shields title='E20.ItemTypeShieldPlural' dataType='shields'}}
+{{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs" items=@root.shields title='E20.ItemTypeShieldPlural' dataType='shield'}}
   {{#*inline "expand-details" item}}
     {{> "systems/essence20/templates/actor/parts/items/shield/details.hbs"}}
   {{/inline}}


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- The Plus button for an Effect on a shield now works
- ParentId gets set on hangups selected from a Choices Prompt on an influence drop.

##### Testing
- Validate creating a weaponEffect on a shield from the actor sheet
- Validate that the flag for parentItem on the Hang up points to the new Influence created. 
