### PR TITLE
Adding add effect and upgrade buttons to weapons/armor

### DIFF
--- a/templates/actor/parts/items/armor/container.hbs
+++ b/templates/actor/parts/items/armor/container.hbs
@@ -3,6 +3,12 @@
     {{> "systems/essence20/templates/actor/parts/items/armor/details.hbs"}}
   {{/inline}}
 
+  {{#*inline "extra-controls" item}}
+    <a class="item-create" data-type="upgrade" data-parent-id="{{item._id}}" data-tooltip="{{ localize 'E20.ItemControlAdd' }} {{localize 'E20.Upgrade'}}">
+      <i class="fas fa-up"></i>
+    </a>
+  {{/inline}}
+
   {{#*inline "subcontainers" parentItem}}
   {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.system.items title="E20.ItemTypeUpgradePlural" dataType="upgrade" parentItem=parentItem}}
     {{#*inline "expand-details" item}}

--- a/templates/actor/parts/items/weapon/container.hbs
+++ b/templates/actor/parts/items/weapon/container.hbs
@@ -11,6 +11,15 @@
     {{item.name}}
   {{/inline}}
 
+  {{#*inline "extra-controls" item}}
+    <a class="item-create" data-type="weaponEffect" data-parent-id="{{item._id}}" data-tooltip="{{ localize 'E20.ItemControlAdd' }} {{localize 'E20.WeaponEffect'}}">
+      <i class="fas fa-burst"></i>
+    </a>
+    <a class="item-create" data-type="upgrade" data-parent-id="{{item._id}}" data-tooltip="{{ localize 'E20.ItemControlAdd' }} {{localize 'E20.Upgrade'}}">
+      <i class="fas fa-up"></i>
+    </a>
+  {{/inline}}
+
   {{#*inline "subcontainers" parentItem}}
     {{!-- Weapon Effects --}}
     {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs" items=parentItem.system.items title="E20.ItemTypeWeaponEffectPlural" dataType="weaponEffect" parentItem=parentItem}}
@@ -39,5 +48,4 @@
       {{/inline}}
     {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-subcontainer.hbs"}}
   {{/inline}}
-
 {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container.hbs"}}

--- a/templates/actor/parts/misc/collapsible-item-container-header.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container-header.hbs
@@ -8,7 +8,7 @@
     {{#ifNotEquals hidePlusButton 'true'}}
       {{#> plus-button dataType=dataType parentId=parentId}}
         {{!-- Custom plus button here, or use default below --}}
-        <a class="item-create" data-type={{dataType}} data-parent-id="{{parentId}}" data-tooltip="{{ localize 'E20.ItemControlAdd' }}">
+        <a class="item-create" data-type="{{dataType}}" data-parent-id="{{parentId}}" data-tooltip="{{ localize 'E20.ItemControlAdd' }}">
           <i class="fas fa-plus"></i>
         </a>
       {{/plus-button}}
@@ -17,7 +17,7 @@
 
   <span class="header-accordion-wrapper">
     {{#if items.length}}
-    <a class="header-accordion-label" data-type={{dataType}} data-tooltip="{{ localize 'E20.ItemControlExpandAll' }}">
+    <a class="header-accordion-label" data-tooltip="{{ localize 'E20.ItemControlExpandAll' }}">
       <i class="accordion-icon fas fa-chevron-down"></i>
     </a>
     {{/if}}

--- a/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs
+++ b/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs
@@ -40,6 +40,9 @@
     {{/item-label}}
   </div>
   <div class="item-controls">
+    {{#> extra-controls item=item}}
+    {{!-- Extra control buttons --}}
+    {{/extra-controls}}
     <a class="item-control item-edit" data-tooltip="{{localize 'E20.ItemControlEdit'}}"><i class="fas fa-edit"></i></a>
     <a class="item-control item-delete" data-tooltip="{{localize 'E20.ItemControlDelete'}}"><i class="fas fa-trash"></i></a>
     <a class="item-control accordion-label" data-tooltip="{{ localize 'E20.ItemControlExpand' }}">

--- a/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
+++ b/templates/actor/parts/misc/collapsible-item-subcontainer.hbs
@@ -1,28 +1,30 @@
-<div class="collapsible-item-container collapsible-item-subcontainer">
-  {{!-- Header with + and v buttons --}}
-  {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-header.hbs" items=items title=title dataType=dataType parentId=parentItem._id}}
-  <ol class="items-list" style="border-color: {{system.color}};">
-    {{#each items as |item|}}
-    {{#ifEquals item.type ../dataType}}
-      <li class="item accordion-wrapper" data-item-key="{{@key}}" data-item-uuid="{{item.uuid}}" data-parent-id="{{../parentItem._id}}">
-        {{!-- Item label and buttons --}}
+{{#itemsContainType items dataType}}
+  <div class="collapsible-item-container collapsible-item-subcontainer">
+    {{!-- Header with + and v buttons --}}
+    {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-header.hbs" items=items title=title dataType=dataType parentId=parentItem._id}}
+    <ol class="items-list" style="border-color: {{system.color}};">
+      {{#each items as |item|}}
+      {{#ifEquals item.type ../dataType}}
+        <li class="item accordion-wrapper" data-item-key="{{@key}}" data-item-uuid="{{item.uuid}}" data-parent-id="{{../parentItem._id}}">
+          {{!-- Item label and buttons --}}
 
-        {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item }}
-          {{#> roll-button}}
-          {{!-- Custom roll button here --}}
-          {{/roll-button}}
+          {{#>"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs" item=item }}
+            {{#> roll-button}}
+            {{!-- Custom roll button here --}}
+            {{/roll-button}}
 
-          {{#> item-label item=item}}
-          {{!-- Custom item label here --}}
-          {{/item-label}}
-        {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs"}}
+            {{#> item-label item=item}}
+            {{!-- Custom item label here --}}
+            {{/item-label}}
+          {{/"systems/essence20/templates/actor/parts/misc/collapsible-item-container-label-buttons.hbs"}}
 
-        {{!-- Item content --}}
-        {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item parentItem=../parentItem}}
-      </li>
+          {{!-- Item content --}}
+          {{> "systems/essence20/templates/actor/parts/misc/collapsible-item-container-content.hbs" item=item parentItem=../parentItem}}
+        </li>
 
-      <hr>
-    {{/ifEquals}}
-    {{/each}}
-  </ol>
-</div>
+        <hr>
+      {{/ifEquals}}
+      {{/each}}
+    </ol>
+  </div>
+{{/itemsContainType}}


### PR DESCRIPTION
##### In this PR
- Adding buttons to add effects and upgrades directly on the weapon/armor header
- Only displays subcontainers if they have items

##### Testing
- New add buttons should work
- Subcontainers only appear if they have items