### PR TITLE
Fixing background color for /me messages

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -329,6 +329,11 @@ body.game .window-app {
   box-shadow: 4px 4px 0 black;
 }
 
+.chat-message.emote {
+  background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
+  border: 4px solid #b5b1b1;
+}
+
 .grid,
 .grid-2col {
   display: grid;

--- a/sass/assets/_chat.scss
+++ b/sass/assets/_chat.scss
@@ -1,4 +1,5 @@
 @use 'variables' as v;
+
 .chat-message {
   background: v.$background-image-1;
   opacity: 80;
@@ -7,15 +8,15 @@
   box-shadow: v.$boxshadow;
 }
 
-.chat-message .flavor-text{
+.chat-message .flavor-text {
   color: v.$textcolor1;
 }
 
-.chat-message .message-sender{
+.chat-message .message-sender {
   color: v.$textcolor1;
 }
 
-.chat-message .message-metadata{
+.chat-message .message-metadata {
   color: v.$textcolor1;
 }
 
@@ -25,4 +26,9 @@
   color: v.$textcolor1;
   border: v.$border2;
   box-shadow: v.$boxshadow;
+}
+
+.chat-message.emote {
+  background: v.$background-image-1;
+  border: v.$border;
 }


### PR DESCRIPTION
Closes https://github.com/WookieeMatt/Essence20/issues/430

##### In this PR
- Fixing background color for /me messages
- Minor whitespace tweaks

##### Testing
- Highlight an actor and type a message starting with `/me`. It should work as expected and be easy to read.
