### PR TITLE
Fixing the trait selector submit button so it's in the footer

### DIFF
--- a/module/apps/trait-selector.mjs
+++ b/module/apps/trait-selector.mjs
@@ -36,7 +36,7 @@ export class TraitSelector extends HandlebarsApplicationMixin(ApplicationV2) {
     },
     footer: {
       template: "templates/generic/form-footer.hbs",
-  }
+    },
   };
 
   get title() {
@@ -65,7 +65,7 @@ export class TraitSelector extends HandlebarsApplicationMixin(ApplicationV2) {
     context.custom = custom;
     context.buttons = [
       { type: "submit", icon: "fa-solid fa-save", label: "SETTINGS.Save" },
-    ]
+    ];
 
     return context;
   }

--- a/module/apps/trait-selector.mjs
+++ b/module/apps/trait-selector.mjs
@@ -19,7 +19,7 @@ export class TraitSelector extends HandlebarsApplicationMixin(ApplicationV2) {
     choices: {},
     customKey: "custom",
     tag: "form",
-    title: "asdf",
+    title: "E20.TraitSelectorTitle",
     form: {
       handler: TraitSelector.myFormHandler,
       submitOnChange: false,

--- a/module/apps/trait-selector.mjs
+++ b/module/apps/trait-selector.mjs
@@ -19,7 +19,7 @@ export class TraitSelector extends HandlebarsApplicationMixin(ApplicationV2) {
     choices: {},
     customKey: "custom",
     tag: "form",
-    title: "E20.TraitSelectorTitle",
+    title: "asdf",
     form: {
       handler: TraitSelector.myFormHandler,
       submitOnChange: false,
@@ -34,6 +34,9 @@ export class TraitSelector extends HandlebarsApplicationMixin(ApplicationV2) {
       scrollable: "",
       template: "systems/essence20/templates/app/trait-selector.hbs",
     },
+    footer: {
+      template: "templates/generic/form-footer.hbs",
+  }
   };
 
   get title() {
@@ -60,6 +63,9 @@ export class TraitSelector extends HandlebarsApplicationMixin(ApplicationV2) {
     context.allowCustom =  data.allowCustom;
     context.choices = choices;
     context.custom = custom;
+    context.buttons = [
+      { type: "submit", icon: "fa-solid fa-save", label: "SETTINGS.Save" },
+    ]
 
     return context;
   }

--- a/templates/app/trait-selector.hbs
+++ b/templates/app/trait-selector.hbs
@@ -22,5 +22,4 @@
     <input type="text" name="custom" value="{{custom}}" data-dtype="String" />
   </div>
   {{/if}}
-  <button type="submit" name="submit" value="1"><i class="far fa-save"></i> {{ localize "E20.TraitSelectorUpdate"}}</button>
 </div>


### PR DESCRIPTION
##### In this PR
- Fixing the trait selector submit button so it's in the footer

##### Testing
- Open a weapon trait selector. The button should always be visible and work as normal.
