### PR TITLE
Adding morphing/transforming support for TAH

### DIFF
--- a/module/apps/transform-option-selector.mjs
+++ b/module/apps/transform-option-selector.mjs
@@ -4,10 +4,10 @@ import { getFormData } from "../helpers/application.mjs";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export default class TransformOptionSelector extends HandlebarsApplicationMixin(ApplicationV2) {
-  constructor(choices, actorSheet, altModes, title){
+  constructor(choices, actor, altModes, title){
     super();
     this._choices = choices;
-    this._actorSheet = actorSheet;
+    this._actor = actor;
     this._altModes = altModes;
     this._title = title;
   }
@@ -54,6 +54,6 @@ export default class TransformOptionSelector extends HandlebarsApplicationMixin(
   static async myFormHandler(event, form, formData) {
     const selectedForm = getFormData(formData.object);
 
-    _altModeSelect(this._actorSheet, this._altModes, selectedForm);
+    _altModeSelect(this._actor, this._altModes, selectedForm);
   }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -4,6 +4,7 @@ import { resizeTokens } from "../helpers/actor.mjs";
 import { getItemsOfType } from "../helpers/utils.mjs";
 import { roleValueChange } from "../sheet-handlers/role-handler.mjs";
 import { onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
+import { onTransform } from "../sheet-handlers/transformer-handler.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -371,5 +372,12 @@ export class Essence20Actor extends Actor {
    */
   morph() {
     onMorph(this);
+  }
+
+  /**
+   * Helper for calling onTransform() for TAH
+   */
+  transform() {
+    onTransform(this);
   }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -4,7 +4,7 @@ import { resizeTokens } from "../helpers/actor.mjs";
 import { getItemsOfType } from "../helpers/utils.mjs";
 import { roleValueChange } from "../sheet-handlers/role-handler.mjs";
 import { onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
-import { onTransform } from "../sheet-handlers/transformer-handler.mjs";
+import { onTransformUuid } from "../sheet-handlers/transformer-handler.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -375,9 +375,9 @@ export class Essence20Actor extends Actor {
   }
 
   /**
-   * Helper for calling onTransform() for TAH
+   * Helper for calling onTransformUuid() for TAH
    */
-  transform() {
-    onTransform(this);
+  transform(altModeUuid=null) {
+    onTransformUuid(this, altModeUuid);
   }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -3,6 +3,7 @@ import { RollDialog } from "../helpers/roll-dialog.mjs";
 import { resizeTokens } from "../helpers/actor.mjs";
 import { getItemsOfType } from "../helpers/utils.mjs";
 import { roleValueChange } from "../sheet-handlers/role-handler.mjs";
+import { onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -363,5 +364,12 @@ export class Essence20Actor extends Actor {
         }
       }
     }
+  }
+
+  /**
+   * Helper for calling onMorph() for TAH
+   */
+  morph() {
+    onMorph(this);
   }
 }

--- a/module/sheet-handlers/power-ranger-handler.mjs
+++ b/module/sheet-handlers/power-ranger-handler.mjs
@@ -2,10 +2,9 @@ import { changeTokenImage } from "../helpers/actor.mjs";
 
 /**
  * Handle morphing an Actor
- * @param {ActorSheet} actorSheet The ActorSheet for the Actor being Morphed
+ * @param {Actor} actor The Actor being Morphed
  */
-export async function onMorph(actorSheet) {
-  const actor = actorSheet.actor;
+export async function onMorph(actor) {
   let newImage = null;
   if (actor.system.isMorphed) {
     newImage = actor.system.image.unmorphed;
@@ -20,5 +19,5 @@ export async function onMorph(actorSheet) {
 
   await actor.update({
     "system.isMorphed": !actor.system.isMorphed,
-  }).then(actorSheet.render(false));
+  });
 }

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -48,6 +48,20 @@ export async function onTransform(actor) {
 }
 
 /**
+ * Handles transforming into the given alt-mode, or bot-mode if none is provided
+ * @param {Actor} actor The Actor being transformed
+ * @param {String} altModeUuid The UUID of the alt-mode being transformed into
+ */
+export async function onTransformUuid(actor, altModeUuid=null) {
+  if (altModeUuid) {
+    const altMode = await fromUuid(altModeUuid);
+    _transformAltMode(actor, altMode);
+  } else {
+    _transformBotMode(actor);
+  }
+}
+
+/**
  * Handle Transforming back into the Bot Mode
  * @param {Actor} actor The Actor being transformed
  * @private

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -20,10 +20,9 @@ export async function onAltModeDelete(actorSheet, altMode) {
 
 /**
  * Handles clicking the transform button
- * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @param {Actor} actor The Actor being transformed
  */
-export async function onTransform(actorSheet) {
-  const actor = actorSheet.actor;
+export async function onTransform(actor) {
   const altModes = getItemsOfType("altMode", actor.items);
   const isTransformed = actor.system.isTransformed;
 
@@ -37,24 +36,23 @@ export async function onTransform(actorSheet) {
     ui.notifications.warn(game.i18n.localize('E20.AltModeNone'));
   } else if (altModes.length > 1) {              // Select from multiple alt-modes
     if (!isTransformed) {
-      _showAltModeChoiceDialog(actorSheet, altModes, false); // More than 1 altMode and not transformed
+      _showAltModeChoiceDialog(actor, altModes, false); // More than 1 altMode and not transformed
     } else {
-      _showAltModeChoiceDialog(actorSheet, altModes, true);  // More than 1 altMode and transformed
+      _showAltModeChoiceDialog(actor, altModes, true);  // More than 1 altMode and transformed
     }
   } else {                                       // Alt-mode/bot-mode toggle
     isTransformed
-      ? _transformBotMode(actorSheet)
-      : _transformAltMode(actorSheet, altModes[0]);
+      ? _transformBotMode(actor)
+      : _transformAltMode(actor, altModes[0]);
   }
 }
 
 /**
  * Handle Transforming back into the Bot Mode
- * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @param {Actor} actor The Actor being transformed
  * @private
  */
-async function _transformBotMode(actorSheet) {
-  const actor = actorSheet.actor;
+async function _transformBotMode(actor) {
   const width = CONFIG.E20.tokenSizes[actor.system.size].width;
   const height = CONFIG.E20.tokenSizes[actor.system.size].height;
   resizeTokens(actor, width, height);
@@ -69,17 +67,16 @@ async function _transformBotMode(actorSheet) {
     "system.isTransformed": false,
     "system.altModeId": "",
     "system.altModesize": "",
-  }).then(actorSheet.render(false));
+  });
 }
 
 /**
  * Handles Transforming into an Alt Mode
- * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @param {Actorheet} actor The Actor being transformed
  * @param {AltMode} altMode The alt-mode that was selected to transform into
  * @private
  */
-async function _transformAltMode(actorSheet, altMode) {
-  const actor = actorSheet.actor;
+async function _transformAltMode(actor, altMode) {
   const width = CONFIG.E20.tokenSizes[altMode.system.altModesize].width;
   const height = CONFIG.E20.tokenSizes[altMode.system.altModesize].height;
   resizeTokens(actor, width, height);
@@ -94,18 +91,17 @@ async function _transformAltMode(actorSheet, altMode) {
     "system.altModesize": altMode.system.altModesize,
     "system.altModeId": altMode._id,
     "system.isTransformed": true,
-  }).then(actorSheet.render(false));
+  });
 }
 
 /**
  * Creates the Alt Mode choice list dialog
- * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @param {Actor} actor The Actor being transformed
  * @param {AltMode[]} altModes A list of the available Alt Modes
  * @param {Boolean} isTransformed Whether the Transformer is transformed or not
  * @private
  */
