### PR TITLE
Caching roles for Item.getData bottleneck

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -13,8 +13,21 @@ export class Essence20Item extends Item {
     this._dice = new Dice(ChatMessage, new RollDialog(), game.i18n);
   }
 
+
+  /** @override */
+  async delete(operation) {
+    super.delete(operation);
+
+    if (this.type == 'role' && this.pack) {
+      updateRoleCache();
+    }
+  }
+
+  /** @override */
   async _onCreate(data, options, userId) {
-    if (this.type == 'role') {
+    super._onCreate(data, options, userId);
+
+    if (this.type == 'role'&& this.pack) {
       updateRoleCache();
     }
   }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1,6 +1,7 @@
 import { Dice } from "../dice.mjs";
 import { RollDialog } from "../helpers/roll-dialog.mjs";
 import { createEntry } from "../sheet-handlers/attachment-handler.mjs";
+import { updateRoleCache } from "../helpers/utils.mjs";
 
 /**
  * Extend the basic Item with some very simple modifications.
@@ -10,6 +11,12 @@ export class Essence20Item extends Item {
   constructor(item, options) {
     super(item, options);
     this._dice = new Dice(ChatMessage, new RollDialog(), game.i18n);
+  }
+
+  async _onCreate(data, options, userId) {
+    if (this.type == 'role') {
+      updateRoleCache();
+    }
   }
 
   /**
@@ -29,6 +36,10 @@ export class Essence20Item extends Item {
   /** @override */
   _onUpdate(change, options, userId) {
     super._onUpdate(change, options, userId);
+
+    if (this.type == 'role') {
+      updateRoleCache();
+    }
 
     // Update the entry on the parent if this is a child Item
     if (['weaponEffect', 'upgrade'].includes(this.type)) {

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -190,7 +190,23 @@ Hooks.once("ready", async function () {
       return false;
     }
   });
+
+  // Caches all roles from compendium packs to prevent repeated
+  // pack.getDocuments() calls in Item.getData()
+  _getAllPackRoles().then(allRoles => CONFIG.E20.allPackRoles = allRoles);
 });
+
+/* Helper to fetch all Roles from compendium packs */
+async function _getAllPackRoles() {
+  let allRoles = [];
+
+  for (const pack of game.packs) {
+    const packRoles = await pack.getDocuments({ type: "role" });
+    allRoles = allRoles.concat(packRoles);
+  }
+
+  return allRoles;
+}
 
 /* eslint-disable no-unused-vars */
 Hooks.on("renderChatMessageHTML", (app, html, data) => {

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -15,6 +15,7 @@ import { preloadHandlebarsTemplates } from "./helpers/templates.mjs";
 import { getNumActions } from "./helpers/actor.mjs";
 import { performPreLocalization } from "./helpers/localize.mjs";
 import { migrateWorld } from "./migration.mjs";
+import { updateRoleCache } from "./helpers/utils.mjs";
 
 function registerSystemSettings() {
   game.settings.register("essence20", "systemMigrationVersion", {
@@ -191,22 +192,8 @@ Hooks.once("ready", async function () {
     }
   });
 
-  // Caches all roles from compendium packs to prevent repeated
-  // pack.getDocuments() calls in Item.getData()
-  _getAllPackRoles().then(allRoles => CONFIG.E20.allPackRoles = allRoles);
+  updateRoleCache();
 });
-
-/* Helper to fetch all Roles from compendium packs */
-async function _getAllPackRoles() {
-  let allRoles = [];
-
-  for (const pack of game.packs) {
-    const packRoles = await pack.getDocuments({ type: "role" });
-    allRoles = allRoles.concat(packRoles);
-  }
-
-  return allRoles;
-}
 
 /* eslint-disable no-unused-vars */
 Hooks.on("renderChatMessageHTML", (app, html, data) => {

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -1107,3 +1107,5 @@ E20.CombinedEssenceRankNames = [
   ...E20.EssenceRankNames,
   ...E20.TFEssenceRankNames,
 ];
+
+E20.allPackRoles = null;

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -84,3 +84,23 @@ export function getShiftedSkill(skill, shift, actor) {
 
   return [newShift, skillString];
 }
+
+/*
+ * Caches all roles from compendium packs to prevent repeated
+ * pack.getDocuments() calls in Item.getData()
+ */
+export function updateRoleCache() {
+  _getAllPackRoles().then(allRoles => CONFIG.E20.allPackRoles = allRoles);
+}
+
+/* Helper to fetch all Roles from compendium packs */
+async function _getAllPackRoles() {
+  let allRoles = [];
+
+  for (const pack of game.packs) {
+    const packRoles = await pack.getDocuments({ type: "role" });
+    allRoles = allRoles.concat(packRoles);
+  }
+
+  return allRoles;
+}

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -70,7 +70,10 @@ export class Essence20ItemSheet extends foundry.appv1.sheets.ItemSheet {
     context.system = itemData.system;
     context.system.description = await foundry.applications.ux.TextEditor.implementation.enrichHTML(itemData.system.description);
     context.flags = itemData.flags;
-    context.roles = await _getVersionRoles(itemData);
+
+    if (this.item.type == 'perk') {
+      context.roles = await _getVersionRoles(itemData);
+    }
 
     return context;
   }

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -201,14 +201,12 @@ export class Essence20ItemSheet extends foundry.appv1.sheets.ItemSheet {
  */
 async function _getVersionRoles(itemData) {
   const versionRoles = {};
-  for (const pack of game.packs) {
-    const selection = await pack.getDocuments({ type: "role" });
-    for (const role of selection) {
-      if (role.system.version == itemData.system.version){
-        versionRoles[role.name] = {
-          type: role.type,
-        };
-      }
+
+  for (const role of CONFIG.E20.allPackRoles) {
+    if (role.system.version == itemData.system.version){
+      versionRoles[role.name] = {
+        type: role.type,
+      };
     }
   }
 

--- a/templates/item/parts/sub-perk-drop.hbs
+++ b/templates/item/parts/sub-perk-drop.hbs
@@ -25,7 +25,7 @@
     {{/each}}
   </div>
 {{else}}
-  <label>{{localize 'E20.ItemDrop'}}</label>
+  <label>{{localize 'E20.ItemDrop' type=(localize (concat "TYPES.Item." type))}}</label>
 {{/itemsContainType}}
 {{/inline}}
 {{/"systems/essence20/templates/item/parts/sheet-field.hbs"}}


### PR DESCRIPTION
##### In this PR
- Perks make use of a list of all roles available within the world, which includes slow queries within compendium packs. This was being done every time an item sheet was opened. This change creates a cache to remove the bottleneck, and only generates the roles list for perk items.
- The `ready` hook now calls a helper method to cache, and the cache is updated when a pack role is created/updated

##### Testing
- Opening/updating item sheets should now be quicker
- Roles available still works correctly
- Might be a good idea to add a breakpoint to `module/helpers/utils.mjs` line 93 so you can confirm every time the cache is generated
  - You can also type `CONFIG.E20.allPackRoles` in the console
- The cache should be generated on initial load
- Within packs, the cache should be regenerated on creation, update, and deletion
- List of roles should populate for Faction perks that add a role variant
