### PR TITLE
 Add reach and range to weapon effect display

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -845,6 +845,7 @@
     "WeaponRange": "Range",
     "WeaponRangeLong": "Long",
     "WeaponRangeMin": "Min",
+    "WeaponRangeReach": "Reach",
     "WeaponRangeReachMultiplier": "Reach Multiplier",
     "WeaponRangeValue": "Value",
     "WeaponRequirements": "Requirements",

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -35,9 +35,9 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
 
   prepareDerivedData() {
     if (["megaform", "npc", "playerCharacter", "vehicle", "zord"].includes(this.parent.parent.type)) {
-      let reachMultiplier = 0;
+      let reachMultiplier = 1;
       const actorReach = CONFIG.E20.actorReach[this.parent.parent.system.size];
-      if (this.range.reachMultiplier > 0) {
+      if (this.range.reachMultiplier > 1) {
         reachMultiplier = this.range.reachMultiplier;
       }
 

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -29,6 +29,20 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
         value: makeInt(null),
       }),
       shiftDown: makeInt(0),
+      totalReach: makeInt(0),
     };
+  }
+
+  prepareDerivedData() {
+    if (["megaform", "npc", "playerCharacter", "vehicle", "zord"].includes(this.parent.parent.type)) {
+      let reachMultiplier = 1;
+      const actorReach = CONFIG.E20.actorReach[this.parent.parent.system.size];
+      if (this.range.reachMultiplier >1) {
+        reachMultiplier = this.range.reachMultiplier;
+      }
+      const totalReach = actorReach * reachMultiplier;
+      this.totalReach = totalReach;
+    }
+    return super.prepareDerivedData;
   }
 }

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -37,7 +37,7 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
     if (["megaform", "npc", "playerCharacter", "vehicle", "zord"].includes(this.parent.parent.type)) {
       let reachMultiplier = 0;
       const actorReach = CONFIG.E20.actorReach[this.parent.parent.system.size];
-      if (this.range.reachMultiplier > 1) {
+      if (this.range.reachMultiplier > 0) {
         reachMultiplier = this.range.reachMultiplier;
       }
 

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -24,7 +24,7 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
       radius: makeInt(0),
       range: new fields.SchemaField({
         min: makeInt(null),
-        reachMultiplier: makeInt(0),
+        reachMultiplier: makeInt(null),
         long: makeInt(null),
         value: makeInt(null),
       }),

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -35,9 +35,9 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
 
   prepareDerivedData() {
     if (["megaform", "npc", "playerCharacter", "vehicle", "zord"].includes(this.parent.parent.type)) {
-      let reachMultiplier = 1;
+      let reachMultiplier = 0;
       const actorReach = CONFIG.E20.actorReach[this.parent.parent.system.size];
-      if (this.range.reachMultiplier >1) {
+      if (this.range.reachMultiplier > 1) {
         reachMultiplier = this.range.reachMultiplier;
       }
       const totalReach = actorReach * reachMultiplier;

--- a/module/data/item/weapon-effect.mjs
+++ b/module/data/item/weapon-effect.mjs
@@ -40,9 +40,11 @@ export class WeaponEffectItemData extends foundry.abstract.TypeDataModel {
       if (this.range.reachMultiplier > 1) {
         reachMultiplier = this.range.reachMultiplier;
       }
+
       const totalReach = actorReach * reachMultiplier;
       this.totalReach = totalReach;
     }
+
     return super.prepareDerivedData;
   }
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -51,6 +51,7 @@ export class Essence20Actor extends Actor {
             if (item.system.range.reachMultiplier > 1) {
               reachMultiplier = item.system.range.reachMultiplier;
             }
+
             const totalReach = actorReach * reachMultiplier;
 
             item.system.totalReach = totalReach;
@@ -61,7 +62,7 @@ export class Essence20Actor extends Actor {
 
             if (parentItem && key) {
               const entry = await createEntry(item, parentItem);
-               const pathPrefix = "system.items";
+              const pathPrefix = "system.items";
 
               await parentItem.update({
                 [`${pathPrefix}.${key}`]: entry,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -5,6 +5,7 @@ import { getItemsOfType } from "../helpers/utils.mjs";
 import { roleValueChange } from "../sheet-handlers/role-handler.mjs";
 import { onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
 import { onTransformUuid } from "../sheet-handlers/transformer-handler.mjs";
+import { createEntry } from "../sheet-handlers/attachment-handler.mjs";
 
 /**
  * Extend the base Actor document by defining a custom roll data structure which is ideal for the Simple system.
@@ -41,6 +42,32 @@ export class Essence20Actor extends Actor {
           changed.prototypeToken ||= {};
           changed.prototypeToken.height = height;
           changed.prototypeToken.width = width;
+        }
+
+        for (let item of this.items) {
+          if (item.type == 'weaponEffect' && item.system.classification.style == 'melee') {
+            let reachMultiplier = 1;
+            const actorReach = CONFIG.E20.actorReach[newSize];
+            if (item.system.range.reachMultiplier > 1) {
+              reachMultiplier = item.system.range.reachMultiplier;
+            }
+            const totalReach = actorReach * reachMultiplier;
+
+            item.system.totalReach = totalReach;
+
+            const parentId = item.flags.essence20.parentId;
+            const parentItem = await this.items.get(parentId);
+            const key = item.flags.essence20.collectionId;
+
+            if (parentItem && key) {
+              const entry = await createEntry(item, parentItem);
+               const pathPrefix = "system.items";
+
+              await parentItem.update({
+                [`${pathPrefix}.${key}`]: entry,
+              });
+            }
+          }
         }
       }
     }

--- a/module/helpers/config.mjs
+++ b/module/helpers/config.mjs
@@ -705,6 +705,21 @@ E20.actorSizes = {
 };
 preLocalize("actorSizes");
 
+//Reach by size
+E20.actorReach = {
+  small: 2,
+  common: 5,
+  large: 5,
+  long: 5,
+  huge: 10,
+  extended: 10,
+  gigantic: 15,
+  extended2: 15,
+  towering: 20,
+  extended3: 15,
+  titanic: 25,
+};
+
 // Subtypes of megaforms
 E20.megaformSubtypes = {
   megaformCombiner: "E20.MegaformSubtypeCombiner",

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -304,6 +304,7 @@ export function createEntry(droppedItem, targetItem) {
       entry['range'] = droppedItem.system.range;
       entry['shiftDown'] = droppedItem.system.shiftDown;
       entry['traits'] = droppedItem.system.traits;
+      entry['totalReach'] = droppedItem.system.totalReach;
       return entry;
     }
 

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -328,6 +328,7 @@ export function createEntry(droppedItem, targetItem) {
       entry['range'] = droppedItem.system.range;
       entry['shiftDown'] = droppedItem.system.shiftDown;
       entry['traits'] = droppedItem.system.traits;
+      entry['totalReach'] = droppedItem.system.totalReach;
       return entry;
     }
 

--- a/templates/actor/parts/items/weapon/weapon-effects.hbs
+++ b/templates/actor/parts/items/weapon/weapon-effects.hbs
@@ -12,12 +12,11 @@
     </div>
     {{#if (eq item.classification.style 'melee')}}
       <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRangeReach"}} {{item.totalReach}}ft">
-        {{log item}}
-        {{item.totalReach}}
+        {{item.totalReach}}ft
       </div>
     {{else}}
-      <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRange"}} {{item.range.value}}ft/{{item.range.long}}ft">
-        {{item.range.value}}/{{item.range.long}}
+      <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRange"}} {{item.range.value}}ft{{#if item.range.long}}/{{item.range.long}}ft{{/if}}{{#if item.range.min}}/minimum {{item.range.min}}ft{{/if}}">
+        {{item.range.value}}ft
       </div>
     {{/if}}
     <div style="text-align: center;" data-tooltip="{{item.shiftDown}} {{localize "E20.ShiftDown"}}">

--- a/templates/actor/parts/items/weapon/weapon-effects.hbs
+++ b/templates/actor/parts/items/weapon/weapon-effects.hbs
@@ -10,7 +10,7 @@
     <div style="text-align: center;" data-tooltip="{{item.numTargets}} {{localize "E20.WeaponTargets"}}">
       {{item.numTargets}} <i class="fas fa-bullseye"></i>
     </div>
-    {{#if (eq item.classification.style 'melee')}}
+    {{#if item.range.reachMultiplier}}
       <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRangeReach"}} {{item.totalReach}}ft">
         {{item.totalReach}}ft
       </div>

--- a/templates/actor/parts/items/weapon/weapon-effects.hbs
+++ b/templates/actor/parts/items/weapon/weapon-effects.hbs
@@ -15,8 +15,8 @@
         {{item.totalReach}}ft
       </div>
     {{else}}
-      <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRange"}} {{item.range.value}}ft{{#if item.range.long}}/{{item.range.long}}ft{{/if}}{{#if item.range.min}}/minimum {{item.range.min}}ft{{/if}}">
-        {{item.range.value}}ft
+      <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRange"}} {{#if item.range.value}}{{item.range.value}}{{else}}0{{/if}}ft{{#if item.range.long}}/{{item.range.long}}ft{{/if}}{{#if item.range.min}}/minimum {{item.range.min}}ft{{/if}}">
+        {{#if item.range.value}}{{item.range.value}}{{else}}0{{/if}}ft
       </div>
     {{/if}}
     <div style="text-align: center;" data-tooltip="{{item.shiftDown}} {{localize "E20.ShiftDown"}}">

--- a/templates/actor/parts/items/weapon/weapon-effects.hbs
+++ b/templates/actor/parts/items/weapon/weapon-effects.hbs
@@ -10,6 +10,16 @@
     <div style="text-align: center;" data-tooltip="{{item.numTargets}} {{localize "E20.WeaponTargets"}}">
       {{item.numTargets}} <i class="fas fa-bullseye"></i>
     </div>
+    {{#if (eq item.classification.style 'melee')}}
+      <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRangeReach"}} {{item.totalReach}}ft">
+        {{log item}}
+        {{item.totalReach}}
+      </div>
+    {{else}}
+      <div style="text-align: center;" data-tooltip="{{localize "E20.WeaponRange"}} {{item.range.value}}ft/{{item.range.long}}ft">
+        {{item.range.value}}/{{item.range.long}}
+      </div>
+    {{/if}}
     <div style="text-align: center;" data-tooltip="{{item.shiftDown}} {{localize "E20.ShiftDown"}}">
       {{item.shiftDown}} <i class="fas fa-arrow-down"></i>
     </div>

--- a/templates/actor/parts/items/weaponEffect/details.hbs
+++ b/templates/actor/parts/items/weaponEffect/details.hbs
@@ -20,11 +20,10 @@
     {{#if item.system.shiftDown}}
     <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.system.shiftDown}}</span>
     {{/if}}
-    {{#if item.system.range.value}}
-    <span class="chip" name="chip.weapon.range.value">{{localize 'E20.WeaponRange'}}: {{item.system.range.value}}{{#if item.system.range.long}}/{{item.system.range.long}}{{/if}}</span>
-    {{/if}}
-    {{#if item.system.range.min}}
-    <span class="chip" name="chip.weapon.range.min">{{localize 'E20.WeaponRange'}} {{localize 'E20.WeaponRangeMin'}}: {{item.system.range.min}}</span>
+    {{#if (eq item.classification.style 'melee')}}
+    <span class="chip" name="chip.weapon.totalReach">{{localize 'E20.WeaponRangeReach'}}: {{item.system.totalReach}}</span>
+    {{else}}
+    <span class="chip" name="chip.weapon.range.value">{{localize 'E20.WeaponRange'}}: {{item.system.range.value}}{{#if item.system.range.long}}/{{item.system.range.long}}{{/if}}{{#if item.system.range.min}}/minimum {{item.system.range.min}}{{/if}}</span>
     {{/if}}
   </div>
 {{else}}
@@ -49,11 +48,10 @@
     {{#if item.shiftDown}}
     <span class="chip" name="chip.weapon.shiftDown">{{localize 'E20.ShiftDown'}}: {{item.shiftDown}}</span>
     {{/if}}
-    {{#if item.range.value}}
-    <span class="chip" name="chip.weapon.range.value">{{localize 'E20.WeaponRange'}}: {{item.range.value}}{{#if item.range.long}}/{{item.range.long}}{{/if}}</span>
-    {{/if}}
-    {{#if item.range.min}}
-    <span class="chip" name="chip.weapon.range.min">{{localize 'E20.WeaponRange'}} {{localize 'E20.WeaponRangeMin'}}: {{item.range.min}}</span>
+    {{#if (eq item.classification.style 'melee')}}
+    <span class="chip" name="chip.weapon.totalReach">{{localize 'E20.WeaponRangeReach'}}: {{item.totalReach}}</span>
+    {{else}}
+    <span class="chip" name="chip.weapon.range.value">{{localize 'E20.WeaponRange'}}: {{item.range.value}}{{#if item.range.long}}/{{item.range.long}}{{/if}}{{#if item.range.min}}/minimum {{item.range.min}}{{/if}}</span>
     {{/if}}
   </div>
 {{/if}}


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- Added calculation to determine reach based on Effect and Actor Size. 
- added display of range on the effect and added a tooltip with details.
- added reset of reach when actor size changes.

##### Testing
- Validate the reach is calculated correctly
- Validate range is showing correctly 
- Validate updates on the weapon effect are showing on the actor
- Validate size change updates the reach of the weapon. 
