### PR TITLE
Fixing colors for hard to read text and icons

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -1326,7 +1326,7 @@ form .notes, form .hint {
   background: initial;
 }
 
-.essence20 input[type=number], input[type=text] {
+input[type=number], input[type=text] {
   color: white;
   vertical-align: middle;
 }

--- a/css/essence20.css
+++ b/css/essence20.css
@@ -1298,6 +1298,34 @@ option {
   background-color: #4a4848;
 }
 
+form .form-group span.units {
+  color: #9e9b9b;
+}
+
+form .form-group.slim .form-fields > label {
+  color: #9e9b9b;
+}
+
+form .notes, form .hint {
+  color: #9e9b9b;
+}
+
+.standard-form .form-group > label {
+  color: #9e9b9b;
+}
+
+.filepicker .display-modes a {
+  background: initial;
+}
+
+.filepicker .display-modes a.active {
+  background: initial;
+}
+
+.filepicker .favorites .path {
+  background: initial;
+}
+
 .essence20 input[type=number], input[type=text] {
   color: white;
   vertical-align: middle;
@@ -1329,11 +1357,6 @@ option {
   width: 20px;
   justify-content: center;
   align-items: center;
-}
-
-form .notes,
-form .hint {
-  color: #c7c4c4;
 }
 
 .essence20 .span {

--- a/sass/assets/_variables.scss
+++ b/sass/assets/_variables.scss
@@ -1,6 +1,7 @@
 // text Colors
 $textcolor1: rgb(199, 196, 196);
 $textcolor2: rgb(0,0,0);
+$textcolor3: rgb(158, 155, 155);
 
 //background colors
 $background-b: #5f5f5f;

--- a/sass/essence20.scss
+++ b/sass/essence20.scss
@@ -13,6 +13,34 @@ option {
   background-color: #4a4848;
 }
 
+form .form-group span.units {
+  color: v.$textcolor3;
+}
+
+form .form-group.slim .form-fields > label {
+  color: v.$textcolor3;
+}
+
+form .notes, form .hint {
+  color: v.$textcolor3;
+}
+
+.standard-form .form-group > label {
+  color: v.$textcolor3;
+}
+
+.filepicker .display-modes a {
+  background: initial;
+}
+
+.filepicker .display-modes a.active {
+  background: initial;
+}
+
+.filepicker .favorites .path {
+  background: initial;
+}
+
 .essence20 input[type="number"], input[type="text"] {
   color: white;
   vertical-align: middle;
@@ -44,11 +72,6 @@ option {
   width: 20px;
   justify-content: center;
   align-items: center;
-}
-
-form .notes,
-form .hint {
-  color: v.$textcolor1;
 }
 
 .essence20 .span {

--- a/sass/essence20.scss
+++ b/sass/essence20.scss
@@ -41,7 +41,7 @@ form .notes, form .hint {
   background: initial;
 }
 
-.essence20 input[type="number"], input[type="text"] {
+input[type="number"], input[type="text"] {
   color: white;
   vertical-align: middle;
 }


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/836

##### In this PR
- Fixing colors for hard to read text and icons
- Probably I missed some, so lmk
![image](https://github.com/user-attachments/assets/dad88469-9adb-4a16-b5c9-61a7b32f2ee7)
![image](https://github.com/user-attachments/assets/6accbf4b-6060-4986-a6aa-de8cc0323d6d)
![image](https://github.com/user-attachments/assets/e640cfd1-433d-406f-ba91-320e07d663c0)
![image](https://github.com/user-attachments/assets/72dc6f46-7e18-4aef-ad36-db983ac19538)

##### Testing
- Text and icons should be more legible for the file picker dialog and the token dialog
