### PR TITLE
Now using buttons for changing levels

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -63,7 +63,7 @@
   list-style: none;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   flex-grow: 0;
@@ -121,7 +121,7 @@
 }
 
 .essence20 .editor-content {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   min-height: fit-content;
   font-size: 16px;
   padding: 0;
@@ -188,21 +188,21 @@
 .window-app {
   font-family: "Rajdhani", sans-serif;
   font-weight: bold;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
 }
 
 .window-app .window-content {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   background-size: cover;
 }
 
 .window-app .window-content button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
   border-color: 4px solid #b5b1b1;
   border-radius: 20px;
@@ -228,17 +228,17 @@ body.game .window-app {
 }
 
 .dialog .dialog-buttons button.default {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons button {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   background: none;
 }
 
 .dialog .dialog-buttons {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding-top: 6px;
 }
 
@@ -246,7 +246,7 @@ body.game .window-app {
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -257,7 +257,7 @@ body.game .window-app {
 }
 
 .dialog input {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .app .window-app dialog {
@@ -268,7 +268,7 @@ body.game .window-app {
   list-style: none;
   padding: 6px;
   overflow-y: none;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   height: 100%;
@@ -279,7 +279,7 @@ body.game .window-app {
 }
 
 #module-management .package-list .package-title {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .item-button-container {
@@ -292,39 +292,39 @@ body.game .window-app {
 
 .rollable:hover,
 .rollable:focus {
-  color: rgb(0, 0, 0);
+  color: black;
   text-shadow: 0 0 10px red;
   cursor: pointer;
 }
 
 .window-app textarea {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px solid #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
 
 .chat-message .flavor-text {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-sender {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message .message-metadata {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .chat-message.whisper {
   background: radial-gradient(farthest-corner at 90% 10%, #535353, #303538, #000000);
   opacity: 80;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border: 4px dashed #b5b1b1;
   box-shadow: 4px 4px 0 black;
 }
@@ -575,6 +575,10 @@ body.game .window-app {
   flex-grow: 0;
 }
 
+.essence20 .pr-header-level-buttons {
+  flex-grow: 0;
+}
+
 /* Generic Item Sheet Styling */
 .essence20 .items-list {
   list-style: none;
@@ -582,7 +586,7 @@ body.game .window-app {
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -701,7 +705,7 @@ body.game .window-app {
 .essence20 .skills-container {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   transform: rotate(0deg);
   scrollbar-width: thin;
   background-color: none;
@@ -717,7 +721,7 @@ body.game .window-app {
 .essence20 .skillscontainer {
   list-style: none;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   gap: 6px;
@@ -728,11 +732,11 @@ body.game .window-app {
 .essence20 h2,
 .essence20 h3,
 .essence20 h4 {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .tox .tox-editor-container {
-  background: rgb(255, 255, 255);
+  background: white;
 }
 
 .essence20 .tox .tox-edit-area {
@@ -763,7 +767,7 @@ body.game .window-app {
   list-style: none;
   padding: 4px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: row;
   flex-grow: 0;
@@ -872,7 +876,7 @@ body.game .window-app {
   margin-right: 3px;
   padding: 8px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: center;
@@ -961,7 +965,7 @@ body.game .window-app {
   list-style: none;
   padding: 6px;
   overflow-y: auto;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   flex-basis: auto;
   justify-content: center;
   background: none;
@@ -1047,7 +1051,7 @@ body.game .window-app {
 
 .essence20 .pony {
   /* background: rgb(78, 78, 78); */
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   border-radius: 15px;
   background: #212c5f;
   background-size: cover;
@@ -1089,7 +1093,7 @@ body.game .window-app {
 }
 
 .essence20 .item {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   gap: 5px;
 }
 
@@ -1100,7 +1104,7 @@ body.game .window-app {
   padding: 0;
   overflow-y: auto;
   scrollbar-width: thin;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1166,7 +1170,7 @@ body.game .window-app {
   -ms-flex-align: center;
   align-items: center;
   padding: 0 2px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .items-list hr {
@@ -1262,7 +1266,7 @@ body.game .window-app {
   background: none;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
   padding: 6px;
   min-height: none;
 }
@@ -1279,7 +1283,7 @@ body.game .window-app {
 /* -- Jornal page styling -- */
 .window-content .journal-sheet-container .journal-entry-content {
   background: none;
-  color: rgb(163, 163, 163);
+  color: #a3a3a3;
   border: 10px #c9c7b8;
   /*background-color: blue;*/
 }
@@ -1299,19 +1303,19 @@ option {
 }
 
 form .form-group span.units {
-  color: rgb(158, 155, 155);
+  color: #9e9b9b;
 }
 
 form .form-group.slim .form-fields > label {
-  color: rgb(158, 155, 155);
+  color: #9e9b9b;
 }
 
 form .notes, form .hint {
-  color: rgb(158, 155, 155);
+  color: #9e9b9b;
 }
 
 .standard-form .form-group > label {
-  color: rgb(158, 155, 155);
+  color: #9e9b9b;
 }
 
 .filepicker .display-modes a {
@@ -1360,7 +1364,7 @@ input[type=number], input[type=text] {
 }
 
 .essence20 .span {
-  color: rgb(199, 196, 196);
+  color: #c7c4c4;
 }
 
 .essence20 .sheet-body {

--- a/lang/en.json
+++ b/lang/en.json
@@ -386,6 +386,8 @@
     "Level18": "18th Level",
     "Level19": "19th Level",
     "Level20": "20th Level",
+    "LevelButtonDown": "Level down",
+    "LevelButtonUp": "Level up",
     "LevelSelector": "Open level selector",
     "LightRangeBright": "Bright",
     "LightRangeDim": "Dim",

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -292,6 +292,7 @@ export async function onRoleDrop(actor, role, dropFunc) {
     return false;
   }
 
+  // Faction updates
   const factionList = getItemsOfType("faction", actor.items);
   if (factionList.length) {
     addFactionPerks(actor, role);
@@ -319,6 +320,7 @@ export async function onRoleDrop(actor, role, dropFunc) {
   actor.setFlag('essence20', 'previousLevel', actor.system.level);
   actor.setFlag('essence20', 'roleDrop', true);
 
+  // Skill updates
   if (role.system.skillDie.isUsed) {
     const skillName = "roleSkillDie";
     const skillStringShift = `system.skills.${skillName}.shift`;
@@ -348,6 +350,7 @@ export async function onRoleDrop(actor, role, dropFunc) {
     });
   }
 
+  // Role version updates
   if (role.system.version =='powerRangers') {
     await actor.update({
       "system.canMorph": true,
@@ -355,6 +358,10 @@ export async function onRoleDrop(actor, role, dropFunc) {
   } else if (role.system.version =='myLittlePony') {
     await actor.update({
       "system.canSpellcast": true,
+    });
+  } else  if (role.system.version == 'giJoe') {
+    await actor.update({
+      "system.canQualify": true,
     });
   }
 
@@ -368,18 +375,14 @@ export async function onRoleDrop(actor, role, dropFunc) {
     await setRoleValues(newRole, actor);
   }
 
-  if (role.system.version == 'giJoe') {
-    await actor.update({
-      "system.canQualify": true,
-    });
-  }
-
+  // Training updates
   await _trainingUpdate(actor, 'armors', 'qualified', true, role);
   await _trainingUpdate(actor, 'armors', 'trained', true, role);
   await _trainingUpdate(actor, 'weapons', 'qualified', true, role);
   await _trainingUpdate(actor, 'weapons', 'trained', true, role);
   await _trainingUpdate(actor, 'armors', 'trained', true, role, true);
 
+  // Morphed toughness bonus updates
   for (const item of actor.items) {
     if (item._stats.compendiumSource == MORPHIN_TIME_PERK_ID) {
       setMorphedToughnessBonus(actor);
@@ -423,6 +426,7 @@ export async function onRoleDelete(actor, role) {
   const focus = getItemsOfType("focus", actor.items);
   const factionList = getItemsOfType("faction", actor.items);
 
+  // Faction updates
   if (factionList.length) {
     for (const item of actor.items) {
       if (item.type == "perk" && item.system.isRoleVariant) {
@@ -431,6 +435,7 @@ export async function onRoleDelete(actor, role) {
     }
   }
 
+  // Essence updates
   for (const essence in role.system.essenceLevels) {
     const totalDecrease = roleValueChange(0, role.system.essenceLevels[essence], previousLevel);
     const essenceMaxValue = Math.max(0, actor.system.essences[essence].max + totalDecrease);
@@ -444,6 +449,7 @@ export async function onRoleDelete(actor, role) {
     });
   }
 
+  // Role version updates
   if (role.system.version =='powerRangers') {
     await actor.update({
       "system.canMorph": false,
@@ -452,8 +458,22 @@ export async function onRoleDelete(actor, role) {
     await actor.update({
       "system.canSpellcast": false,
     });
+  } else if (role.system.version == 'giJoe') {
+    await actor.update({
+      "system.canQualify": false,
+    });
   }
 
+  if (role.system.version == 'myLittlePony' || role.system.hasSpecialAdvancement) {
+    await actor.update({
+      "system.essenceRanks.smarts": null,
+      "system.essenceRanks.social": null,
+      "system.essenceRanks.speed": null,
+      "system.essenceRanks.strength": null,
+    });
+  }
+
+  // Personal Power updates
   if (role.system.powers.personal.starting) {
     const totalDecrease = roleValueChange(0, role.system.powers.personal.levels, previousLevel);
     const newPersonalPowerMax = Math.max(0, parseInt(actor.system.powers.personal.max) - role.system.powers.personal.starting + (role.system.powers.personal.increase * totalDecrease));
@@ -464,6 +484,7 @@ export async function onRoleDelete(actor, role) {
     });
   }
 
+  // Skill updates
   if (role.system.skillDie.isUsed) {
     const skillName = "roleSkillDie";
     const skillStringShift = `system.skills.${skillName}.shift`;
@@ -493,6 +514,7 @@ export async function onRoleDelete(actor, role) {
     });
   }
 
+  // Health updates
   if (role.system.adjustments.health.length) {
     const totalDecrease = roleValueChange(0, role.system.adjustments.health, previousLevel);
     const newHealthBonus = Math.max(0, actor.system.health.bonus + totalDecrease);
@@ -502,32 +524,20 @@ export async function onRoleDelete(actor, role) {
     });
   }
 
+  // Focus updates
   if (focus[0]) {
     await onFocusDelete(actor, focus[0]);
     await focus[0].delete();
   }
 
-  if (role.system.version == 'myLittlePony' || role.system.hasSpecialAdvancement) {
-    await actor.update({
-      "system.essenceRanks.smarts": null,
-      "system.essenceRanks.social": null,
-      "system.essenceRanks.speed": null,
-      "system.essenceRanks.strength": null,
-    });
-  }
-
-  if (role.system.version == 'giJoe') {
-    await actor.update({
-      "system.canQualify": false,
-    });
-  }
-
+  // Training updates
   await _trainingUpdate(actor, 'armors', 'qualified', false, role);
   await _trainingUpdate(actor, 'armors', 'trained', false, role);
   await _trainingUpdate(actor, 'weapons', 'qualified', false, role);
   await _trainingUpdate(actor, 'weapons', 'trained', false, role);
   await _trainingUpdate(actor, 'armors', 'trained', false, role, true);
 
+  // Misc updates
   await actor.update ({
     "system.defenses.toughness.morphed": 0,
   });
@@ -618,11 +628,11 @@ export async function _setEssenceProgression(actor, options, role, dropFunc, lev
 }
 
 /**
- *
+ * Adds or removes Item type training for the given Actor.
  * @param {Actor} actor The Actor whose training is being updated
  * @param {String} itemType The type of item that we are training
  * @param {String} trainingType The type of training we are applying
- * @param {Boolean} updateType Whether we are adding or removing training
+ * @param {Boolean} updateType Whether we are adding (true) or removing (false) training
  * @param {Object} role The role that actor has
  * @param {Boolean} useUpgradesAccessor Whether this is targeting Upgrades or not
  */

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -540,6 +540,7 @@ export async function onRoleDelete(actor, role) {
   // Misc updates
   await actor.update ({
     "system.defenses.toughness.morphed": 0,
+    "system.level": 1,
   });
 
   deleteAttachmentsForItem(role, actor);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -606,7 +606,7 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
    */
   async _onLevelChangeHelper(levelChange) {
     const newLevel = this.actor.system.level + levelChange;
-    if (newLevel > 0) {
+    if (newLevel > 0 && newLevel <= 20) {
       await this.actor.update({
         "system.level": this.actor.system.level + levelChange,
       }).then(this.render(false));

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -522,6 +522,10 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
     // Rest button
     html.find('.rest').click(() => onRest(this));
 
+    // Leveling buttons
+    html.find('.level-up').click(() => this._onLevelChangeHelper(1));
+    html.find('.level-down').click(() => this._onLevelChangeHelper(-1));
+
     const isLocked = this.actor.system.isLocked;
 
     // Inputs
@@ -583,11 +587,30 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
    * Handle changes to an input element, submitting the form if options.submitOnChange is true.
    * Do not preventDefault in this handler as other interactions on the form may also be occurring.
    * @param {Event} event The initial change event
+   *
+   * @override
    */
   async _onChangeInput(event) {
     await super._onChangeInput(event);
 
-    if (event.currentTarget.name == "system.level") {
+    // Use this if we can get the manual level input working again
+    // if (event.currentTarget.name == "system.level") {
+    //   return await onLevelChange(this.actor, this.actor.system.level);
+    // }
+  }
+
+  /**
+   * Handle clicking on the leveling buttons, where the up arrow increases the
+   * level by 1 and the down arrow decreases it by 1
+   * @param {Integer} levelChange The change in the level
+   */
+  async _onLevelChangeHelper(levelChange) {
+    const newLevel = this.actor.system.level + levelChange;
+    if (newLevel > 0) {
+      await this.actor.update({
+        "system.level": this.actor.system.level + levelChange,
+      }).then(this.render(false));
+
       return await onLevelChange(this.actor, this.actor.system.level);
     }
   }

--- a/sass/assets/_headers.scss
+++ b/sass/assets/_headers.scss
@@ -97,3 +97,7 @@
 .essence20 .pr-header-color {
   flex-grow: 0;
 }
+
+.essence20 .pr-header-level-buttons {
+  flex-grow: 0;
+}

--- a/templates/actor/parts/headers/character.hbs
+++ b/templates/actor/parts/headers/character.hbs
@@ -21,8 +21,19 @@
 </div>
 <div class="pr-header-level">
   <label for="system.level" class="resource-label">{{localize 'E20.ActorLevel'}}</label>
-  {{numberInput system.level name="system.level" min=0 step=1}}
+  {{numberInput system.level name="system.level" min=0 step=1 disabled=true class="two-digit-input"}}
 </div>
+{{#unless system.isLocked}}
+  <div class="flexcol pr-header-level-buttons" style="align-items: flex-end">
+    <div></div>
+    <a class="level-up" data-tooltip="E20.LevelUp">
+      <i class="fas fa-up"></i>
+    </a>
+    <a class="level-down" data-tooltip="E20.LevelDown">
+      <i class="fas fa-down"></i>
+    </a>
+  </div>
+{{/unless}}
 <div class="pr-header-color flex-group-center">
   <label for="system.color" class="resource-label">{{localize 'E20.ActorColor'}}</label>
   <input type="color" class="picker" name="system.color" value="{{system.color}}" />

--- a/templates/actor/parts/headers/character.hbs
+++ b/templates/actor/parts/headers/character.hbs
@@ -27,10 +27,10 @@
   {{#if @root.role}}
     <div class="flexcol pr-header-level-buttons" style="align-items: flex-end">
       <div></div>
-      <a class="level-up" data-tooltip="E20.LevelUp" {{#if (eq system.level 20)}}disabled{{/if}}>
+      <a class="level-up" data-tooltip="E20.LevelButtonUp" {{#if (eq system.level 20)}}disabled{{/if}}>
         <i class="fa{{#if (eq system.level 20)}}-regular{{/if}} fa-up"></i>
       </a>
-      <a class="level-down" data-tooltip="E20.LevelDown" {{#if (eq system.level 1)}}disabled{{/if}}>
+      <a class="level-down" data-tooltip="E20.LevelButtonDown" {{#if (eq system.level 1)}}disabled{{/if}}>
         <i class="fa{{#if (eq system.level 1)}}-regular{{/if}} fa-down"></i>
       </a>
     </div>

--- a/templates/actor/parts/headers/character.hbs
+++ b/templates/actor/parts/headers/character.hbs
@@ -42,4 +42,3 @@
 </div>
 {{/inline}}
 {{/"systems/essence20/templates/actor/parts/headers/common.hbs"}}
-e

--- a/templates/actor/parts/headers/character.hbs
+++ b/templates/actor/parts/headers/character.hbs
@@ -24,15 +24,17 @@
   {{numberInput system.level name="system.level" min=0 step=1 disabled=true class="two-digit-input"}}
 </div>
 {{#unless system.isLocked}}
-  <div class="flexcol pr-header-level-buttons" style="align-items: flex-end">
-    <div></div>
-    <a class="level-up" data-tooltip="E20.LevelUp">
-      <i class="fas fa-up"></i>
-    </a>
-    <a class="level-down" data-tooltip="E20.LevelDown">
-      <i class="fas fa-down"></i>
-    </a>
-  </div>
+  {{#if @root.role}}
+    <div class="flexcol pr-header-level-buttons" style="align-items: flex-end">
+      <div></div>
+      <a class="level-up" data-tooltip="E20.LevelUp">
+        <i class="fas fa-up"></i>
+      </a>
+      <a class="level-down" data-tooltip="E20.LevelDown">
+        <i class="fas fa-down"></i>
+      </a>
+    </div>
+  {{/if}}
 {{/unless}}
 <div class="pr-header-color flex-group-center">
   <label for="system.color" class="resource-label">{{localize 'E20.ActorColor'}}</label>
@@ -40,3 +42,4 @@
 </div>
 {{/inline}}
 {{/"systems/essence20/templates/actor/parts/headers/common.hbs"}}
+e

--- a/templates/actor/parts/headers/character.hbs
+++ b/templates/actor/parts/headers/character.hbs
@@ -27,11 +27,11 @@
   {{#if @root.role}}
     <div class="flexcol pr-header-level-buttons" style="align-items: flex-end">
       <div></div>
-      <a class="level-up" data-tooltip="E20.LevelUp">
-        <i class="fas fa-up"></i>
+      <a class="level-up" data-tooltip="E20.LevelUp" {{#if (eq system.level 20)}}disabled{{/if}}>
+        <i class="fa{{#if (eq system.level 20)}}-regular{{/if}} fa-up"></i>
       </a>
-      <a class="level-down" data-tooltip="E20.LevelDown">
-        <i class="fas fa-down"></i>
+      <a class="level-down" data-tooltip="E20.LevelDown" {{#if (eq system.level 1)}}disabled{{/if}}>
+        <i class="fa{{#if (eq system.level 1)}}-regular{{/if}} fa-down"></i>
       </a>
     </div>
   {{/if}}


### PR DESCRIPTION
##### In this PR
- Handling multiple dialogs for newly supported perks when jumping multiple levels only allowed a single dialog to be displayed. We can probably fix this via callbacks, but it will require a good amount of refactoring. In the meantime, this PR disables the level input and instead uses buttons to enforce advancing one level at a time.
- Sets level to 1 on role deletion
- Added some comments to the role adding/deleting code

##### Testing
- Drop some roles and use the leveling arrows, and it should work as expected
- Can't level below 1 or above 20 because of disabled arrows
- Sets level to 1 on role deletion