### PR TITLE
Replace getItemsOfType with documentsByType

### DIFF
--- a/module/apps/sheet-options.mjs
+++ b/module/apps/sheet-options.mjs
@@ -1,4 +1,3 @@
-import { getItemsOfType } from "../helpers/utils.mjs";
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 export default class SheetOptions extends HandlebarsApplicationMixin(ApplicationV2) {
@@ -39,8 +38,8 @@ export default class SheetOptions extends HandlebarsApplicationMixin(Application
 
   async _prepareContext(options) {
     const context = await super._prepareContext(options);
-    context.role = await getItemsOfType("role", this._actor.items);
-    const origin = await getItemsOfType("altMode", this._actor.items);
+    context.role = await this._actor.items.documentsByType.role;
+    const origin = await this._actor.items.documentsByType.origin;
     if (origin.length > 1) {
       context.altMode = true;
     }

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -108,7 +108,7 @@ export class Dice {
     const rolePointsList = actor.items?.documentsByType?.rolePoints;
 
     let rolePoints = null;
-    if (item?.type == 'weaponEffect' && rolePointsList.length) {
+    if (item?.type == 'weaponEffect' && rolePointsList?.length) {
       rolePoints = rolePointsList[0]; // There should only be one RolePoints
       if (rolePoints.system.bonus.type == 'attackUpshift' && (rolePoints.system.isActive || !rolePoints.system.isActivatable)) {
         updatedShiftDataset.rolePoints = rolePoints;

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -105,7 +105,7 @@ export class Dice {
     };
 
     updatedShiftDataset.rolePoints = null;
-    const rolePointsList = actor.items.documentsByType.rolePoints;
+    const rolePointsList = actor.items?.documentsByType?.rolePoints;
 
     let rolePoints = null;
     if (item?.type == 'weaponEffect' && rolePointsList.length) {
@@ -127,7 +127,7 @@ export class Dice {
     switch(item?.type) {
     case 'weaponEffect':
       {
-        const roleList = actor.items.documentsByType.role;
+        const roleList = actor.items?.documentsByType?.role;
         roleSkillDieName = roleList.length ? roleList[0].system.skillDie.name : null;
       }
 

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -1,5 +1,4 @@
 import { E20 } from "./helpers/config.mjs";
-import { getItemsOfType } from "./helpers/utils.mjs";
 
 export class Dice {
   /**
@@ -106,7 +105,7 @@ export class Dice {
     };
 
     updatedShiftDataset.rolePoints = null;
-    const rolePointsList = getItemsOfType('rolePoints', actor.items);
+    const rolePointsList = actor.items.documentsByType.rolePoints;
 
     let rolePoints = null;
     if (item?.type == 'weaponEffect' && rolePointsList.length) {
@@ -128,7 +127,7 @@ export class Dice {
     switch(item?.type) {
     case 'weaponEffect':
       {
-        const roleList = getItemsOfType('role', actor.items);
+        const roleList = actor.items.documentsByType.role;
         roleSkillDieName = roleList.length ? roleList[0].system.skillDie.name : null;
       }
 

--- a/module/dice.mjs
+++ b/module/dice.mjs
@@ -128,7 +128,7 @@ export class Dice {
     case 'weaponEffect':
       {
         const roleList = actor.items?.documentsByType?.role;
-        roleSkillDieName = roleList.length ? roleList[0].system.skillDie.name : null;
+        roleSkillDieName = roleList?.length ? roleList[0].system.skillDie.name : null;
       }
 
       label = this._getWeaponRollLabel(dataset, skillRollOptions, item, roleSkillDieName);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1,7 +1,6 @@
 import { Dice } from "../dice.mjs";
 import { RollDialog } from "../helpers/roll-dialog.mjs";
 import { resizeTokens } from "../helpers/actor.mjs";
-import { getItemsOfType } from "../helpers/utils.mjs";
 import { roleValueChange } from "../sheet-handlers/role-handler.mjs";
 import { onMorph } from "../sheet-handlers/power-ranger-handler.mjs";
 import { onTransformUuid } from "../sheet-handlers/transformer-handler.mjs";
@@ -113,7 +112,7 @@ export class Essence20Actor extends Actor {
     const bonusName = game.i18n.localize('E20.Bonus');
 
     // Health from Origin
-    const origins = getItemsOfType('origin', this.items);
+    const origins = this.items.documentsByType.origin;
     if (origins.length > 0) {
       const origin = origins[0];
       originStartingHealth = origin.system.startingHealth;
@@ -121,7 +120,7 @@ export class Essence20Actor extends Actor {
     }
 
     // Health from Role Points
-    const rolePointsList = getItemsOfType('rolePoints', this.items);
+    const rolePointsList = this.items.documentsByType.rolePoints;
     if (rolePointsList.length > 0 && rolePointsList[0].system.bonus.type == 'healthBonus'
       && (!rolePointsList[0].system.isActivatable || rolePointsList[0].system.isActive)) {
       const rolePoints = rolePointsList[0];
@@ -162,7 +161,7 @@ export class Essence20Actor extends Actor {
       let rolePointsName = game.i18n.localize('E20.RolePoints');
 
       // Armor from Role Points
-      const rolePointsList = getItemsOfType('rolePoints', this.items);
+      const rolePointsList = this.items.documentsByType.rolePoints;
       if (rolePointsList.length) {
         const rolePoints = rolePointsList[0]; // There should only be one RolePoints
 
@@ -251,7 +250,7 @@ export class Essence20Actor extends Actor {
    * Prepare Resource (from Role Points) type specific data.
    */
   _prepareResource() {
-    const rolePointsList = getItemsOfType('rolePoints', this.items);
+    const rolePointsList = this.items.documentsByType.rolePoints;
     if (rolePointsList.length) {
       const rolePoints = rolePointsList[0]; // There should only be one RolePoints
       this.system.useUnlimitedResource = rolePoints.system.resource.level20ValueIsUnlimited && this.system.level == 20;

--- a/module/helpers/utils.mjs
+++ b/module/helpers/utils.mjs
@@ -16,7 +16,7 @@ export function parseId(uuid) {
 * @param {Item[]} items The Items to search through
 * @returns {Item[]}     All Items of the type requested
 */
-export function getItemsOfType(type, items) {
+export function getItemsOfTypeFromSystemItems(type, items) {
   const itemsOfType = [];
   for (const item of items) {
     if (item.type == type) {

--- a/module/migration.mjs
+++ b/module/migration.mjs
@@ -1,4 +1,4 @@
-import { createId, getItemsOfType } from "./helpers/utils.mjs";
+import { createId } from "./helpers/utils.mjs";
 
 /**
  * Perform a system migration for the entire World, applying migrations for Actors, Items, and Compendium packs
@@ -160,7 +160,7 @@ export const migrateActorData = async function(actor, compendiumActor) {
   //Migration for Weapon and Armor Training and Qualificaitons moving to Actors from Roles
   const currentVersion = game.settings.get("essence20", "systemMigrationVersion");
   if (!currentVersion || foundry.utils.isNewerVersion('4.5.1', currentVersion)) {
-    const role = getItemsOfType('role', actor.items)[0];
+    const role = actor.items.documentsByType.role[0];
 
     if (role) {
       for (const armorType of role.system.armors.qualified) {

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -1,5 +1,5 @@
 import ChoicesSelector from "../apps/choices-selector.mjs";
-import { createId, getItemsOfType } from "../helpers/utils.mjs";
+import { createId } from "../helpers/utils.mjs";
 import { onPerkDelete, setPerkValues, setPerkAdvancesName } from "./perk-handler.mjs";
 
 /**
@@ -127,12 +127,12 @@ export async function onAttachmentDrop(actor, droppedItem, dropFunc) {
 
   if (droppedItem.system.type) {
     upgradableItems = upgradableItems.concat(
-      getItemsOfType(droppedItem.system.type, actor.items),
+      actor.items.documentsByType[droppedItem.system.type]
     );
   } else if (droppedItem.type == 'weaponEffect') {
     upgradableItems = upgradableItems
-      .concat(getItemsOfType("weapon", actor.items))
-      .concat(getItemsOfType("shield", actor.items));
+      .concat(actor.items.documentsByType.weapon)
+      .concat(actor.items.documentsByType.shield);
   } else {
     return false;
   }

--- a/module/sheet-handlers/attachment-handler.mjs
+++ b/module/sheet-handlers/attachment-handler.mjs
@@ -127,7 +127,7 @@ export async function onAttachmentDrop(actor, droppedItem, dropFunc) {
 
   if (droppedItem.system.type) {
     upgradableItems = upgradableItems.concat(
-      actor.items.documentsByType[droppedItem.system.type]
+      actor.items.documentsByType[droppedItem.system.type],
     );
   } else if (droppedItem.type == 'weaponEffect') {
     upgradableItems = upgradableItems

--- a/module/sheet-handlers/background-handler.mjs
+++ b/module/sheet-handlers/background-handler.mjs
@@ -1,5 +1,5 @@
 import ChoicesSelector from "../apps/choices-selector.mjs";
-import { getItemsOfType, getShiftedSkill } from "../helpers/utils.mjs";
+import { getItemsOfTypeFromSystemItems, getShiftedSkill } from "../helpers/utils.mjs";
 import { createItemCopies, deleteAttachmentsForItem } from "./attachment-handler.mjs";
 
 /**
@@ -76,7 +76,7 @@ async function _showOriginEssencePrompt(actor, origin, dropFunc) {
     };
   }
 
-  const influences = getItemsOfType("influence", actor.items);
+  const influences = actor.items.documentsByType.influence;
   for (const influence of influences) {
     if (influence.system.skills.length) {
       for (const skill of influence.system.skills) {
@@ -122,7 +122,7 @@ export async function _showOriginSkillPrompt(actor, origin, selectedEssence, dro
     }
   }
 
-  const influences = getItemsOfType("influence", actor.items);
+  const influences = actor.items.documentsByType.influence;
   for (const influence of influences) {
     if (influence.system.skills) {
       for (const skill of influence.system.skills) {
@@ -159,7 +159,7 @@ export async function _checkForAltModes(actor, origin, essence, selectedSkill, d
   }
 
   const choices = {};
-  const altModes = getItemsOfType('altMode', Object.values(origin.system.items));
+  const altModes = getItemsOfTypeFromSystemItems('altMode', Object.values(origin.system.items));
 
   if (altModes.length > 1) {
     for (const altMode of altModes) {
@@ -190,7 +190,7 @@ export async function _checkForAltModes(actor, origin, essence, selectedSkill, d
  * @param {String} selectedAltMode The selected altMode resulting from _checkForAltModes()
  */
 export async function setOriginValues(actor, origin, essence, skill, dropFunc, selectedAltMode) {
-  const altModes = getItemsOfType('altMode', Object.values(origin.system.items));
+  const altModes = getItemsOfTypeFromSystemItems('altMode', Object.values(origin.system.items));
   let altModeToCreate = null;
 
   if (altModes.length > 0) {
@@ -299,7 +299,7 @@ export async function onOriginDelete(actor, origin) {
   const [newShift, skillString] = getShiftedSkill(selectedSkill, -1, actor);
   await deleteAttachmentsForItem(origin, actor);
 
-  const hasAltMode = !!getItemsOfType("altMode", actor.items).length;
+  const hasAltMode = !!actor.items.documentsByType.length;
 
   const essenceString = `system.essences.${essence}.max`;
 

--- a/module/sheet-handlers/faction-handler.mjs
+++ b/module/sheet-handlers/faction-handler.mjs
@@ -1,4 +1,3 @@
-import { getItemsOfType } from "../helpers/utils.mjs";
 import { deleteAttachmentsForItem } from "./attachment-handler.mjs";
 import { onPerkDrop } from "./perk-handler.mjs";
 
@@ -12,7 +11,7 @@ import { onPerkDrop } from "./perk-handler.mjs";
 export async function onFactionDrop(actor, dropFunc=null, defaultRoleFaction=null) {
   let newFaction = null;
   if (!defaultRoleFaction) {
-    const hasFaction = getItemsOfType("faction", actor.items).length > 0;
+    const hasFaction = actor.items.documentsByType.faction.length > 0;
     if (hasFaction) {
       ui.notifications.error(game.i18n.localize('E20.FactionMultipleError'));
       return false;
@@ -26,7 +25,7 @@ export async function onFactionDrop(actor, dropFunc=null, defaultRoleFaction=nul
     newFaction = factionDrop[0];
   }
 
-  const perks = getItemsOfType('perk', Object.values(newFaction.system.items));
+  const perks = getItemsOfTypeFromSystemItems('perk', Object.values(newFaction.system.items));
 
   for (const perk of perks) {
     const itemToCreate = await fromUuid(perk.uuid);

--- a/module/sheet-handlers/listener-item-handler.mjs
+++ b/module/sheet-handlers/listener-item-handler.mjs
@@ -1,6 +1,5 @@
 import ChoicesSelector from "../apps/choices-selector.mjs";
 import { checkIsLocked } from "../helpers/actor.mjs";
-import { getItemsOfType } from "../helpers/utils.mjs";
 import { onAlterationDelete } from "./alteration-handler.mjs";
 import { deleteAttachmentsForItem, setEntryAndAddItem } from "./attachment-handler.mjs";
 import { onOriginDelete } from "./background-handler.mjs";
@@ -262,7 +261,7 @@ export async function onInlineEdit(event, actor) {
  */
 export async function onShieldActivationToggle(event, actorSheet) {
   const actor = actorSheet.actor;
-  const shields = await getItemsOfType('shield', actor.items);
+  const shields = await actor.items.documentsByType.shield;
   let currentShield = null;
   for (const shield of shields) {
     if (shield._id == event.currentTarget.dataset.id) {
@@ -294,7 +293,7 @@ export async function onShieldActivationToggle(event, actorSheet) {
  */
 export async function onShieldEquipToggle(event, actorSheet) {
   const actor = actorSheet.actor;
-  const shields = await getItemsOfType('shield', actor.items);
+  const shields = await actor.items.documentsByType.shield;
   let currentShield = null;
   for (const shield of shields) {
     if (shield._id == event.currentTarget.dataset.id) {

--- a/module/sheet-handlers/listener-misc-handler.mjs
+++ b/module/sheet-handlers/listener-misc-handler.mjs
@@ -1,4 +1,3 @@
-import { getItemsOfType } from "../helpers/utils.mjs";
 import { powerCost } from "./power-handler.mjs";
 import RollerSelector from "../apps/roller-selector.mjs";
 import DefenseModificationSelector from "../apps/defense-modification.mjs";
@@ -149,7 +148,7 @@ export async function onRest(actorSheet) {
   }
 
   // Resetting Role Points
-  const rolePointsList = getItemsOfType('rolePoints', actor.items);
+  const rolePointsList = actor.items.documentsByType.rolePoints;
   if (rolePointsList.length) {
     const rolePoints = rolePointsList[0];
     rolePoints.update({ 'system.resource.value': rolePoints.system.resource.max });

--- a/module/sheet-handlers/role-handler.mjs
+++ b/module/sheet-handlers/role-handler.mjs
@@ -1,6 +1,5 @@
 import ChoicesSelector from "../apps/choices-selector.mjs";
 import EssenceProgressionSelector from "../apps/essence-progression-selector.mjs";
-import { getItemsOfType } from "../helpers/utils.mjs";
 import { createItemCopies, deleteAttachmentsForItem } from "./attachment-handler.mjs";
 import MultiEssenceSelector from "../apps/multi-essence-selector.mjs";
 import { onPerkDrop, setMorphedToughnessBonus } from "./perk-handler.mjs";
@@ -150,8 +149,8 @@ export async function onFocusDrop(actor, focus, dropFunc) {
     return false;
   }
 
-  const hasFocus = getItemsOfType("focus", actor.items).length > 0;
-  const role = getItemsOfType("role", actor.items);
+  const hasFocus = actor.items.documentsByType.focus.length > 0;
+  const role = actor.items.documentsByType.role;
   const attachedRole = [];
 
   for (const [, item] of Object.entries(focus.system.items)) {
@@ -286,14 +285,14 @@ export async function onFocusDelete(actor, focus) {
  */
 export async function onRoleDrop(actor, role, dropFunc) {
   // Actors can only have one Role
-  const hasRole = getItemsOfType("role", actor.items).length > 0;
+  const hasRole = actor.items.documentsByType.role.length > 0;
   if (hasRole) {
     ui.notifications.error(game.i18n.localize('E20.RoleMultipleError'));
     return false;
   }
 
   // Faction updates
-  const factionList = getItemsOfType("faction", actor.items);
+  const factionList = actor.items.documentsByType.faction;
   if (factionList.length) {
     addFactionPerks(actor, role);
   } else {
@@ -401,14 +400,14 @@ export async function onLevelChange(actor, newLevel) {
     return;
   }
 
-  const roles = getItemsOfType("role", actor.items);
+  const roles = actor.items.documentsByType.role;
   if (roles.length == 1) {
     await setRoleValues(roles[0], actor, newLevel, previousLevel);
   } else {
     return;
   }
 
-  const focus = getItemsOfType("focus", actor.items);
+  const focus = actor.items.documentsByType.focus;
   if (focus.length == 1) {
     await _setFocusValues(focus[0], actor, newLevel, previousLevel);
   }
@@ -423,8 +422,8 @@ export async function onLevelChange(actor, newLevel) {
  */
 export async function onRoleDelete(actor, role) {
   const previousLevel = actor.getFlag('essence20', 'previousLevel');
-  const focus = getItemsOfType("focus", actor.items);
-  const factionList = getItemsOfType("faction", actor.items);
+  const focus = actor.items.documentsByType.focus;
+  const factionList = actor.items.documentsByType.faction;
 
   // Faction updates
   if (factionList.length) {

--- a/module/sheet-handlers/transformer-handler.mjs
+++ b/module/sheet-handlers/transformer-handler.mjs
@@ -1,6 +1,6 @@
 import TransformOptionSelector from "../apps/transform-option-selector.mjs";
 import { changeTokenImage, resizeTokens } from "../helpers/actor.mjs";
-import { getItemsOfType } from "../helpers/utils.mjs";
+
 
 /**
  * Handles AltModes being deleted
@@ -8,7 +8,7 @@ import { getItemsOfType } from "../helpers/utils.mjs";
  * @param {AltMode} altMode The deleted Alt Mode.
  */
 export async function onAltModeDelete(actorSheet, altMode) {
-  const altModes = getItemsOfType("altMode", actorSheet.actor.items);
+  const altModes = actorSheet.actor.items.documentsByType.altMode;
   if (altModes.length > 1) {
     if (altMode._id == actorSheet.actor.system.altModeId) {
       _transformBotMode(actorSheet);
@@ -23,7 +23,7 @@ export async function onAltModeDelete(actorSheet, altMode) {
  * @param {Actor} actor The Actor being transformed
  */
 export async function onTransform(actor) {
-  const altModes = getItemsOfType("altMode", actor.items);
+  const altModes = actor.items.documentsByType.altMode;
   const isTransformed = actor.system.isTransformed;
 
   if (!actor.system.isTransformed ) {
@@ -57,7 +57,7 @@ export async function onTransformUuid(actor, altModeUuid=null) {
     await actor.update ({
       "system.image.botmode": actor.prototypeToken.texture.src,
     });
-    
+
     const altMode = await fromUuid(altModeUuid);
     _transformAltMode(actor, altMode);
   } else {

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -21,7 +21,6 @@ import {
   onShieldActivationToggle,
   onShieldEquipToggle,
 } from "../sheet-handlers/listener-item-handler.mjs";
-import { getItemsOfType } from "../helpers/utils.mjs";
 
 export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
   constructor(...args) {
@@ -89,7 +88,7 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
     }
 
     // Prepare WeaponEffect Skill List
-    this._prepareWeaponEffectSkills(actorData, context);
+    this._prepareWeaponEffectSkills(this.actor, context);
 
     // Prepare number of actions
     if (actorData.type == "playerCharacter") {
@@ -224,17 +223,17 @@ export class Essence20ActorSheet extends foundry.appv1.sheets.ActorSheet {
    * @param {Object} actorData The acor data converted to an object
    * @param {Object} context The actor data to prepare.
    */
-  _prepareWeaponEffectSkills(actorData, context) {
+  _prepareWeaponEffectSkills(actor, context) {
     let hasSkillDie = false;
     let skillDieName = null;
-    const items = getItemsOfType ("role", actorData.items);
+    const items = actor.items.documentsByType.role;
     if (items.length && items[0].system.skillDie.isUsed) {
       hasSkillDie = true;
       skillDieName = items[0].system.skillDie.name;
     }
 
     let weaponEffectSkills = {};
-    for (const skill of Object.keys(actorData.system.skills)) {
+    for (const skill of Object.keys(actor.system.skills)) {
       if (skill != 'wealth' && (skill != 'roleSkillDie' || hasSkillDie)) {
         weaponEffectSkills[skill] = {
           key: skill,


### PR DESCRIPTION
Closes [issue URL]

##### In this PR
- Replaces the custom function for Actors with the built in function
- renamed the custom function to refer to Items attached to Items

##### Testing
- Validate all drops that use the DocumentsByType function still all function correctly. 
