### PR TITLE
Fixes for WE descriptions

### DIFF
--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -243,11 +243,13 @@ export class Dice {
     const attackRollStr = this._localize('E20.RollTypeAttack');
     const effectStr = this._localize('E20.WeaponEffect');
     const damageType = this._localize(E20.damageTypes[weaponEffect.system.damageType]);
+    const descStr = this._localize('E20.ItemDescription');
     const noneStr = "";
 
     let label = `<b>${attackRollStr}</b> - ${weaponEffect.name} (${rolledSkillStr})`;
     label += `${this._getEdgeSnagText(skillRollOptions.edge, skillRollOptions.snag)}<br>`;
     label += `<b>${effectStr}</b> - ${weaponEffect.system.damageValue || noneStr} ${damageType}<br>`;
+    label += `<b>${descStr}</b>:${weaponEffect.system.description || noneStr}<br>`;
 
     return label;
   }

--- a/module/dice.test.js
+++ b/module/dice.test.js
@@ -387,7 +387,7 @@ describe("rollSkill", () => {
     expect(dice._rollSkillHelper).toHaveBeenCalledWith(
       'd20 + 0',
       mockActor,
-      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics)<br><b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>",
+      "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics)<br><b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br><b>E20.ItemDescription</b>:<br>",
       false,
     );
   });
@@ -557,7 +557,7 @@ describe("_getWeaponRollLabel", () => {
 
     const expected =
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics)<br>" +
-      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br><b>E20.ItemDescription</b>:<br>";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
@@ -573,7 +573,7 @@ describe("_getWeaponRollLabel", () => {
 
     const expected =
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics) E20.RollWithAnEdge<br>" +
-      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br><b>E20.ItemDescription</b>:<br>";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
@@ -589,7 +589,7 @@ describe("_getWeaponRollLabel", () => {
 
     const expected =
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (E20.SkillAthletics) E20.RollWithASnag<br>" +
-      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br><b>E20.ItemDescription</b>:<br>";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect)).toEqual(expected);
   });
@@ -605,7 +605,7 @@ describe("_getWeaponRollLabel", () => {
 
     const expected =
       "<b>E20.RollTypeAttack</b> - Zeo Power Clubs Effect (Foo Role Skill)<br>" +
-      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br>";
+      "<b>E20.WeaponEffect</b> - 1 E20.DamageBlunt<br><b>E20.ItemDescription</b>:<br>";
 
     expect(dice._getWeaponRollLabel(dataset, skillRollOptions, weaponEffect, 'Foo Role Skill')).toEqual(expected);
   });

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -201,6 +201,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
     img: droppedItem.img,
     name: droppedItem.name,
     type: droppedItem.type,
+    description: droppedItem.description,
   };
 
   switch (targetItem.type) {

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -1,5 +1,5 @@
 {{#if item.system }}
-  <div>{{localize 'E20.ItemDescription'}}: {{{item.description}}}</div>
+  <div>{{localize 'E20.ItemDescription'}}: {{{item.system.description}}}</div>
   <div class="chip-section">
     <span class="chip" name="chip.weapon.classification">
       {{#if parentItem.system.isPoison}}


### PR DESCRIPTION
##### In this PR
- Fixing some description display issues for WEs
- Note: Due to an issue with attachments not updating, the description won't show up when you expand a WE in a container if it was modified post-dropping

##### Testing
- On an actor, add a weapon and a WE with a description
- The description should be displayed when using the info button or when making a roll