### PR TITLE
Fix to allow optGroups on the Create Item in v13

### DIFF
--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -199,8 +199,7 @@ Hooks.on("renderChatMessage", (app, html, data) => {
 /* Hook to organize the item options by type */
 Hooks.on("renderDialogV2", (dialog, html) => {
   const select = html.querySelector("select[name='type']");
-  if (select){
-
+  if (select) {
     const classFeatureOption = select.querySelector("option[value='classFeature']");
     if (classFeatureOption) {
       classFeatureOption.style.display = 'none';

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -197,9 +197,9 @@ Hooks.on("renderChatMessage", (app, html, data) => {
 });
 
 /* Hook to organize the item options by type */
-Hooks.on("renderDialog", (dialog, html) => {
-  if (html[0].innerText.includes('Create New Item')) {
-    const select = html[0].querySelector("select[name='type']");
+Hooks.on("renderDialogV2", (dialog, html) => {
+  const select = html.querySelector("select[name='type']");
+  if (select){
 
     const classFeatureOption = select.querySelector("option[value='classFeature']");
     if (classFeatureOption) {

--- a/module/story-points-tracker.js
+++ b/module/story-points-tracker.js
@@ -220,7 +220,7 @@ Hooks.on('dragEndStoryPointsTracker', (app) => {
 // Init the button in the controls for toggling the dialog
 Hooks.on("getSceneControlButtons", (controls) => {
   if (setting("sptShow") == 'toggle' && (setting("sptAccess") == 'everyone' || (setting("sptAccess") == 'gm' == game.user.isGM))) {
-    let tokenControls = controls.token;
+    let tokenControls = controls.find(control => control.name === "token");
     tokenControls.tools.push({
       name: "toggleDialog",
       title: i18nf("E20.SptToggleDialog", {name: getPointsName(false)}),

--- a/module/story-points-tracker.js
+++ b/module/story-points-tracker.js
@@ -220,7 +220,7 @@ Hooks.on('dragEndStoryPointsTracker', (app) => {
 // Init the button in the controls for toggling the dialog
 Hooks.on("getSceneControlButtons", (controls) => {
   if (setting("sptShow") == 'toggle' && (setting("sptAccess") == 'everyone' || (setting("sptAccess") == 'gm' == game.user.isGM))) {
-    let tokenControls = controls.find(control => control.name === "token");
+    let tokenControls = controls.token;
     tokenControls.tools.push({
       name: "toggleDialog",
       title: i18nf("E20.SptToggleDialog", {name: getPointsName(false)}),


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- changes how we implement the optGroups in the Create Item drop down to support v13 and DialogV2

##### Testing
- Validate that the drop down has the items ordered correctly
- Note there is supposed to be a better way to do this with extending the static createDialog method, will look at that later.
