### PR TITLE
Making selector headers more visible

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -209,6 +209,10 @@
   box-shadow: 4px 4px 0 black;
 }
 
+body.game .window-app {
+  --color-select-option-bg: #5f5f5f;
+}
+
 .essence20 .sheet {
   min-width: fit-content;
   max-width: 55%;

--- a/sass/assets/_global-windows.scss
+++ b/sass/assets/_global-windows.scss
@@ -25,6 +25,10 @@
   box-shadow: v.$boxshadow;
 }
 
+body.game .window-app {
+  --color-select-option-bg: #5f5f5f;
+}
+
 .essence20 .sheet {
   min-width: fit-content;
   max-width: 55%;


### PR DESCRIPTION
##### In this PR
- Making selector headers more visible
- I tried using the `v.$background-b` variable but for some reason that did nothing
![image](https://github.com/user-attachments/assets/a47ec0f2-258a-4b3d-a2b6-9500980aa5ad)

##### Testing
- Headers for the create item selector should be more visible
