### PR TITLE
Fix for profile image stretching

### DIFF
--- a/css/essence20.css
+++ b/css/essence20.css
@@ -516,6 +516,7 @@ body.game .window-app {
   margin-right: 10px;
   border: 4px solid #b5b1b1;
   border-radius: 15px;
+  object-fit: contain;
 }
 
 .essence20 .sheet-header h1.charname {

--- a/sass/assets/_headers.scss
+++ b/sass/assets/_headers.scss
@@ -34,6 +34,7 @@
   margin-right: 10px;
   border: v.$border;
   border-radius: 15px;
+  object-fit: contain;
 }
 
 .essence20 .sheet-header h1.charname {


### PR DESCRIPTION
##### In this PR
- Fix for profile image stretching on actor sheets

##### Testing
- Use an image with non-square dimensions as an actor's profile image. It should fit into the container and no longer stretch.
