### PR TITLE
Fix for TAH bot-mode actor image

### DIFF
--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -54,6 +54,10 @@ export async function onTransform(actor) {
  */
 export async function onTransformUuid(actor, altModeUuid=null) {
   if (altModeUuid) {
+    await actor.update ({
+      "system.image.botmode": actor.prototypeToken.texture.src,
+    });
+    
     const altMode = await fromUuid(altModeUuid);
     _transformAltMode(actor, altMode);
   } else {


### PR DESCRIPTION
##### In this PR
- The bot-mode image wasn't being set when transforming via TAH. Fixing that to match transforming via sheet.
- To be used in conjunction with https://github.com/phildominguez/token-action-hud-essence20/pull/10

##### Testing
- Create a TF that has a normal image and images for its alt-mode
- Transforming via TAH should change its token correctly
