### PR TITLE
Fix for attachment details description

### DIFF
--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -201,7 +201,7 @@ export async function setEntryAndAddItem(droppedItem, targetItem) {
     img: droppedItem.img,
     name: droppedItem.name,
     type: droppedItem.type,
-    description: droppedItem.description,
+    description: droppedItem.system.description,
   };
 
   switch (targetItem.type) {


### PR DESCRIPTION
##### In this PR
- Fix for attachment details description on actor sheets

##### Testing
- Drop a WE with a description onto an actor's weapon. Expanding the WE should show the description.
