### PR TITLE
Improving skill container layout

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -63,7 +63,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -121,7 +121,7 @@
 }
 
 .essence20 .editor-content {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -188,21 +188,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -228,17 +228,17 @@ body.game .window-app {
 }
 
 .dialog .dialog-buttons button.default {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding-top: 6px;
 }
 
@@ -246,7 +246,7 @@ body.game .window-app {
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -257,7 +257,7 @@ body.game .window-app {
 }
 
 .dialog input {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .app .window-app dialog {
@@ -268,7 +268,7 @@ body.game .window-app {
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -279,7 +279,7 @@ body.game .window-app {
 }
 
 #module-management .package-list .package-title {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .item-button-container {
@@ -292,39 +292,39 @@ body.game .window-app {
 
 .rollable:hover,
 .rollable:focus {
-  color: rgb(0, 0, 0);
+  color: black;
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-sender {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-metadata {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -582,7 +582,7 @@ body.game .window-app {
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -627,36 +627,56 @@ body.game .window-app {
   white-space: nowrap;
   overflow: hidden;
   color: white;
+  margin-top: 2px;
+}
+
+.essence20 .skill-header .add-specialization {
+  flex-grow: 0;
+  margin-right: 8px;
+  margin-top: 3px;
 }
 
 .essence20 .skill-body {
-  margin-left: 10px;
-  margin-right: 10px;
+  display: flex;
+  flex-direction: column;
 }
 
 .essence20 .skill-body .shift-select {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  justify-content: center;
   margin-top: 5px;
+  margin-bottom: 5px;
+  align-items: center;
 }
 
 .essence20 .skill-body .shift-select > * {
   vertical-align: middle;
 }
 
-.essence20 .skill-body .shift-select .specialized-label {
-  margin-left: 5px;
+.essence20 .skill-body .shift-select .modifier-plus {
+  display: flex;
+  align-items: center;
 }
 
-.essence20 .skill-body .shift-select .specialized-checkbox {
-  margin-left: 2px;
+.essence20 .skill-body .specialized-checkbox {
+  margin: 0;
 }
 
 .essence20 .skill-body .specializations-list {
-  margin-top: 5px;
+  margin-bottom: 5px;
 }
 
 .essence20 .skill-body .specializations-list .specializations-item {
   align-items: center;
   gap: 5px;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.essence20 .skill-body .specializations-list .specializations-item .item-button-container {
+  padding-top: 3px;
 }
 
 .essence20 .skill-body .specializations-header {
@@ -681,7 +701,7 @@ body.game .window-app {
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -697,7 +717,7 @@ body.game .window-app {
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -708,11 +728,11 @@ body.game .window-app {
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .tox .tox-editor-container {
-  background: rgb(255, 255, 255);
+  background: white;
 }
 
 .essence20 .tox .tox-edit-area {
@@ -743,7 +763,7 @@ body.game .window-app {
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -852,7 +872,7 @@ body.game .window-app {
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -957,7 +977,7 @@ body.game .window-app {
   list-style: none;
   padding: 6px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   background: none;
@@ -1043,7 +1063,7 @@ body.game .window-app {
 
 .essence20 .pony {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: #212c5f;
   background-size: cover;
@@ -1085,7 +1105,7 @@ body.game .window-app {
 }
 
 .essence20 .item {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   gap: 5px;
 }
 
@@ -1096,7 +1116,7 @@ body.game .window-app {
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1162,7 +1182,7 @@ body.game .window-app {
   -ms-flex-align: center;
   align-items: center;
   padding: 0 2px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .items-list hr {
@@ -1258,7 +1278,7 @@ body.game .window-app {
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding: 6px;
   min-height: none;
 }
@@ -1275,7 +1295,7 @@ body.game .window-app {
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: rgb(163, 163, 163);
+  color: #a3a3a3;
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1329,11 +1349,11 @@ option {
 
 form .notes,
 form .hint {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .span {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .sheet-body {

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -936,22 +936,6 @@ body.game .window-app {
   width: 50%;
 }
 
-.essence20 .npc-skills.vehicle {
-  width: 22%;
-}
-
-.essence20 .npc-items.vehicle {
-  width: 78%;
-}
-
-.essence20 .npc-skills.zord {
-  width: 23%;
-}
-
-.essence20 .npc-items.zord {
-  width: 77%;
-}
-
 .essence20 .skill-separator {
   display: flex;
   align-items: center;

--- a/lang/en.json
+++ b/lang/en.json
@@ -98,6 +98,7 @@
     "ActorSizeTitanic": "Titanic",
     "ActorSizeTowering": "Towering",
     "ActorStun": "Stun",
+    "AddSpecialization": "Add Specialization",
     "ActorWealth": "Wealth Die",
     "AdvancedRole": "Is Advanced?",
     "Alteration": "Alteration",

--- a/sass/actors/_npc.scss
+++ b/sass/actors/_npc.scss
@@ -54,22 +54,6 @@
   width: 50%;
 }
 
-.essence20 .npc-skills.vehicle {
-  width: 22%;
-}
-
-.essence20 .npc-items.vehicle {
-  width: 78%;
-}
-
-.essence20 .npc-skills.zord {
-  width: 23%;
-}
-
-.essence20 .npc-items.zord {
-  width: 77%;
-}
-
 .essence20 .skill-separator {
   display: flex;
   align-items: center;

--- a/sass/assets/_skill.scss
+++ b/sass/assets/_skill.scss
@@ -17,36 +17,56 @@
   white-space: nowrap;
   overflow: hidden;
   color: white;
+  margin-top: 2px;
+}
+
+.essence20 .skill-header .add-specialization {
+  flex-grow: 0;
+  margin-right: 8px;
+  margin-top: 3px;
 }
 
 .essence20 .skill-body {
-  margin-left: 10px;
-  margin-right: 10px;
+  display: flex;
+  flex-direction: column;
 }
 
 .essence20 .skill-body .shift-select {
+  display: flex;
+  flex-direction: row;
+  gap: 5px;
+  justify-content: center;
   margin-top: 5px;
+  margin-bottom: 5px;
+  align-items: center;
 }
 
 .essence20 .skill-body .shift-select > * {
   vertical-align: middle;
 }
 
-.essence20 .skill-body .shift-select .specialized-label {
-  margin-left: 5px;
+.essence20 .skill-body .shift-select .modifier-plus {
+  display: flex;
+  align-items: center;
 }
 
-.essence20 .skill-body .shift-select .specialized-checkbox {
-  margin-left: 2px;
+.essence20 .skill-body .specialized-checkbox {
+  margin: 0;
 }
 
 .essence20 .skill-body .specializations-list {
-  margin-top: 5px;
+  margin-bottom: 5px;
 }
 
 .essence20 .skill-body .specializations-list .specializations-item {
   align-items: center;
   gap: 5px;
+  margin-left: 5px;
+  margin-right: 5px;
+}
+
+.essence20 .skill-body .specializations-list .specializations-item .item-button-container {
+  padding-top: 3px;
 }
 
 .essence20 .skill-body .specializations-header {

--- a/templates/actor/parts/misc/essence-skills.hbs
+++ b/templates/actor/parts/misc/essence-skills.hbs
@@ -1,4 +1,4 @@
-{{!-- Skill header and shift selector --}}
+{{!-- Skill header --}}
 <div class="flexrow skill-header" style="background-color: {{@root.system.color}}50">
   <span class="skill-roll">
     <a
@@ -10,15 +10,17 @@
     </a>
   </span>
   <span class="skill-name">{{lookup @root.config.skills skill}}</span>
+  <a class="item-create add-specialization" data-type="specialization" data-skill="{{skill}}" data-shift="{{fields.shift}}" data-tooltip="{{ localize 'E20.AddSpecialization' }}">
+    <i class="fas fa-plus"></i>
+  </a>
 </div>
 
 <div class="skill-body">
-  {{!-- Mod and Spec inputs --}}
   <div class="shift-select">
     <select name="system.skills.{{skill}}.shift">
       {{selectOptions @root.config.skillShifts selected=fields.shift}}
     </select>
-    <span for="system.skills.{{skill}}.modifier">+</span>
+    <span class="modifier-plus" for="system.skills.{{skill}}.modifier">+</span>
     <input class="one-digit-input" type="number" name="system.skills.{{skill}}.modifier" value="{{fields.modifier}}" min="0" step="1" />
 
     {{#ifEquals @root.actor.type 'npc'}}
@@ -29,14 +31,6 @@
 
   {{!-- Only PCs and NPCs get Specializations. Update this as new PC types are added. --}}
   {{#inArray '["companion", "giJoe", "powerRanger", "npc", "transformer", "pony"]' @root.actor.type}}
-
-  {{!-- Specializations header --}}
-  <div class="specializations-header">
-    <span>{{localize 'E20.ItemTypeSpecializationPlural'}}</span>
-    <a class="item-create" data-type="specialization" data-skill="{{skill}}" data-shift="{{fields.shift}}" data-tooltip="{{ localize 'E20.ItemControlAdd' }}">
-      <i class="fas fa-plus"></i>
-    </a>
-  </div>
 
   {{!-- Specializations list --}}
   <ol class="items-list"></ol>

--- a/templates/actor/parts/misc/essence-skills.hbs
+++ b/templates/actor/parts/misc/essence-skills.hbs
@@ -23,14 +23,11 @@
     <span class="modifier-plus" for="system.skills.{{skill}}.modifier">+</span>
     <input class="one-digit-input" type="number" name="system.skills.{{skill}}.modifier" value="{{fields.modifier}}" min="0" step="1" />
 
-    {{#ifEquals @root.actor.type 'npc'}}
+    {{#inArray '["companion", "npc", "vehicle", "zord"]' @root.actor.type}}
     <span class="specialized-label">{{localize 'E20.RollIsSpecialized'}}:</span>
     <input class="specialized-checkbox" type="checkbox" name="system.skills.{{skill}}.isSpecialized" {{checked fields.isSpecialized}} data-dtype="Boolean"/>
-    {{/ifEquals}}
+    {{/inArray}}
   </div>
-
-  {{!-- Only PCs and NPCs get Specializations. Update this as new PC types are added. --}}
-  {{#inArray '["companion", "giJoe", "powerRanger", "npc", "transformer", "pony"]' @root.actor.type}}
 
   {{!-- Specializations list --}}
   <ol class="items-list"></ol>
@@ -38,7 +35,7 @@
     <li class="item specializations-list" data-item-id="{{specialization._id}}">
       <div class="flexrow specializations-item">
         <span class="item-button-container">
-          {{#ifEquals @root.actor.type 'npc'}}
+          {{#inArray '["companion", "npc", "vehicle", "zord"]' @root.actor.type}}
           {{!-- NPCs can have unspecialized specializations, but PCs are always specialized --}}
           <a
             class="rollable" data-roll-type="skill" data-skill="{{../skill}}" data-essence="{{../essence}}"
@@ -52,18 +49,18 @@
             data-shift-up ="{{../fields.shiftDown}}" data-shift-down ="{{../fields.shiftDown}}"
             data-shift="{{../fields.shift}}" data-specialization-name="{{specialization.name}}" data-is-specialized="true" data-tooltip="{{ localize 'E20.SkillRollTitle'}}"
           >
-          {{/ifEquals}}
+          {{/inArray}}
             <i class="fas fa-dice-d20"></i>
           </a>
         </span>
         <input class="inline-edit" data-field="name" type="text" name="{{../skill}}.{{specialization.name}}" value="{{specialization.name}}" />
-        {{#ifEquals @root.actor.type 'npc'}}
+        {{#inArray '["companion", "npc", "vehicle", "zord"]' @root.actor.type}}
         <select class="inline-edit" style="flex-grow: 0;" data-field="system.shift" name="system.shift">
           {{selectOptions @root.config.skillShifts selected=specialization.system.shift}}
         </select>
         <span class="specialized-label" style="flex-grow: 0;">{{localize 'E20.RollIsSpecialized'}}:</span>
         <input class="inline-edit specialized-checkbox" type="checkbox" data-field="system.isSpecialized" name="specialization.system.isSpecialized" {{checked specialization.system.isSpecialized}} data-dtype="Boolean"/>
-        {{/ifEquals}}
+        {{/inArray}}
         <span class="item-button-container">
           <a class="item-control item-delete" data-tooltip="{{localize 'E20.ItemControlDelete'}}"><i class="fas fa-trash"></i></a>
         </span>
@@ -71,6 +68,4 @@
     </li>
     {{/each}}
   </ol>
-
-  {{/inArray}}
 </div>

--- a/templates/actor/parts/misc/zord-common.hbs
+++ b/templates/actor/parts/misc/zord-common.hbs
@@ -21,12 +21,12 @@
 </div>
 
 <div class="npc-row">
-  <div class="npc-skills zord">
-    {{!-- Skills --}}
+  {{!-- Skills --}}
+  <div class="npc-skills">
     {{> "systems/essence20/templates/actor/parts/misc/accordion-skills.hbs"}}
   </div>
 
-  <div class="npc-items zord">
+  <div class="npc-items">
     {{!-- Weapons --}}
     {{> "systems/essence20/templates/actor/parts/items/weapon/container.hbs"}}
     {{!-- Features --}}

--- a/templates/actor/sheets/vehicle.hbs
+++ b/templates/actor/sheets/vehicle.hbs
@@ -32,13 +32,12 @@
       {{> "systems/essence20/templates/actor/parts/misc/common.hbs"}}
 
       <div class="npc-row">
-        {{!-- Skills --}}
-        <div class="npc-skills vehicle">
+        <div class="npc-skills">
           {{> "systems/essence20/templates/actor/parts/misc/accordion-skills.hbs"}}
         </div>
 
         {{!-- Items --}}
-        <div class="npc-items vehicle">
+        <div class="npc-items">
           {{> "systems/essence20/templates/actor/parts/items/weapon/container.hbs"}}
           {{> "systems/essence20/templates/actor/parts/items/trait/container.hbs"}}
           {{> "systems/essence20/templates/actor/parts/items/power/container.hbs"}}


### PR DESCRIPTION
##### In this PR
- Improving skill container layout
- Non-PCs now have the same layout

New for non-PCs:
![image](https://github.com/user-attachments/assets/ffe1fe91-f187-499f-9b60-01056623c441)

New for PCs:
![image](https://github.com/user-attachments/assets/3ecafbeb-04fe-4080-a00d-bb56a1015c5f)

##### Testing
- Sheets should look as above and function as normal for all actors
