### PR TITLE
Fixes Toxin training

### DIFF
--- a/templates/actor/parts/misc/training.hbs
+++ b/templates/actor/parts/misc/training.hbs
@@ -51,9 +51,11 @@
             {{else}}
               {{formatBooleanList @root.system.trained.poisons @root.config.poisonTraining 'unit'}}
             {{/if}}
-          {{#if @root.actor.system.trained.toxins.all}}
-              {{localize "E20.PoisonTrainingAll"}}
-          {{/if}}
+          </td>
+        {{/if}}
+        {{#if @root.actor.system.trained.toxins.all}}
+          <td class="tg-td">
+            {{localize "E20.PoisonTrainingAll"}}
           </td>
         {{/if}}
       </tr>


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- Toxin training all was showing in the <td> for Poisons and not Toxins

##### Testing
- Create actor with 5 or more in poisonTraining. 
