### PR TITLE
Fix for armor upgrade traits

### DIFF
--- a/module/data/item/upgrade.mjs
+++ b/module/data/item/upgrade.mjs
@@ -23,7 +23,7 @@ export class UpgradeItemData extends foundry.abstract.TypeDataModel {
       }),
       availability: makeStrWithChoices(Object.keys(E20.availabilities), 'standard'),
       benefit: makeStr(''),
-      traits: makeStrArrayWithChoices(Object.keys(E20.weaponTraits).concat(E20.armorTraits)),
+      traits: makeStrArrayWithChoices(Object.keys({...E20.weaponTraits, ...E20.armorTraits})),
       type: makeStrWithChoices(Object.keys(E20.upgradeTypes), 'armor'),
       prerequisite: makeStr(null),
     };


### PR DESCRIPTION
##### In this PR
- Fixing an issues where the data model for upgrade traits wasn't correctly combining them from armor + weapons

##### Testing
- You should now be able to select any traits for armor and weapon upgrades
