### PR TITLE
Converted to ProseMirror

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -38,8 +38,8 @@ export class Essence20ActorSheet extends ActorSheet {
         onSave: () => {
           this.saveEditor(name, { remove: true });
           this.editingDescriptionTarget = null;
-        }
-      })
+        },
+      }),
     };
     return super.activateEditor(name, options, initialContent);
   }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -29,6 +29,22 @@ export class Essence20ActorSheet extends ActorSheet {
   }
 
   /** @override */
+  async activateEditor(name, options={}, initialContent="") {
+    options.relativeLinks = true;
+    options.plugins = {
+      menu: ProseMirror.ProseMirrorMenu.build(ProseMirror.defaultSchema, {
+        compact: true,
+        destroyOnSave: true,
+        onSave: () => {
+          this.saveEditor(name, { remove: true });
+          this.editingDescriptionTarget = null;
+        }
+      })
+    };
+    return super.activateEditor(name, options, initialContent);
+  }
+
+  /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["essence20", "sheet", "actor"],

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -18,8 +18,8 @@ export class Essence20ItemSheet extends ItemSheet {
         onSave: () => {
           this.saveEditor(name, { remove: true });
           this.editingDescriptionTarget = null;
-        }
-      })
+        },
+      }),
     };
     return super.activateEditor(name, options, initialContent);
   }

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -9,6 +9,22 @@ import { setEntryAndAddItem } from "../sheet-handlers/attachment-handler.mjs";
 export class Essence20ItemSheet extends ItemSheet {
 
   /** @override */
+  async activateEditor(name, options={}, initialContent="") {
+    options.relativeLinks = true;
+    options.plugins = {
+      menu: ProseMirror.ProseMirrorMenu.build(ProseMirror.defaultSchema, {
+        compact: true,
+        destroyOnSave: true,
+        onSave: () => {
+          this.saveEditor(name, { remove: true });
+          this.editingDescriptionTarget = null;
+        }
+      })
+    };
+    return super.activateEditor(name, options, initialContent);
+  }
+
+  /** @override */
   static get defaultOptions() {
     return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["essence20", "sheet", "item"],

--- a/templates/actor/parts/misc/notes.hbs
+++ b/templates/actor/parts/misc/notes.hbs
@@ -1,3 +1,3 @@
 <div class="notes-container" style="border-color: {{system.color}};">
-  {{editor system.notes target="system.notes" button=true owner=owner editable=editable}}
+  {{editor system.notes target="system.notes" button=true owner=owner editable=editable engine="prosemirror" collaborate=false}}
 </div>

--- a/templates/item/parts/description.hbs
+++ b/templates/item/parts/description.hbs
@@ -9,5 +9,5 @@
 {{!-- Description --}}
 <h3>{{localize 'E20.ItemDescription'}}</h3>
 <div class="description-tab flexrow active" data-group="primary" data-tab="description">
-  {{editor system.description target="system.description" button=true owner=owner editable=editable}}
+  {{editor system.description target="system.description" button=true owner=owner editable=editable engine="prosemirror" collaborate=false}}
 </div>


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- Moved all Descriptions and Notes field to use the Prose Mirror editor instead of the TinyMCE editor.

##### Testing
- Open Item and actor descriptions and note fields and edit them. 