-async function _showAltModeChoiceDialog(actorSheet, altModes, isTransformed) {
-  const actor = actorSheet.actor;
+async function _showAltModeChoiceDialog(actor, altModes, isTransformed) {
   const choices = {};
   if (isTransformed) {
     choices["BotMode"] = {
@@ -124,17 +120,17 @@ async function _showAltModeChoiceDialog(actorSheet, altModes, isTransformed) {
   }
 
   const title = "E20.AltModeChoice";
-  new TransformOptionSelector(choices, actorSheet, altModes, title).render(true);
+  new TransformOptionSelector(choices, actor, altModes, title).render(true);
 }
 
 /**
  * Handles selecting an Alt Mode from the Alt Mode dialog
- * @param {ActorSheet} actorSheet The ActorSheet being transformed
+ * @param {Actor} actor The Actor being transformed
  * @param {AltMode[]} altModes A list of the available Alt Modes
  * @param {Object} options The options resulting from _showAltModeDialog()
  * @private
  */
-export async function _altModeSelect(actorSheet, altModes, selectedForm) {
+export async function _altModeSelect(actor, altModes, selectedForm) {
   let transformation = null;
 
   if (!selectedForm) {
@@ -142,7 +138,7 @@ export async function _altModeSelect(actorSheet, altModes, selectedForm) {
   }
 
   if (selectedForm == "BotMode") {
-    _transformBotMode(actorSheet);
+    _transformBotMode(actor);
   } else {
     for (const mode of altModes) {
       if (selectedForm == mode._id) {
@@ -152,7 +148,7 @@ export async function _altModeSelect(actorSheet, altModes, selectedForm) {
     }
 
     if (transformation) {
-      _transformAltMode(actorSheet, transformation);
+      _transformAltMode(actor, transformation);
     }
   }
 }

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -483,7 +483,7 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
     html.find(".effect-control").click(ev => onManageActiveEffect(ev, this.actor));
 
     // Morph Button
-    html.find('.morph').click(() => onMorph(this));
+    html.find('.morph').click(() => onMorph(this.actor));
 
     // Transform Button
     html.find('.transform').click(() => onTransform(this));

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -486,7 +486,7 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
     html.find('.morph').click(() => onMorph(this.actor));
 
     // Transform Button
-    html.find('.transform').click(() => onTransform(this));
+    html.find('.transform').click(() => onTransform(this.actor));
 
     //Equip Shield
     html.find('.shield-equip').change(ev => onShieldEquipToggle(ev, this));


### PR DESCRIPTION
##### In this PR
- Exposing `morph()` and `transform()` in `Essence20Actor` so that it can be used via TAH
- Adding `onTransformUuid()` so that the transform dialog can be skipped

##### Testing
- Normal transforming/morphing via actor sheet should still work
- Use in conjunction with https://github.com/phildominguez/token-action-hud-essence20/pull/9
- "Morph" and "Transform" should only appear for actors that can do so
- Icons should match the morph/alt-mode images
- Morphing/transforming via TAH should work as expected
- "Bot Mode" only appears when not in bot mode