### PR TITLE
Fixing renderChatMessage warning

### DIFF
--- a/module/chat.mjs
+++ b/module/chat.mjs
@@ -1,5 +1,5 @@
 // Changes the color of the roll total for crits and fumbles
-// Called on the renderChatMessage hook
+// Called on the renderChatMessageHTML hook
 export const highlightCriticalSuccessFailure = function (message, html) {
   if (!message.isRoll || !message.isContentVisible || !message.rolls.length) {
     return;
@@ -8,12 +8,14 @@ export const highlightCriticalSuccessFailure = function (message, html) {
   const [isCrit, isFumble] = _isCritIsFumble(message.rolls[0].dice, message.flags.essence20?.canCritD2);
 
   // Set roll total class to alter its color
+  const diceTotalElement = html.getElementsByClassName('dice-total')[0];
+
   if (isCrit && isFumble) {
-    html.find(".dice-total").addClass("crumble");
+    diceTotalElement.classList.add('crumble');
   } else if (isCrit) {
-    html.find(".dice-total").addClass("critical");
+    diceTotalElement.classList.add('critical');
   } else if (isFumble) {
-    html.find(".dice-total").addClass("fumble");
+    diceTotalElement.classList.add('fumble');
   }
 };
 

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -192,7 +192,7 @@ Hooks.once("ready", async function () {
 });
 
 /* eslint-disable no-unused-vars */
-Hooks.on("renderChatMessage", (app, html, data) => {
+Hooks.on("renderChatMessageHTML", (app, html, data) => {
   highlightCriticalSuccessFailure(app, html, data);
 });
 


### PR DESCRIPTION
##### In this PR
- Fixing renderChatMessage warning
- Had to tweak `highlightCriticalSuccessFailure()` since JQuery is no longer used

##### Testing
- Should no longer see the warning
- Crit/fumble coloring should still work. You can hard code `isCrit` and `isFumble` in `chat.mjs` to make things easier.
