### PR TITLE
Adding morphing/transforming support for TAH

### DIFF
--- a/module/apps/transform-option-selector.mjs
+++ b/module/apps/transform-option-selector.mjs
@@ -4,10 +4,10 @@ import { getFormData } from "../helpers/application.mjs";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export default class TransformOptionSelector extends HandlebarsApplicationMixin(ApplicationV2) {
-  constructor(choices, actorSheet, altModes, title){
+  constructor(choices, actor, altModes, title){
     super();
     this._choices = choices;
-    this._actorSheet = actorSheet;
+    this._actor = actor;
     this._altModes = altModes;
     this._title = title;
   }
@@ -54,6 +54,6 @@ export default class TransformOptionSelector extends HandlebarsApplicationMixin(
   static async myFormHandler(event, form, formData) {
     const selectedForm = getFormData(formData.object);
 
-    _altModeSelect(this._actorSheet, this._altModes, selectedForm);
+    _altModeSelect(this._actor, this._altModes, selectedForm);
   }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -3,6 +3,8 @@ import { RollDialog } from "../helpers/roll-dialog.mjs";
 import { resizeTokens } from "../helpers/actor.mjs";
 import { getItemsOfType } from "../helpers/utils.mjs";
 import { roleValueChange } from "../sheet-handlers/role-handler.mjs";
+import { onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
+import { onTransformUuid } from "../sheet-handlers/transformer-handler.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -363,5 +365,19 @@ export class Essence20Actor extends Actor {
         }
       }
     }
+  }
+
+  /**
+   * Helper for calling onMorph() for TAH
+   */
+  morph() {
+    onMorph(this);
+  }
+
+  /**
+   * Helper for calling onTransformUuid() for TAH
+   */
+  transform(altModeUuid=null) {
+    onTransformUuid(this, altModeUuid);
   }
 }

--- a/module/sheet-handlers/power-ranger-handler.mjs
+++ b/module/sheet-handlers/power-ranger-handler.mjs
@@ -2,10 +2,9 @@ import { changeTokenImage } from "../helpers/actor.mjs";
 
 /**
  * Handle morphing an Actor
- * @param {ActorSheet} actorSheet The ActorSheet for the Actor being Morphed
+ * @param {Actor} actor The Actor being Morphed
  */
-export async function onMorph(actorSheet) {
-  const actor = actorSheet.actor;
+export async function onMorph(actor) {
   let newImage = null;
   if (actor.system.isMorphed) {
     newImage = actor.system.image.unmorphed;
@@ -20,5 +19,5 @@ export async function onMorph(actorSheet) {
 
   await actor.update({
     "system.isMorphed": !actor.system.isMorphed,
-  }).then(actorSheet.render(false));
+  });
 }

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -23,7 +23,6 @@ export async function onAltModeDelete(actorSheet, altMode) {
  * @param {Actor} actor The Actor being transformed
  */
 export async function onTransform(actor) {
-  const actor = actorSheet.actor;
   const altModes = getItemsOfType("altMode", actor.items);
   const isTransformed = actor.system.isTransformed;
 
@@ -68,7 +67,6 @@ export async function onTransformUuid(actor, altModeUuid=null) {
  * @private
  */
 async function _transformBotMode(actor) {
-  const actor = actorSheet.actor;
   const width = CONFIG.E20.tokenSizes[actor.system.size].width;
   const height = CONFIG.E20.tokenSizes[actor.system.size].height;
   resizeTokens(actor, width, height);
@@ -93,7 +91,6 @@ async function _transformBotMode(actor) {
  * @private
  */
 async function _transformAltMode(actor, altMode) {
-  const actor = actorSheet.actor;
   const width = CONFIG.E20.tokenSizes[altMode.system.altModesize].width;
   const height = CONFIG.E20.tokenSizes[altMode.system.altModesize].height;
   resizeTokens(actor, width, height);
@@ -119,7 +116,6 @@ async function _transformAltMode(actor, altMode) {
  * @private
  */
 async function _showAltModeChoiceDialog(actor, altModes, isTransformed) {
-  const actor = actorSheet.actor;
   const choices = {};
   if (isTransformed) {
     choices["BotMode"] = {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -483,10 +483,10 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
     html.find(".effect-control").click(ev => onManageActiveEffect(ev, this.actor));
 
     // Morph Button
-    html.find('.morph').click(() => onMorph(this));
+    html.find('.morph').click(() => onMorph(this.actor));
 
     // Transform Button
-    html.find('.transform').click(() => onTransform(this));
+    html.find('.transform').click(() => onTransform(this.actor));
 
     //Equip Shield
     html.find('.shield-equip').change(ev => onShieldEquipToggle(ev, this));


### PR DESCRIPTION
##### In this PR
- Exposing `morph()` and `transform()` in `Essence20Actor` so that it can be used via TAH
- Adding `onTransformUuid()` so that the transform dialog can be skipped

##### Testing
- Normal transforming/morphing via actor sheet should still work
- Use in conjunction with https://github.com/phildominguez/token-action-hud-essence20/pull/9
- "Morph" and "Transform" should only appear for actors that can do so
- Icons should match the morph/alt-mode images
- Morphing/transforming via TAH should work as expected
- "Bot Mode" only appears when not in bot mode