### PR TITLE
More checks for role cache

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -19,7 +19,7 @@ export class Essence20Item extends Item {
     super.delete(operation);
 
     if (this.type == 'role' && this.pack) {
-      updateRoleCache();
+      await updateRoleCache();
     }
   }
 
@@ -28,7 +28,7 @@ export class Essence20Item extends Item {
     super._onCreate(data, options, userId);
 
     if (this.type == 'role'&& this.pack) {
-      updateRoleCache();
+      await updateRoleCache();
     }
   }
 
@@ -47,11 +47,11 @@ export class Essence20Item extends Item {
   }
 
   /** @override */
-  _onUpdate(change, options, userId) {
+  async _onUpdate(change, options, userId) {
     super._onUpdate(change, options, userId);
 
     if (this.type == 'role') {
-      updateRoleCache();
+      await updateRoleCache();
     }
 
     // Update the entry on the parent if this is a child Item
@@ -64,7 +64,7 @@ export class Essence20Item extends Item {
         const entry = createEntry(this, parentItem);
         const pathPrefix = "system.items";
 
-        parentItem.update({
+        await parentItem.update({
           [`${pathPrefix}.${key}`]: entry,
         });
       }

--- a/module/essence20.mjs
+++ b/module/essence20.mjs
@@ -192,7 +192,7 @@ Hooks.once("ready", async function () {
     }
   });
 
-  updateRoleCache();
+  await updateRoleCache();
 });
 
 /* eslint-disable no-unused-vars */

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -89,8 +89,9 @@ export function getShiftedSkill(skill, shift, actor) {
  * Caches all roles from compendium packs to prevent repeated
  * pack.getDocuments() calls in Item.getData()
  */
-export function updateRoleCache() {
-  _getAllPackRoles().then(allRoles => CONFIG.E20.allPackRoles = allRoles);
+export async function updateRoleCache() {
+  const allRoles = await _getAllPackRoles();
+  CONFIG.E20.allPackRoles = allRoles;
 }
 
 /* Helper to fetch all Roles from compendium packs */

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -1,5 +1,6 @@
 import { onManageActiveEffect, prepareActiveEffectCategories } from "../helpers/effects.mjs";
 import { onManageSelectTrait } from "../helpers/traits.mjs";
+import { updateRoleCache } from "../helpers/utils.mjs";
 import { setEntryAndAddItem } from "../sheet-handlers/attachment-handler.mjs";
 
 /**
@@ -204,6 +205,11 @@ export class Essence20ItemSheet extends foundry.appv1.sheets.ItemSheet {
  */
 async function _getVersionRoles(itemData) {
   const versionRoles = {};
+
+  // Should be generated on world load, but just in case
+  if (CONFIG.E20.allPackRoles == null) {
+    await updateRoleCache();
+  }
 
   for (const role of CONFIG.E20.allPackRoles) {
     if (role.system.version == itemData.system.version){


### PR DESCRIPTION
##### In this PR
- More checks for the role cache, and `await`ing it too

##### Testing
- After world load, doing `CONFIG.E20.allPackRoles` in the console should yield roles
- Do `CONFIG.E20.allPackRoles = null`. `CONFIG.E20.allPackRoles` should now yield `null`
- Open a perk sheet. `CONFIG.E20.allPackRoles` should yield roles again.
