### PR TITLE
Auto-replacing vars in system.json

### DIFF
--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
-  release:
-    types: [published]
+  pull_request:
+    branches: [beta]
 jobs:
   Compile:
     runs-on: ubuntu-latest
@@ -14,6 +14,23 @@ jobs:
         uses: actions/checkout@v2
       - run: echo "💡 The ${{ github.repository }} repository has been cloned to the runner."
       - run: echo "🖥️ The workflow is now ready to test your code on the runner."
+
+      # Get part of the tag after the `v`
+      - name: Extract tag version number
+        id: get_version
+        uses: battila7/get-version-action@v2
+
+      # Substitute the Manifest and Download URLs in the system.json
+      - name: Substitute Manifest and Download Links For Versioned Ones
+        id: sub_manifest_link_version
+        uses: microsoft/variable-substitution@v1
+        with:
+          files: 'system.json'
+        env:
+          version: ${{steps.get_version.outputs.version-without-v}}
+          url: https://github.com/${{github.repository}}
+          manifest: https://github.com/${{github.repository}}/releases/latest/download/system.json
+          download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/Essence20.zip
 
       - name: Setup node
         uses: actions/setup-node@v3

--- a/.github/workflows/github-actions-release.yml
+++ b/.github/workflows/github-actions-release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
-  pull_request:
-    branches: [beta]
+  release:
+    types: [published]
 jobs:
   Compile:
     runs-on: ubuntu-latest

--- a/system.json
+++ b/system.json
@@ -1,7 +1,7 @@
 {
   "title": "Essence20",
   "description": "The Essence20 system for FoundryVTT!",
-  "version": "4.6.7",
+  "version": "This is auto replaced",
   "esmodules": [
     "module/essence20.mjs",
     "module/story-points-tracker.js",
@@ -243,9 +243,9 @@
   "primaryTokenAttribute": "health",
   "secondaryTokenAttribute": "stun",
   "socket": true,
-  "url": "https://github.com/WookieeMatt/Essence20",
-  "manifest": "https://raw.githubusercontent.com/WookieeMatt/Essence20/main/system.json",
-  "download": "https://github.com/WookieeMatt/Essence20/releases/latest/download/Essence20.zip",
+  "url": "This is auto replaced",
+  "manifest": "This is auto replaced",
+  "download": "This is auto replaced",
   "license": "LICENSE.txt",
   "id": "essence20",
   "authors": [


### PR DESCRIPTION
##### In this PR
- Auto-replacing vars in system.json. This will allow us to install old versions of the system, and won't have to add a commit for bumping the system version.

##### Testing
- I [had it run](https://github.com/WookieeMatt/Essence20/actions/runs/14980122169/job/42081987951?pr=870) when I created the PR, and it didn't error until it got to the release-specific stuff, so that's good
- I think we won't know for sure until we release
