### PR TITLE
Adding EOF newline lint rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -43,5 +43,9 @@ module.exports = {
       'error',
       'always-multiline',
     ],
+    'eol-last': [
+      'error',
+      'always',
+    ],
   },
 };


### PR DESCRIPTION
##### In this PR
- Adding a new rule to the linter to require newlines at the end of files

##### Testing
- Remove the newline from the end of a file and running `npm run lint` should fail
- `npm run lint-fix` will fix it
